### PR TITLE
Add factory girl

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ group :development, :test do
   gem 'byebug'
   gem 'pry'
 
+  gem 'factory_girl_rails'
   gem 'timecop'
   gem 'brakeman', require: false
   gem 'hakiri',  require: false

--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,9 @@ group :development, :test do
   gem 'byebug'
   gem 'pry'
 
+  gem 'database_cleaner'
   gem 'factory_girl_rails'
+  gem 'faker'
   gem 'timecop'
   gem 'brakeman', require: false
   gem 'hakiri',  require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,13 @@ GEM
       activemodel
     erubis (2.7.0)
     execjs (2.6.0)
+    factory_girl (4.5.0)
+      activesupport (>= 3.0.0)
+    factory_girl_rails (4.5.0)
+      factory_girl (~> 4.5.0)
+      railties (>= 3.0.0)
+    faker (1.6.1)
+      i18n (~> 0.5)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     fastercsv (1.5.5)
@@ -285,6 +292,8 @@ DEPENDENCIES
   cucumber-rails
   database_cleaner
   email_validator
+  factory_girl_rails
+  faker
   hakiri
   omniauth
   omniauth-github

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,5 +33,11 @@ module Micropurchase
     config.active_record.raise_in_transactional_callbacks = true
 
     config.assets.debug = true
+
+    # Don't automatically generate factories for now
+    config.generators do |g|
+      g.factory_girl false
+    end
   end
 end
+

--- a/spec/factories/auctions.rb
+++ b/spec/factories/auctions.rb
@@ -1,0 +1,33 @@
+FactoryGirl.define do
+  factory :auction do
+    start_datetime { Time.now - 3.days }
+    end_datetime { Time.now + 3.days }
+    title 'Oh no, fix the world'
+    description 'it is broken!'
+    issue_url 'https://github.com/18F/calc/issues/255'
+    github_repo 'https://github.com/18F/calc'
+
+    trait :with_bidders do
+      after(:build) do |instance|
+        (1..4).each do |i|
+          amount = 3499 - (20 * i) - rand(10)
+          instance.bids << FactoryGirl.create(:bid, auction: instance, amount: amount)
+        end
+      end
+    end
+    
+    factory :current_auction do
+      with_bidders
+    end
+
+    factory :closed_auction do
+      end_datetime { Time.now - 1.day }
+      with_bidders
+    end
+
+    factory :running_auction do
+      end_datetime { Time.now + 1.day }
+      with_bidders
+    end
+  end
+end

--- a/spec/factories/bids.rb
+++ b/spec/factories/bids.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :bid do
+    association :bidder, factory: :user
+    association :auction
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,12 @@
+FactoryGirl.define do
+  sequence :github_id do |n|
+    n
+  end
+  
+  factory :user do
+    name { Faker::Name.name }
+    email { Faker::Internet.email }
+    duns_number { Faker::Company.duns_number }
+    github_id
+  end
+end

--- a/spec/features/admin_auctions_spec.rb
+++ b/spec/features/admin_auctions_spec.rb
@@ -28,8 +28,8 @@ RSpec.feature "AdminAuctions", type: :feature do
     title = 'Build the micropurchase thing'
     fill_in("auction_title", with: title)
     fill_in("auction_description", with: 'and the admin related stuff')
-    fill_in("auction_start_datetime", with: (Time.now + 3.days).strftime("%m/%d/%Y"))
-    fill_in("auction_end_datetime", with: (Time.now - 3.days).strftime("%m/%d/%Y"))
+    fill_in("auction_start_datetime", with: Presenter::DcTime.convert(Time.now + 3.days).strftime("%m/%d/%Y"))
+    fill_in("auction_end_datetime", with: Presenter::DcTime.convert(Time.now - 3.days).strftime("%m/%d/%Y"))
     fill_in("auction_github_repo", with: "https://github.com/18F/calc")
     fill_in("auction_issue_url", with: "https://github.com/18F/calc/issues/255")
     click_on("Submit")

--- a/spec/features/bidder_interacts_with_auction_spec.rb
+++ b/spec/features/bidder_interacts_with_auction_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'rails_helper'
 
 RSpec.feature "bidder interacts with auction", type: :feature do
@@ -55,7 +56,7 @@ RSpec.feature "bidder interacts with auction", type: :feature do
     # seeing auction list
     visit "/"
     expect(page).to have_content(@auction.title)
