### PR TITLE
Specs cover the displayed status on /bids/:id

### DIFF
--- a/spec/features/bidder_interacts_with_auction_spec.rb
+++ b/spec/features/bidder_interacts_with_auction_spec.rb
@@ -15,6 +15,20 @@ RSpec.feature "bidder interacts with auction", type: :feature do
     expect(page).to have_content(h1_text)
   end
 
+  scenario "Viewing an open auction" do
+    current_auction, _bids = create_current_auction
+    visit auction_path(current_auction)
+
+    expect(page).to have_content("Open")
+  end
+
+  scenario "Viewing a closed auction" do
+    closed_auction, _bids = create_closed_auction
+    visit auction_path(closed_auction)
+
+    expect(page).to have_content("Closed")
+  end
+
   scenario "Viewing auction detail page and navigating to bid history" do
     create_current_auction
 

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -35,6 +35,7 @@ def create_current_auction
     increment = index * 10
     @auction.bids.create(bidder: bidder, amount: 3499 - increment)
   end
+  return @auction, @bidders
 end
 
 def create_closed_auction
@@ -43,6 +44,7 @@ def create_closed_auction
     increment = index * 10
     @auction.bids.create(bidder: bidder, amount: 3499 - increment)
   end
+  return @auction, @bidders
 end
 
 def create_running_auction
@@ -51,6 +53,7 @@ def create_running_auction
     increment = index * 10
     @auction.bids.create(bidder: bidder, amount: 3499 - increment)
   end
+  return @auction, @bidders
 end
 
 def sign_in_admin


### PR DESCRIPTION
Feature helpers returning both the auction and bid
objects. This makes it easier to access the objects
from within the specs.