### PR TITLE
fixed 508 compliance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 
 /coverage
 /public/capybara.html
+.env

--- a/app/views/admin/auctions/index.html.erb
+++ b/app/views/admin/auctions/index.html.erb
@@ -10,7 +10,7 @@
 <% @auctions.each do |auction| %>
   <div class='usa-width-one-whole auction-name'>
     <a class='usa-width-three-fourths' href="/admin/auctions/<%= auction.id %>">
-      <h3><%= auction.title %></h3>
+      <h2><%= auction.title %></h2>
     </a>
     <a class='usa-width-one-fourth' href="/admin/auctions/<%= auction.id %>/edit">Edit</a>
   </div>

--- a/app/views/auctions/_list_item.html.erb
+++ b/app/views/auctions/_list_item.html.erb
@@ -3,9 +3,9 @@
     <%= image_tag "issue-icon.png", alt: 'issue-icon', class: 'issue-icon' %>
   </div>
   <div class='usa-width-three-fourths'>
-    <h4 class='issue-title'>
+    <h3 class='issue-title'>
       <a href="/auctions/<%= auction.id %>"><%= auction.title %></a>
-    </h4>
+    </h3>
     <p class='issue-description'>
       <%= auction.description %>
     </p>

--- a/app/views/auctions/show.html.erb
+++ b/app/views/auctions/show.html.erb
@@ -7,9 +7,9 @@
       <%= image_tag "issue-icon.png", alt: 'issue-icon', class: 'issue-icon' %>
     </div>
     <div class='usa-width-three-fourths'>
-      <h4 class='issue-title'>
+      <h2 class='issue-title'>
         <a href="/auctions/<%= @auction.id %>"><%= @auction.title %></a>
-      </h4>
+      </h2>
       <p class='issue-description'>
         <%= @auction.description %>
       </p>

--- a/app/views/bids/new.html.erb
+++ b/app/views/bids/new.html.erb
@@ -6,12 +6,12 @@
     <%= image_tag "issue-icon.png", alt: 'issue-icon', class: 'issue-icon' %>
   </div>
   <div class='usa-width-three-fourths'>
-    <h4 class='issue-title'><%= @auction.title %></h4>
+    <h2 class='issue-title'><%= @auction.title %></h2>
     <p class='issue-description'>
       <%= @auction.description %>
     </p>
     <% if @auction.available? %>
-      <h4>Ends in <%= distance_of_time_in_words(Time.now, @auction.end_datetime) %></h4>
+      <h3>Ends in <%= distance_of_time_in_words(Time.now, @auction.end_datetime) %></h3>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
Used [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) to detect 508 issues. There were a few instances of header nesting problems. This PR would resolve those issues and close https://trello.com/c/o8grPB7I/34-accessibility-run-tool-through-code-sniffer

(Also, updated .gitignore to reflect the .env file that I personally use to store the GitHub API keys)