-    expect(page).to have_content("Current Bid:")
+    expect(page).to have_content("Current bid:")
 
     # going to the auction detail page
     click_on(@auction.title)

--- a/spec/features/logging_in_and_out_spec.rb
+++ b/spec/features/logging_in_and_out_spec.rb
@@ -37,7 +37,7 @@ RSpec.feature "logging in and out of the app", type: :feature do
 
     # another bad UX, users have to see this entry point regardless of whether they have a duns number
     expect(page).to have_content("Enter your DUNS number")
-    expect(page.find('#user_duns_number').value).to eq('DUNS-123')
+    expect(page.find('#user_duns_number').value).to eq(@bidder.duns_number)
   end
 
   scenario "User logs in when viewing protected or specific information" do
@@ -46,7 +46,7 @@ RSpec.feature "logging in and out of the app", type: :feature do
     expect(page).to have_content("Authorize with GitHub")
 
     click_on("Authorize with GitHub")
-    expect(page).to have_content("Doris Doogooder")
+    expect(page).to have_content('Doris Doogooder')
     expect(page).to have_content("Logout")
   end
 
@@ -64,8 +64,8 @@ RSpec.feature "logging in and out of the app", type: :feature do
     email_field = find_field("Email Address")
     duns_field = find_field("DUNS Number")
 
-    expect(email_field.value).to eq("doris@doogooder.io")
-    expect(duns_field.value).to eq("DUNS-123")
+    expect(email_field.value).to eq(@bidder.email)
+    expect(duns_field.value).to eq(@bidder.duns_number)
 
     fill_in("Email Address", with: "doris@doogooder.com")
     click_on('Submit')
@@ -88,8 +88,8 @@ RSpec.feature "logging in and out of the app", type: :feature do
     email_field = find_field("Email Address")
     duns_field = find_field("DUNS Number")
 
-    expect(email_field.value).to eq("doris@doogooder.io")
-    expect(duns_field.value).to eq("DUNS-123")
+    expect(email_field.value).to eq(@bidder.email)
+    expect(duns_field.value).to eq(@bidder.duns_number)
 
     fill_in("Email Address", with: "doris_the_nonvalid_email_address_person")
     click_on('Submit')

--- a/spec/models/place_bid_spec.rb
+++ b/spec/models/place_bid_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe PlaceBid do
   let(:place_bid) { PlaceBid.new(params, current_user) }
