### PR TITLE
Fix redirect warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,35 @@ cf push
 
 Pull requests merged into the `master` branch will be automatically deployed to https://micropurchase.18f.gov.
 
+## Security Scans
+
+This repository uses two tools to provide a total of three types of automated security checks:
+
+- [Brakeman](http://brakemanscanner.org/) provides static code analysis.
+- [Hakiri](https://hakiri.io/) is used to ensure the Rails/Ruby versions contain no known CVEs.
+- Hakiri is used to ensure the gems declared in the Gemfile contain no known CVEs.
+
+All security scans are built into the test suite. `bundle exec rake spec` will run them. To run the security scans ad hoc:
+
+Brakeman:
+```
+bundle exec brakeman
+```
+
+Hakiri for Ruby/Rails versions:
+```
+bundle exec hakiri system:scan -m hakiri_manifest.json
+```
+
+Hakiri for Gemfile dependency versions:
+```
+bundle exec hakiri gemfile:scan
+```
+
+### Ignored Brakeman warnings
+
+Sometimes Brakeman will report a false positive. In cases like these, the warnings will be ignored. Ignored warnings are declared in `config/brakeman.ignore`. This file contains a machine-readable list of all ignored warnings. Any ignored warning will contain a note explaining (or linking to an explanation of) why the warning is ignored.
+
 ## Public domain
 
 This project is in the worldwide [public domain](LICENSE.md). As stated in [CONTRIBUTING](CONTRIBUTING.md):

--- a/app/controllers/authentications_controller.rb
+++ b/app/controllers/authentications_controller.rb
@@ -1,6 +1,7 @@
 class AuthenticationsController < ApplicationController
   def create
-    redirect_to(Authenticator.new(request.env['omniauth.auth'], session).perform)
+    path = Authenticator.new(request.env['omniauth.auth'], session).perform
+    redirect_to(path)
   end
 
   def destroy

--- a/app/models/authenticator.rb
+++ b/app/models/authenticator.rb
@@ -5,7 +5,7 @@ class Authenticator < Struct.new(:auth_hash, :session)
     find_or_create_user
     update_user
     sign_in
-    redirect_url
+    redirect_hash
   end
 
   private
@@ -24,8 +24,22 @@ class Authenticator < Struct.new(:auth_hash, :session)
     session[:user_id] = user.id
   end
 
-  def redirect_url
-    admin? ? '/' : "/users/#{user.id}/edit"
+  def redirect_hash
+    # protects redirects as outlined here:
+    # http://brakemanscanner.org/docs/warning_types/redirect/
+    index_hash = {
+      controller: :auctions,
+      action: :index,
+      only_path: true
+    }
+    edit_users_hash = {
+      controller: :users,
+      action: :edit,
+      id: user.id,
+      only_path: true
+    }
+
+    admin? ? index_hash : edit_users_hash
   end
 
   def found_user

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,25 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Redirect",
+      "warning_code": 18,
+      "fingerprint": "1f5e56ec432800fd1896435e9cd488f3c75047cdb1855add003acf99052a04f3",
+      "message": "Possible unprotected redirect",
+      "file": "app/controllers/authentications_controller.rb",
+      "line": 4,
+      "link": "http://brakemanscanner.org/docs/warning_types/redirect/",
+      "code": "redirect_to(Authenticator.new(request.env[\"omniauth.auth\"], session).perform)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "AuthenticationsController",
+        "method": "create"
+      },
+      "user_input": "Authenticator.new(request.env[\"omniauth.auth\"], session).perform",
+      "confidence": "High",
+      "note": "Fixed here: https://github.com/18F/micropurchase/commit/799d74393c394e016fba5eab9df1eb638a7d2b06"
+    }
+  ],
+  "updated": "2015-11-17 18:38:44 -0500",
+  "brakeman_version": "3.1.2"
+}

