### PR TITLE
Admin can edit auction:

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,6 @@ group :test do
 end
 
 group :development, :test do
-  gem 'capybara'
   gem 'rspec-rails'
   gem 'capybara'
   gem 'byebug'

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -76,6 +76,10 @@ body.admin {
   .current-bid-headline {
     margin: 0;
   }
+
+  .auction-name h3 {
+    margin: 0;
+  }
 }
 
 nav.usa-site-navbar a {

--- a/app/controllers/admin/auctions_controller.rb
+++ b/app/controllers/admin/auctions_controller.rb
@@ -15,11 +15,24 @@ module Admin
     end
 
     def create
-      AdminCreateAuction.new(params).perform
+      CreateAuction.new(params).perform
       redirect_to "/admin/auctions"
     rescue ArgumentError => e
       flash[:error] = e.message
       redirect_to "/admin/auctions" # render edit
+    end
+
+    def update
+      auction = Auction.find(params[:id])
+      UpdateAuction.new(auction, params).perform
+      redirect_to "/admin/auctions"
+    rescue ArgumentError => e
+      flash[:error] = e.message
+      redirect_to "/admin/auctions"
+    end
+
+    def edit
+      @auction = Auction.find(params[:id])
     end
   end
 end

--- a/app/models/auction_parser.rb
+++ b/app/models/auction_parser.rb
@@ -1,12 +1,4 @@
-class AdminCreateAuction < Struct.new(:params)
-  attr_reader :auction
-
-  def perform
-    @auction = Auction.create(attributes)
-  end
-
-  private
-
+class AuctionParser < Struct.new(:params)
   def attributes
     {
       title: title,

--- a/app/models/create_auction.rb
+++ b/app/models/create_auction.rb
@@ -1,0 +1,15 @@
+class CreateAuction < Struct.new(:params)
+  attr_reader :auction
+
+  def perform
+    @auction = Auction.create(attributes)
+  end
+
+  private
+
+  def parser
+    AuctionParser.new(params)
+  end
+
+  delegate :attributes, to: :parser
+end

--- a/app/models/update_auction.rb
+++ b/app/models/update_auction.rb
@@ -1,0 +1,13 @@
+class UpdateAuction < Struct.new(:auction, :params)
+  def perform
+    auction.update(attributes)
+  end
+
+  private
+
+  def parser
+    AuctionParser.new(params)
+  end
+
+  delegate :attributes, to: :parser
+end

--- a/app/views/admin/auctions/_form.html.erb
+++ b/app/views/admin/auctions/_form.html.erb
@@ -1,0 +1,24 @@
+<%= form_for [:admin, @auction] do |f| %>
+  <label for='auction_title'>Title</label>
+  <%= f.text_field :title %>
+
+  <label for='auction_github_repo'>Github Repo Url</label>
+  <%= f.text_field :github_repo %>
+
+  <label for='auction_issue_url'>Github Issue Url</label>
+  <%= f.text_field :issue_url %>
+
+  <label for='auction_description'>Description</label>
+  <%= f.text_field :description %>
+
+  <label for='auction_description'>Start Date</label>
+  <%= f.text_field :start_datetime %>
+
+  <label for='auction_description'>End Date</label>
+  <%= f.text_field :end_datetime %>
+
+  <label for='auction_start_price'>Start Price</label>
+  <%= f.text_field(:start_price, value: '3500') %>
+
+  <%= f.submit value: 'Submit' %>
+<% end %>

--- a/app/views/admin/auctions/edit.html.erb
+++ b/app/views/admin/auctions/edit.html.erb
@@ -1,3 +1,3 @@
-<h1>Create a new auction</h1>
+<h1>Edit the auction</h1>
 
 <%= render partial: 'form' %>

--- a/app/views/admin/auctions/index.html.erb
+++ b/app/views/admin/auctions/index.html.erb
@@ -8,8 +8,14 @@
 <div class='usa-grid-full'>
 <hr>
 <% @auctions.each do |auction| %>
-  <a href="/admin/auctions/<%= auction.id %>"><h3 class='usa-width-one-whole'><%= auction.title %></h3></a>
-  <div class='usa-width-one-whole'>
+  <div class='usa-width-one-whole auction-name'>
+    <a class='usa-width-three-fourths' href="/admin/auctions/<%= auction.id %>">
+      <h3><%= auction.title %></h3>
+    </a>
+    <a class='usa-width-one-fourth' href="/admin/auctions/<%= auction.id %>/edit">Edit</a>
+  </div>
+
+  <div class='usa-width-one-whole auction-details'>
     <div class='usa-width-one-sixth'>
       <% if auction.available? %>
         <%= image_tag "issue-icon", class: 'issue-icon' %>

--- a/spec/features/admin_auctions_spec.rb
+++ b/spec/features/admin_auctions_spec.rb
@@ -35,4 +35,18 @@ RSpec.feature "AdminAuctions", type: :feature do
       Presenter::DcTime.convert(Time.now + 3.days).beginning_of_day.to_s(:long)
     )
   end
+
+  scenario "updating an auction" do
+    visit "/admin/auctions"
+    click_on("Edit")
+
+    title = 'Build the micropurchase thing'
+    fill_in("auction_title", with: title)
+    fill_in("auction_description", with: 'and the admin related stuff')
+    fill_in("auction_github_repo", with: "https://github.com/18F/calc")
+    fill_in("auction_issue_url", with: "https://github.com/18F/calc/issues/255")
+    click_on("Submit")
+
+    expect(page).to have_text("Build the micropurchase thing")
+  end
 end

--- a/spec/models/auction_parser_spec.rb
+++ b/spec/models/auction_parser_spec.rb
@@ -1,8 +1,9 @@
 require 'rails_helper'
 
-RSpec.describe AdminCreateAuction do
-  let(:creator) { AdminCreateAuction.new(params) }
-  let(:auction) { creator.auction }
+RSpec.describe AuctionParser do
+  let(:parser) { AuctionParser.new(params) }
+  let(:auction) { parser.auction }
+  let(:attributes) { parser.attributes }
 
   describe '#perform' do
     context 'when the price is too high' do
@@ -20,8 +21,7 @@ RSpec.describe AdminCreateAuction do
       }
 
       it 'drops the price down to the bid upper limit' do