-  let(:current_user) { FactoryGirl.create(:user,, id: 111) }
+  let(:current_user) { FactoryGirl.create(:user, id: 111) }
   let(:amount) { 1005 }
   let(:params) {
     {

--- a/spec/models/place_bid_spec.rb
+++ b/spec/models/place_bid_spec.rb
@@ -2,12 +2,7 @@ require 'rails_helper'
 
 RSpec.describe PlaceBid do
   let(:place_bid) { PlaceBid.new(params, current_user) }
-  let(:current_user) { double('bidder', id: 111) }
-  let(:bidders) {
-    5.times.map do |i|
-      double('bidder', id: i+1)
-    end
-  }
+  let(:current_user) { FactoryGirl.create(:user,, id: 111) }
   let(:amount) { 1005 }
   let(:params) {
     {
@@ -18,6 +13,9 @@ RSpec.describe PlaceBid do
     }
   }
   let(:auction_id) { auction.id }
+  let(:auction) { FactoryGirl.create(:auction,
+                                     start_datetime: Time.now - 3.days,
+                                     end_datetime: Time.now + 7.days) }
 
   context 'when auction cannot be found' do
     let(:auction) { double('auction', id: 1000) }
@@ -30,7 +28,9 @@ RSpec.describe PlaceBid do
   end
 
   context 'when the auction has expired' do
-    let(:auction) { Auction.create(start_datetime: Time.now - 5.days, end_datetime: Time.now - 3.day) }
+    let(:auction) { FactoryGirl.create(:auction,
+                                       start_datetime: Time.now - 5.days,
+                                       end_datetime: Time.now - 3.day) }
 
     it 'should raise an authorization error (because we have that baked in)' do
       expect {
@@ -40,7 +40,9 @@ RSpec.describe PlaceBid do
   end
 
   context 'when the auction has not started yet' do
-    let(:auction) { Auction.create(start_datetime: Time.now + 5.days, end_datetime: Time.now + 7.days) }
+    let(:auction) { FactoryGirl.create(:auction,
+                                       start_datetime: Time.now + 5.days,
+                                       end_datetime: Time.now + 7.days) }
 
     it 'should raise an authorization error (same as above)' do
       expect {
@@ -50,13 +52,8 @@ RSpec.describe PlaceBid do
   end
 
   context 'when the bid amount is in increments small than one dollar' do
-    let(:auction) {
-      Auction.create({
-        start_datetime: Time.now - 3.days,
-        end_datetime: Time.now + 7.days
-      })
-    }
     let(:amount) {1000.99}
+
     it 'should raise an authorization error' do
       expect {
         place_bid.perform
@@ -65,12 +62,6 @@ RSpec.describe PlaceBid do
   end
 
   context 'when the bid amount is above the starting price' do
-    let(:auction) {
-      Auction.create({
-        start_datetime: Time.now - 3.days,
-        end_datetime: Time.now + 7.days
-      })
-    }
     let(:amount) { 3600 }
 
     it 'should raise an authorization error' do
@@ -81,16 +72,10 @@ RSpec.describe PlaceBid do
   end
 
   context 'when the bid amount is above the current bid price' do
-    let(:auction) {
-      Presenter::Auction.new(Auction.create({
-        start_datetime: Time.now - 3.days,
-        end_datetime: Time.now + 7.days
-      }))
-    }
     let(:amount) { 405 }
 
     it 'should raise an authorization error' do
-      allow_any_instance_of(Presenter::Auction).to receive_message_chain(:current_bid, :amount).and_return(400)
+      FactoryGirl.create(:bid, auction: auction, amount: amount - 5)
       expect {
         place_bid.perform
       }.to raise_error(UnauthorizedError)
@@ -98,16 +83,9 @@ RSpec.describe PlaceBid do
   end
 
   context 'when the bid amount is above the auction start price and there are no bids' do
-    let(:auction) {
-      Presenter::Auction.new(Auction.create({
-        start_datetime: Time.now - 3.days,
-        end_datetime: Time.now + 7.days
-      }))
-    }
     let(:amount) { 3600 }
 
     it 'should raise an authorization error' do
-      allow_any_instance_of(Presenter::Auction).to receive(:current_bid).and_return(Presenter::Bid::Null.new)
       expect {
         place_bid.perform
       }.to raise_error(UnauthorizedError)
@@ -115,16 +93,10 @@ RSpec.describe PlaceBid do
   end
 
   context 'when the bid amount is equal to the current bid price' do
-    let(:auction) {
-      Presenter::Auction.new(Auction.create({
-        start_datetime: Time.now - 3.days,
-        end_datetime: Time.now + 7.days
-      }))
-    }
     let(:amount) { 400 }
 
     it 'should raise an authorization error' do
-      allow_any_instance_of(Presenter::Auction).to receive_message_chain(:current_bid, :amount).and_return(400)
+      FactoryGirl.create(:bid, auction: auction, amount: amount)
       expect {
         place_bid.perform
       }.to raise_error(UnauthorizedError)
@@ -132,16 +104,9 @@ RSpec.describe PlaceBid do
   end
 
   context 'when the bid amount is equal to the auction start price and there are no bids' do
-    let(:auction) {
-      Presenter::Auction.new(Auction.create({
-        start_datetime: Time.now - 3.days,
-        end_datetime: Time.now + 7.days
-      }))
-    }
     let(:amount) { 3500 }
 
     it 'should raise an authorization error' do
-      allow_any_instance_of(Presenter::Auction).to receive(:current_bid).and_return(Presenter::Bid::Null.new)
       expect {
         place_bid.perform
       }.to raise_error(UnauthorizedError)
@@ -149,12 +114,6 @@ RSpec.describe PlaceBid do
   end
 
   context 'when the bid amount is negative' do
-    let(:auction) {
-      Auction.create({
-        start_datetime: Time.now - 3.days,
-        end_datetime: Time.now + 7.days
-      })
-    }
     let(:amount) { '-10' }
 
     it 'should raise an authorization error' do
@@ -165,12 +124,6 @@ RSpec.describe PlaceBid do
   end
 
   context 'when the bid amount is 0' do
-    let(:auction) {
-      Auction.create({
-        start_datetime: Time.now - 3.days,
-        end_datetime: Time.now + 7.days
-      })
-    }
     let(:amount) { 0 }
 
     it 'should raise an authorization error' do
@@ -181,13 +134,6 @@ RSpec.describe PlaceBid do
   end
 
   context 'when all the data is great' do
-    let(:auction) {
-      Auction.create({
-        start_datetime: Time.now - 3.days,
-        end_datetime: Time.now + 7.days
-      })
-    }
-
     let(:bid) { place_bid.bid }
 
     it 'creates a bid' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -54,7 +54,19 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
 
   OmniAuth.config.test_mode = true
+  DatabaseCleaner.strategy = :transaction
+  
+  #  config.include FactoryGirl::Syntax::Methods
 
+  config.before(:suite) do
+    begin
+      DatabaseCleaner.start
+      FactoryGirl.lint
+    ensure
+      DatabaseCleaner.clean
+    end
+  end
+  
   config.before do
     mock_github
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,6 +45,17 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
+  config.include FactoryGirl::Syntax::Methods
+
+  config.before(:suite) do
+    begin
+      DatabaseCleaner.start
+      FactoryGirl.lint
+    ensure
+      DatabaseCleaner.clean
+    end
+  end
+  
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
 =begin

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,17 +45,6 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
-  config.include FactoryGirl::Syntax::Methods
-
-  config.before(:suite) do
-    begin
-      DatabaseCleaner.start
-      FactoryGirl.lint
-    ensure
-      DatabaseCleaner.clean
-    end
-  end
-  
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
 =begin

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -1,67 +1,31 @@
 def create_user
-  @user = User.create({
-    email: 'bob@thebuiler.io',
-    duns_number: '0000123456789',
-    name: 'Bob T. Builder',
-    github_id: '12345'
-  })
+  @user = FactoryGirl.create(:user)
 end
 
 def create_bidless_auction(end_datetime: Time.now + 3.days)
-  @auction = Auction.create({
-    start_datetime: Time.now - 3.days,
-    end_datetime: end_datetime,
-    title: 'Oh no, fix the world',
-    description: 'it is broken!',
-    issue_url: 'https://github.com/18F/calc/issues/255',
-    github_repo: 'https://github.com/18F/calc'
-  })
-  @bidders = [
-    User.create(
-      github_id: 'uid',
-      duns_number: 'duns',
-      name: 'Bob the Bidder'
-    ),
-    User.create(
-      github_id: 'uid_2',
-      duns_number: 'duns_2',
-      name: 'Mary the Maker'
-    ),
-    User.create(
-      github_id: 'uid_3',
-      duns_number: 'duns_3',
-      name: 'Carl the Contractor'
-    )
-  ]
-
-
+  @auction = FactoryGirl.create(:auction, end_datetime: Time.now + 3.days)
+  @bidders = []
+  
   return @auction, @bidders
 end
 
 def create_current_auction
-  @auction, @bidders = create_bidless_auction
-  @bidders.each_with_index do |bidder, index|
-    increment = index * 10
-    @auction.bids.create(bidder: bidder, amount: 3499 - increment)
-  end
+  @auction = FactoryGirl.create(:current_auction)
+  @bidders = @auction.bids
+  
   return @auction, @bidders
 end
 
 def create_closed_auction
-  @auction, @bidders = create_bidless_auction(end_datetime: Time.now - 1.days)
-  @bidders.each_with_index do |bidder, index|
-    increment = index * 10
-    @auction.bids.create(bidder: bidder, amount: 3499 - increment)
-  end
+  @auction = FactoryGirl.create(:closed_auction)
+  @bidders = @auction.bids
   return @auction, @bidders
 end
 
 def create_running_auction
-  @auction, @bidders = create_bidless_auction(end_datetime: Time.now + 1.days)
-  @bidders.each_with_index do |bidder, index|
-    increment = index * 10
-    @auction.bids.create(bidder: bidder, amount: 3499 - increment)
-  end
+  @auction = FactoryGirl.create(:running_auction)
+  @bidders = @auction.bids
+
   return @auction, @bidders
 end
 
@@ -80,11 +44,7 @@ def sign_in_bidder
 end
 
 def create_authed_bidder
-  @bidder = User.create(
-    github_id: current_user_uid,
-    duns_number: 'DUNS-123',
-    email: 'doris@doogooder.io'
-  )
+  @bidder = FactoryGirl.create(:user, github_id: current_user_uid)
 end
 
 def show_page


### PR DESCRIPTION
This pull request adds a few useful gems for testing:

- Factory_girl for defining factories in tests
- Database Cleaner for clearing out the database between tests
- Faker for generating fake names, email addresses, etc.

These let me replace the insides of some method in `feature_helpers.rb` with factory_girl invocations instead and also use factories instead of `allow_any_instance_of` and `method_chain` in the place_bid specs