--- a/spec/features/security_spec.rb
+++ b/spec/features/security_spec.rb
@@ -1,24 +1,28 @@
 require 'rails_helper'
 require 'brakeman'
 
-RSpec.feature "Security (via Brakeman static code analysis)" do
-  before do
-    tracker = Brakeman.run(Rails.root.to_s)
-    @brakeman_warnings = tracker.checks.warnings
+RSpec.feature "Security" do
+  context 'Static code analysis and check for CVEs' do
+    before(:all) do
+      @tracker = Brakeman.run(Rails.root.to_s)
+      @gemfile_vulns = `bundle exec hakiri gemfile:scan`
+      @ruby_rails_vulns = `bundle exec hakiri system:scan -m hakiri_manifest.json`
+    end
 
-    @gemfile_vulns = `bundle exec hakiri gemfile:scan`
-    @ruby_rails_vulns = `bundle exec hakiri system:scan -m hakiri_manifest.json`
-  end
+    let(:brakeman_warnings) { @tracker.filtered_warnings }
+    let(:gemfile_vulns) { @gemfile_vulns }
+    let(:ruby_rails_vulns) { @ruby_rails_vulns }
 
-  scenario "The site has zero Brakeman security warnings" do
-    expect(@brakeman_warnings.length).to eq(0), "Expected 0 security warnings, got: \n #{@brakeman_warnings.map(&:to_s)}."
-  end
+    scenario "The site has zero Brakeman security warnings" do
+      expect(brakeman_warnings.length).to eq(0), "Expected 0 security warnings, got: \n #{brakeman_warnings.map(&:to_s)}."
+    end
 
-  scenario "The Gemfile does not depend on vulnerable gems" do
-    expect(@gemfile_vulns).to have_content("No vulnerabilities found. Keep it up!")
-  end
+    scenario "The Gemfile does not depend on vulnerable gems" do
+      expect(gemfile_vulns).to have_content("No vulnerabilities found. Keep it up!")
+    end
 
-  scenario "The Ruby and Rails versions have no known (CVE) vulnerabilities" do
-    expect(@ruby_rails_vulns).to have_content("No vulnerabilities found. Keep it up!")
+    scenario "The Ruby and Rails versions have no known (CVE) vulnerabilities" do
+      expect(ruby_rails_vulns).to have_content("No vulnerabilities found. Keep it up!")
+    end
   end
 end

--- a/spec/models/authenticator_spec.rb
+++ b/spec/models/authenticator_spec.rb
@@ -44,7 +44,12 @@ RSpec.describe Authenticator do
     end
 
     it 'returns the redirect path' do
-      expect(authenticator.perform).to eq("/users/#{user.id}/edit")
+      expect(authenticator.perform).to(eq({
+        controller: :users,
+        action: :edit,
+        id: user.id,
+        only_path: true
+      }))
     end
   end
 
@@ -64,7 +69,12 @@ RSpec.describe Authenticator do
     end
 
     it 'returns the redirect path' do
-      expect(authenticator.perform).to eq("/users/#{user.id}/edit")
+      expect(authenticator.perform).to(eq({
+        controller: :users,
+        action: :edit,
+        id: user.id,
+        only_path: true
+      }))
     end
   end
 
@@ -85,7 +95,11 @@ RSpec.describe Authenticator do
 
 
     it 'has the redirect url as home' do
-      expect(authenticator.perform).to eq("/")
+      expect(authenticator.perform).to(eq({
+        controller: :auctions,
+        action: :index,
+        only_path: true
+      }))
     end
   end
 end


### PR DESCRIPTION
This pull request depends on https://github.com/18F/micropurchase/pull/88 and fixes https://github.com/18F/micropurchase/issues/89.

Even after the fix, the warning is still reported by Brakeman. I am confident that the fix actually addresses the warning, and that now it is a false positive. I would like another set of :eyes: to confirm this.

I have added this warning to `config/brakeman.ignore`.