### PR TITLE
Failing spec for who won features on auction page. [WIP]

### DIFF
--- a/spec/features/bidder_interacts_with_auction_spec.rb
+++ b/spec/features/bidder_interacts_with_auction_spec.rb
@@ -180,6 +180,18 @@ RSpec.feature "bidder interacts with auction", type: :feature do
     end
   end
 
+  scenario "Viewing auction page for a closed auction" do
+    create_closed_auction
+    auction = Presenter::Auction.new(@auction)
+    visit auction_bids_path(auction.id)
+
+    expect(page).to have_content("Winning Bid (#{auction.current_bidder.name}):")
+    expect(page).not_to have_content("Current Bid:")
+
+    expect(page).to have_content("Auction ended at:")
+    expect(page).not_to have_content("Bid deadline:")
+  end
+
   scenario "Viewing bid history for a closed auction" do
     Timecop.scale(36000) do
       create_closed_auction

--- a/spec/features/bidder_interacts_with_auction_spec.rb
+++ b/spec/features/bidder_interacts_with_auction_spec.rb
@@ -192,6 +192,19 @@ RSpec.feature "bidder interacts with auction", type: :feature do
     expect(page).not_to have_content("Bid deadline:")
   end
 
+  scenario "Viewing auction page for a closed auction with no bidders" do
+    create_closed_bidless_auction
+    auction = Presenter::Auction.new(@auction)
+    visit auction_bids_path(auction.id)
+
+    expect(page).to have_content("Auction ended with no bids.")
+    expect(page).not_to have_content("Current Bid:")
+
+    expect(page).to have_content("Auction ended at:")
+    expect(page).not_to have_content("Bid deadline:")
+  end
+
+
   scenario "Viewing bid history for a closed auction" do
     Timecop.scale(36000) do
       create_closed_auction

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -29,6 +29,12 @@ def create_bidless_auction(end_datetime: Time.now + 3.days)
   return @auction, @bidders
 end
 
+def create_closed_bidless_auction
+  create_bidless_auction
+  @auction.end_datetime = Time.now - 1.day
+  @auction.save
+end
+
 def create_current_auction
   @auction, @bidders = create_bidless_auction
   @bidders.each_with_index do |bidder, index|


### PR DESCRIPTION
acceptance criteria:

```ruby
  scenario "Viewing auction page for a closed auction" do
    create_closed_auction
    auction = Presenter::Auction.new(@auction)
    visit auction_bids_path(auction.id)

    expect(page).to have_content("Winning Bid (#{auction.current_bidder.name}):")
    expect(page).not_to have_content("Current Bid:")

    expect(page).to have_content("Auction ended at:")
    expect(page).not_to have_content("Bid deadline:")
  end

  scenario "Viewing auction page for a closed auction with no bidders" do
    create_closed_bidless_auction
    auction = Presenter::Auction.new(@auction)
    visit auction_bids_path(auction.id)

    expect(page).to have_content("Auction ended with no bids.")
    expect(page).not_to have_content("Current Bid:")

    expect(page).to have_content("Auction ended at:")
    expect(page).not_to have_content("Bid deadline:")
  end
```