### PR TITLE
Non-logged in users can view /auctions/:id.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,7 @@ class ApplicationController < ActionController::Base
 
   def require_authentication
     should_redirect = !current_user
-    redirect_to '/auth/github' if should_redirect
+    redirect_to '/login' if should_redirect
     should_redirect
   end
 

--- a/app/controllers/auctions_controller.rb
+++ b/app/controllers/auctions_controller.rb
@@ -2,4 +2,8 @@ class AuctionsController < ApplicationController
   def index
     @auctions = Auction.all.includes(:bids).map{|auction| Presenter::Auction.new(auction) }
   end
+
+  def show
+    @auction = Presenter::Auction.new(Auction.find(params[:id]))
+  end
 end

--- a/app/controllers/bids_controller.rb
+++ b/app/controllers/bids_controller.rb
@@ -9,6 +9,7 @@ class BidsController < ApplicationController
   end
 
   def new
+    require_authentication
     @auction = Presenter::Auction.new(Auction.find(params[:auction_id]))
     @bid = Bid.new
   end

--- a/app/views/auctions/_bids_and_form.html.erb
+++ b/app/views/auctions/_bids_and_form.html.erb
@@ -5,6 +5,3 @@
   <p>No bids yet</p>
 <% end %>
 <p>Ends in <%= distance_of_time_in_words(Time.now, auction.end_datetime) %></p>
-<p>
-  <a href="/auctions/<%= auction.id %>/bids/new" class='usa-button usa-button-green'>Bid »</a>
-</p>

--- a/app/views/auctions/_list_item.html.erb
+++ b/app/views/auctions/_list_item.html.erb
@@ -3,16 +3,22 @@
     <%= image_tag "issue-icon.png", alt: 'issue-icon', class: 'issue-icon' %>
   </div>
   <div class='usa-width-three-fourths'>
-    <h4 class='issue-title'><%= auction.title %></h4>
+    <h4 class='issue-title'>
+      <a href="/auctions/<%= auction.id %>"><%= auction.title %></a>
+    </h4>
     <p class='issue-description'>
       <%= auction.description %>
     </p>
   </div>
   <div class='usa-width-one-sixth issue-bids-info'>
     <% if auction.available? %>
-      <p>Current bid:</p>
-      <p><%= number_to_currency(auction.current_bid_amount) %></p>
       <%= render partial: 'auctions/bids_and_form', locals: {auction: auction} %>
+      <p>
+        <a href="/auctions/<%= auction.id %>/bids/new" class='usa-button usa-button-green'>Bid »</a>
+      </p>
+      <p>
+        <a href="/auctions/<%= auction.id %>" class='usa-button usa-button-blue'>Details »</a>
+      </p>
     <% else %>
       <%= render partial: 'auctions/winning_bid', locals: {auction: auction} %>
     <% end %>

--- a/app/views/auctions/show.html.erb
+++ b/app/views/auctions/show.html.erb
@@ -1,0 +1,29 @@
+<h1>Auction Details (<a href="<%= @auction.issue_url %>">view on GitHub</a>)</h1>
+
+<div class="usa-grid-full">
+  <hr class='usa-size-one-whole'>
+  <div class='usa-width-one-whole issue-list-item'>
+    <div class='usa-width-one-twelfth center'>
+      <%= image_tag "issue-icon.png", alt: 'issue-icon', class: 'issue-icon' %>
+    </div>
+    <div class='usa-width-three-fourths'>
+      <h4 class='issue-title'>
+        <a href="/auctions/<%= @auction.id %>"><%= @auction.title %></a>
+      </h4>
+      <p class='issue-description'>
+        <%= @auction.description %>
+      </p>
+    </div>
+    <div class='usa-width-one-sixth issue-bids-info'>
+      <% if @auction.available? %>
+        <%= render partial: 'auctions/bids_and_form', locals: {auction: @auction} %>
+        <p>
+          <a href="/auctions/<%= @auction.id %>/bids/new" class='usa-button usa-button-green'>Bid »</a>
+        </p>
+      <% else %>
+        <%= render partial: 'auctions/winning_bid', locals: {auction: @auction} %>
+      <% end %>
+    </div>
+  </div>
+  <hr />
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   root 'auctions#index'
 
-  resources :auctions, only: [:index] do
+  resources :auctions, only: [:index, :show] do
     resources :bids, only: [:new, :create]
   end
 

--- a/spec/controllers/bids_controller_spec.rb
+++ b/spec/controllers/bids_controller_spec.rb
@@ -11,13 +11,26 @@ RSpec.describe BidsController, controller: true do
   }
 
   describe '#new' do
-    before do
-      allow(controller).to receive(:current_user).and_return(current_bidder)
+    context 'when logged in' do
+      before do
+        allow(controller).to receive(:current_user).and_return(current_bidder)
+      end
+
+      it 'should render the bid information' do
+        get :new, auction_id: auction.id
+        expect(response).to render_template(:new)
+      end
     end
 
-    it 'should render the bid information' do
-      get :new, auction_id: auction.id
-      expect(response).to render_template(:new)
+    context 'when logged out' do
+      before do
+        allow(controller).to receive(:current_user).and_return(nil)
+      end
+
+      it 'should redirect to /login' do
+        get :new, auction_id: auction.id
+        expect(response).to redirect_to("/login")
+      end
     end
   end
 
@@ -25,7 +38,7 @@ RSpec.describe BidsController, controller: true do
     context 'when not logged in' do
       it 'redirects to authenticate' do
         post :create, auction_id: auction.id, bid: {amount: 1000.00}
-        expect(response).to redirect_to("/auth/github")
+        expect(response).to redirect_to("/login")
       end
     end
 
@@ -49,4 +62,3 @@ RSpec.describe BidsController, controller: true do
     end
   end
 end
-

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe UsersController, type: :controller do
       allow(controller).to receive(:current_user).and_return(nil)
       put :update, {id: user.id, user: {duns_number: '222'}}
       expect(response).to be_redirect
-      expect(response.location).to include('auth')
+      expect(response.location).to eq('http://test.host/login')
     end
 
     it 'raises a ActiveRecord::RecordNotFound when user is not found' do


### PR DESCRIPTION
Created route, template, and controller action for auctions#show

Changed redirect path in ApplicationController#require_authentication
from /auth/github/ to /login. Updated specs accordingly.

Ensure non-logged in users cannot view bids#new. Instead,they are
redirected to /login. Updated specs accordingly.

Fixes https://github.com/18F/micropurchase/issues/16 and https://github.com/18F/micropurchase/issues/18