### PR TITLE
Auction list view aka. Home page uses real data

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -1,3 +1,37 @@
+$color-green: #2e8540;
+
+.issue-list-item {
+  .issue-icon {
+    padding-top: 0.75rem;
+  }
+
+  .issue-title {
+    margin-top: 1rem;
+    font-size: 2rem;
+  }
+
+  .issue-bids-info {
+    p {
+      margin: 0;
+      padding: 0;
+    }
+
+    a.usa-button {
+      padding: 0.5rem 1rem;
+      white-space: nowrap;
+      background-color: $color-green;
+
+      &:hover {
+        background-color: darken($color-green, 10);
+      }
+
+      &:active {
+        background-color: darken($color-green, 20);
+      }
+    }
+  }
+}
+
 
 nav.usa-site-navbar {
   background: gray;
@@ -17,7 +51,7 @@ nav.usa-site-navbar a {
 }
 
 hr {
-  border: .5px solid #5b616b;
+  border: 1px solid #5b616b;
 }
 
 footer {

--- a/app/controllers/auctions_controller.rb
+++ b/app/controllers/auctions_controller.rb
@@ -1,4 +1,5 @@
 class AuctionsController < ApplicationController
   def index
+    @auctions = Auction.all.includes(:bids).map{|auction| Presenter::Auction.new(auction) }
   end
 end

--- a/app/models/presenter/auction.rb
+++ b/app/models/presenter/auction.rb
@@ -1,0 +1,19 @@
+module Presenter
+  class Auction < SimpleDelegator
+    def current_bid
+      @current_bid ||= bids.sort_by{|bid| [bid.amount, bid.created_at, bid.id]}.first
+    end
+
+    def current_bid_amount
+      current_bid && current_bid.amount
+    end
+
+    def bids?
+      bids.size > 0
+    end
+
+    def bids
+      __getobj__.bids.to_a
+    end
+  end
+end

--- a/app/views/auctions/_list_item.html.erb
+++ b/app/views/auctions/_list_item.html.erb
@@ -1,0 +1,23 @@
+<div class='usa-width-one-whole issue-list-item'>
+  <div class='usa-width-one-twelfth center'>
+    <%= image_tag "issue-icon.png", alt: 'issue-icon', class: 'issue-icon' %>
+  </div>
+  <div class='usa-width-three-fourths'>
+    <h4 class='issue-title'><%= auction.title %></h4>
+    <p class='issue-description'>
+      <%= auction.description %>
+    </p>
+  </div>
+  <div class='usa-width-one-sixth issue-bids-info'>
+    <% if auction.bids? %>
+      <p>Current Bid:</p>
+      <p><%= number_to_currency(auction.current_bid_amount) %></p>
+    <% else %>
+      <p>No bids yet</p>
+    <% end %>
+    <p>Ends in <%= distance_of_time_in_words(Time.now, auction.end_datetime) %></p>
+    <p>
+      <a href="/auctions/<%= auction.id %>/bids/new" class='usa-button'>Bid »</a>
+    </p>
+  </div>
+</div>

--- a/app/views/auctions/index.html.erb
+++ b/app/views/auctions/index.html.erb
@@ -1,17 +1,14 @@
+<h1>Welcome to 18F's Micropurchase experiment.</h1>
 
-<h1>Welcome to 18F's Micro-purchase Threshold experiment.</h1>
-
-<a href="/my-bids">View my bids »</a>
+<a href="/bids">View my bids »</a>
 
 <h2>Here are current issues open for bid:</h2>
 
-<div class="table-container">
-  <table class="usa-table-borderless table-open-issue-list">
-    <tbody>
-      <% 6.times do %>
-        <%= render partial: '/bids/bid_row_cell' %>
-      <% end %>
-    </tbody>
-  </table>
+<div class="usa-grid-full">
+  <hr class='usa-size-one-whole'>
+  <% @auctions.each do |auction| %>
+    <%= render partial: 'list_item', locals: {auction: auction} %>
+    <hr>
+  <% end %>
 </div>
 

--- a/spec/models/presenter/auction_spec.rb
+++ b/spec/models/presenter/auction_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe Presenter::Auction do
+  let(:auction) { Presenter::Auction.new(ar_auction_mock) }
+  let(:ar_auction_mock) {
+    double('AR Auction', {
+      bids: bids,
+      start_datetime: Time.now - 1.day,
+      end_datetime: Time.now + 1.day
+    })
+  }
+
+  describe '#current_bid when there are no bids' do
+    let(:bids) { [] }
+
+    it 'return nil' do
+      expect(auction.current_bid).to be_nil
+    end
+  end
+
+  describe '#current_bid when there is only one bid in the timeframe' do
+    let(:bid) { Bid.create }
+    let(:bids) { [bid] }
+
+    it 'return that bid' do
+      expect(auction.current_bid).to eq(bid)
+    end
+  end
+
+  describe '#current_bid when there are multiple bids of different amounts' do
+    let(:bids) {
+      [
+        Bid.create(amount: 20.00),
+        Bid.create(amount: 10.00)
+      ]
+    }
+
+    it 'return the bid with the lowest amount' do
+      expect(auction.current_bid).to eq(bids.last)
+    end
+  end
+
+  describe '#current_bid when there are multiple bids with the same amount' do
+    let(:bids) {
+      collection = [
+        Bid.create(amount: 10.00),
+        Bid.create(amount: 10.00),
+        Bid.create(amount: 10.00)
+      ]
+      collection[1].update_attribute(:created_at, (Time.now - 3.hours).utc)
+      collection
+    }
+
+    it 'return the bid with the lowest amount' do
+      expect(auction.current_bid).to eq(bids[1])
+    end
+  end
+end


### PR DESCRIPTION
        The old Sinatra app was using a table to display content. This
        changes the dynamic view to use the usa-grid system. It does not
        look exactly the same as the table, so product ... please check.

        The auction controller loads all the auctions. Product needs to
        supply some details about what to show and not show. The query
        preloads bids to reduce number of queries, and then maps the
        records into a presenter for the view.

        Logic about who has the winning bid is in that auction
        presenter and there are test. Product should checkout the test
        and make sure it makes sense.

@adelevie There is a template candidate that you can take apart and use for other view realization work