-        creator.perform
-        expect(auction.start_price).to eq(3400.99)
+        expect(attributes[:start_price]).to eq(3400.99)
       end
     end
 
@@ -40,8 +40,7 @@ RSpec.describe AdminCreateAuction do
       }
 
       it 'bumps the price to the bid upper limit' do
-        creator.perform
-        expect(auction.start_price).to eq(3400.99)
+        expect(attributes[:start_price]).to eq(3400.99)
       end
     end
 
@@ -59,8 +58,7 @@ RSpec.describe AdminCreateAuction do
       }
 
       it 'makes the price the bid upper limit' do
-        creator.perform
-        expect(auction.start_price).to eq(3400.99)
+        expect(attributes[:start_price]).to eq(3400.99)
       end
     end
 
@@ -78,9 +76,8 @@ RSpec.describe AdminCreateAuction do
       }
 
       it 'uses the time and date' do
-        creator.perform
-        expect(auction.start_datetime.utc.to_s).to  eq(Time.parse('Nov 3, 2015 15:15 EST').utc.to_s)
-        expect(auction.end_datetime.utc.to_s).to    eq(Time.parse("Nov 10, 2015 14:15 EST").utc.to_s)
+        expect(attributes[:start_datetime].utc.to_s).to  eq(Time.parse('Nov 3, 2015 15:15 EST').utc.to_s)
+        expect(attributes[:end_datetime].utc.to_s).to    eq(Time.parse("Nov 10, 2015 14:15 EST").utc.to_s)
       end
     end
 
@@ -98,9 +95,8 @@ RSpec.describe AdminCreateAuction do
       }
 
       it 'uses the time and date' do
-        creator.perform
-        expect(auction.start_datetime.utc.to_s).to eq(Time.parse('Nov 3, 2015 0:00 EST').utc.to_s)
-        expect(auction.end_datetime.utc.to_s).to   eq(Time.parse("Nov 10, 2015 0:00 EST").utc.to_s)
+        expect(attributes[:start_datetime].utc.to_s).to eq(Time.parse('Nov 3, 2015 0:00 EST').utc.to_s)
+        expect(attributes[:end_datetime].utc.to_s).to   eq(Time.parse("Nov 10, 2015 0:00 EST").utc.to_s)
       end
     end
 
@@ -119,7 +115,7 @@ RSpec.describe AdminCreateAuction do
 
       it 'raise an error' do
         expect {
-          creator.perform
+          attributes
         }.to raise_error(ArgumentError)
       end
     end
@@ -139,11 +135,10 @@ RSpec.describe AdminCreateAuction do
       }
 
       it 'stores the right stuff' do
-        creator.perform
-        expect(auction.title).to eq(params[:auction][:title])
-        expect(auction.description).to eq(params[:auction][:description])
-        expect(auction.github_repo).to eq(params[:auction][:github_repo])
-        expect(auction.issue_url).to eq(params[:auction][:issue_url])
+        expect(attributes[:title]).to eq(params[:auction][:title])
+        expect(attributes[:description]).to eq(params[:auction][:description])
+        expect(attributes[:github_repo]).to eq(params[:auction][:github_repo])
+        expect(attributes[:issue_url]).to eq(params[:auction][:issue_url])
       end
     end
   end


### PR DESCRIPTION
https://github.com/18F/micropurchase/issues/75

        Since all the same data munging needed to happen in both create
        and update, I extracted out a parser. Probably not the right
        name for the object. There is a CreateAuction and UpdateAuction
        object but these are pretty light weight. Might be that they
        should go away or a repository object to handle the upsert
        stuff.

        Also unifies the form into one location instead of copying and
        pasting in both. Feature specs of course. No real controller
        specs since the only additional logic is with the flash
        generation.