### PR TITLE
Fix "winning bid" prompt that is also shown to the losers.

### DIFF
--- a/app/helpers/bids_helper.rb
+++ b/app/helpers/bids_helper.rb
@@ -6,4 +6,10 @@ module BidsHelper
       number_to_currency(bid.amount)
     end
   end
+
+  def user_is_winning_bidder?(user, auction)
+    return false if !auction.current_bid?
+
+    user.id == auction.current_bid.bidder_id
+  end
 end

--- a/app/views/bids/new.html.erb
+++ b/app/views/bids/new.html.erb
@@ -22,9 +22,11 @@
     <div class='usa-width-one-whole'>
       <div class="usa-width-one-half">
         <h2 class='center'>Current bid:</h2>
-        <% if @auction.bids? %>
-          <p class="current-bid-amount center"><%= number_to_currency(@auction.current_bid_amount) %></p>
+        <p class="current-bid-amount center"><%= number_to_currency(@auction.current_bid_amount) %></p>
+        <% if user_is_winning_bidder?(current_user, @auction) %>
           <h3 class="center">You are currently the winning bidder.</h3>
+        <% elsif @auction.bids? %>
+          <h3 class="center">You are currently <b>not</b> the winning bidder.</h3>
         <% else %>
           <p class="current-bid-amount center">No bids yet.</p>
         <% end %>

--- a/spec/features/bidder_interacts_with_auction_spec.rb
+++ b/spec/features/bidder_interacts_with_auction_spec.rb
@@ -88,7 +88,7 @@ RSpec.feature "bidder interacts with auction", type: :feature do
 
 
 
-  scenario "Is not the current winning bidder" do
+  scenario "Is not the current winning bidder with no bids" do
     create_bidless_auction
 
     visit "/"
@@ -99,6 +99,23 @@ RSpec.feature "bidder interacts with auction", type: :feature do
     expect(page).to have_content("Current bid:")
     expect(page).to have_content("No bids yet.")
     expect(page).not_to have_content("You are currently the winning bidder.")
+
+    fill_in("bid_amount", with: '999')
+    click_on("Submit")
+  end
+
+  scenario "Is not the current winning bidder with bids from other users" do
+    create_current_auction
+
+    visit "/"
+    sign_in_bidder
+
+    click_on("Bid »")
+
+    expect(page).not_to have_content("Authorize with GitHub")
+    expect(page).to have_content("Current bid:")
+    expect(page).not_to have_content("You are currently the winning bidder.")
+    expect(page).to have_content("You are currently not the winning bidder.")
   end
 
   scenario "Bidding on a bid-less auction while logged in" do

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -60,9 +60,10 @@ def sign_in_admin
 end
 
 def sign_in_bidder
+  @bidder = create_authed_bidder
   click_on "Login"
   click_on("Authorize with GitHub")
-  fill_in("user_duns_number", with: "123-duns")
+  fill_in("user_duns_number", with: @bidder.duns_number)
   click_on('Submit')
 end
 


### PR DESCRIPTION
Currently, the "you are the winning bidder" text is
displayed to *all* users when there is at least one bid.

Previously our tests were not capturinig this error because
they only tested presence or non-presence of the "winning
bidder" text in two scenarios: when the user placed bids
and when there are no bids. The latter scenario
insufficiently covered the cases when the "winning bid"
prompt should be present.

This commit presents another scenario, where there are bids,
but from other users. Currently this spec fails and will
ensure confidence in the subsequent bug fix.