### PR TITLE
Users list in admin panel

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,14 @@
+module Admin
+  class UsersController < ApplicationController
+    before_filter :require_admin
+
+    def index
+      @users = User.all.map {|user| Presenter::User.new(user)}
+    end
+
+    def show
+      @user = Presenter::User.new(User.find(params[:id]))
+    end
+
+  end
+end

--- a/app/models/presenter/user.rb
+++ b/app/models/presenter/user.rb
@@ -1,0 +1,7 @@
+module Presenter
+  class User < SimpleDelegator
+    def github_json_url
+      "https://api.github.com/user/#{github_id}"
+    end
+  end
+end

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,0 +1,22 @@
+<h1>Users</h1>
+
+<table class="usa-table-borderless">
+  <thead>
+    <tr>
+      <th scope="col">Name</th>
+      <th scope="col">Email</th>
+      <th scope="col">DUNS Number</th>
+      <th scope="col">GitHub ID</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @users.each do |user| %>
+      <tr>
+        <td><%= user.name %></td>
+        <td><%= user.email %></td>
+        <td><%= user.duns_number %></td>
+        <td><%= link_to(user.github_id, user.github_json_url) %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
 
   namespace :admin do
     resources :auctions
+    resources :users
   end
 
   get '/auth/:provider/callback', to: 'authentications#create'

--- a/spec/features/admin_users_spec.rb
+++ b/spec/features/admin_users_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.feature "AdminUsers", type: :feature do
+  before do
+    create_user
+    sign_in_admin
+  end
+
+  scenario "visiting the admin users list and then a user" do
+    visit "/admin/users"
+    expect(page).not_to have_text('must be an admin')
+    user = Presenter::User.new(@user)
+
+    expect(page).to have_text(user.duns_number)
+    expect(page).to have_text(user.email)
+    expect(page).to have_text(user.name)
+    expect(page).to have_text(user.github_id)
+  end
+end

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -1,3 +1,12 @@
+def create_user
+  @user = User.create({
+    email: 'bob@thebuiler.io',
+    duns_number: '0000123456789',
+    name: 'Bob T. Builder',
+    github_id: '12345'
+  })
+end
+
 def create_bidless_auction(end_datetime: Time.now + 3.days)
   @auction = Auction.create({
     start_datetime: Time.now - 3.days,


### PR DESCRIPTION
Acceptance criteria:

```ruby
    visit "/admin/users"
    expect(page).not_to have_text('must be an admin')
    user = Presenter::User.new(@user)

    expect(page).to have_text(user.duns_number)
    expect(page).to have_text(user.email)
    expect(page).to have_text(user.name)
    expect(page).to have_text(user.github_id)
```