### PR TITLE
As an Infrastructure Director, I need this app to default to serving secure cookies

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -42,7 +42,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
Basic OWASP recommendation. Pure defense in depth AFAIK given, how HSTS works, and is now deployed across.

Why standard Rails comments this out by default is beyond me. If I was braver, I would head to rails / rails right now and PR it...

For now, it should continue to be considered a universal defense in depth control for 18F across the board, especially where Auth is involved. I wonder if we can flip this on the cloud.gov level in the future? Mucking with `nginx` on this level appears to be possible, but not sure it's a good idea, as it makes fuzzy the concerns of the app vs the web server? Agnostic, will take team recommendations regardless.

cc @konklone @dlapiduz @ozzyjohnson 