### PR TITLE
Disallow bids with penny-sized increments.

### DIFF
--- a/app/models/place_bid.rb
+++ b/app/models/place_bid.rb
@@ -1,5 +1,5 @@
 class PlaceBid < Struct.new(:params,:current_user)
-  BID_LIMIT = 3400.99
+  BID_LIMIT = 3500.00
 
   attr_reader :bid
 
@@ -27,6 +27,10 @@ class PlaceBid < Struct.new(:params,:current_user)
   end
 
   def validate_bid_data
+    if amount.to_i != amount
+      raise UnauthorizedError, 'Bids must be in increments of one dollar'
+    end
+
     if !auction_available?
       raise UnauthorizedError, 'Auction not available'
     end

--- a/spec/models/auction_parser_spec.rb
+++ b/spec/models/auction_parser_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe AuctionParser do
       }
 
       it 'drops the price down to the bid upper limit' do
-        expect(attributes[:start_price]).to eq(3400.99)
+        expect(attributes[:start_price]).to eq(3500.00)
       end
     end
 
@@ -40,7 +40,7 @@ RSpec.describe AuctionParser do
       }
 
       it 'bumps the price to the bid upper limit' do
-        expect(attributes[:start_price]).to eq(3400.99)
+        expect(attributes[:start_price]).to eq(3500.00)
       end
     end
 
@@ -58,7 +58,7 @@ RSpec.describe AuctionParser do
       }
 
       it 'makes the price the bid upper limit' do
-        expect(attributes[:start_price]).to eq(3400.99)
+        expect(attributes[:start_price]).to eq(3500.00)
       end
     end
 

--- a/spec/models/place_bid_spec.rb
+++ b/spec/models/place_bid_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe PlaceBid do
   let(:place_bid) { PlaceBid.new(params, current_user) }
   let(:current_user) { double('bidder', id: 111) }
-  let(:amount) {  1005.012 }
+  let(:amount) { 1005 }
   let(:params) {
     {
       auction_id: auction_id,
@@ -44,6 +44,21 @@ RSpec.describe PlaceBid do
     end
   end
 
+  context 'when the bid amount is in increments small than one dollar' do
+    let(:auction) {
+      Auction.create({
+        start_datetime: Time.now - 3.days,
+        end_datetime: Time.now + 7.days
+      })
+    }
+    let(:amount) {1000.99}
+    it 'should raise an authorization error' do
+      expect {
+        place_bid.perform
+      }.to raise_error(UnauthorizedError)
+    end
+  end
+
   context 'when the bid amount is too high' do
     let(:auction) {
       Auction.create({
@@ -51,7 +66,7 @@ RSpec.describe PlaceBid do
         end_datetime: Time.now + 7.days
       })
     }
-    let(:amount) { 3500 }
+    let(:amount) { 3600 }
 
     it 'should raise an authorization error' do
       expect {
@@ -97,7 +112,7 @@ RSpec.describe PlaceBid do
     it 'rounds the amount to two decimal places' do
       place_bid.perform
       bid.reload
-      expect(bid.amount).to eq(1005.01)
+      expect(bid.amount).to eq(1005)
     end
   end
 end


### PR DESCRIPTION
PlaceBid prevents increments that are less than one dollar.

Update other specs to no longer user increments less than one dollar.

Update PlaceBid and AuctionParser specs to reflect 3500.00 bid limit