### PR TITLE
Eliminate mocking within the controller tests

### DIFF
--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -2,6 +2,12 @@ require 'rails_helper'
 
 RSpec.describe ApplicationController, controller: true do
   describe '#require_admin' do
+    let(:current_user) { nil }
+    
+    before do
+      allow(controller).to receive(:current_user).and_return(current_user)
+    end
+
     context 'when no current user' do
       it 'redirects to authenticate' do
         expect(controller).to receive(:redirect_to).with("/login")
@@ -10,11 +16,7 @@ RSpec.describe ApplicationController, controller: true do
     end
 
     context 'when current user is not an admin' do
-      let(:current_user) { double('user', github_id: 'not-here') }
-
-      before do
-        allow(controller).to receive(:current_user).and_return(current_user)
-      end
+      let(:current_user) { FactoryGirl.create(:user) }
 
       it 'raises an authorization error' do
         expect {
@@ -24,11 +26,7 @@ RSpec.describe ApplicationController, controller: true do
     end
 
     context 'when current user is an admin' do
-      let(:current_user) { double('user', github_id: Admins.github_ids.first) }
-
-      before do
-        allow(controller).to receive(:current_user).and_return(current_user)
-      end
+      let(:current_user) { FactoryGirl.create(:admin_user) }
 
       it 'lets the request pass through' do
         expect(controller).to_not receive(:redirect_to)

--- a/spec/controllers/auctions_controller_spec.rb
+++ b/spec/controllers/auctions_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe AuctionsController, controller: true do
   describe '#index' do
     it 'assigns presented auctions' do
-      auction_record = Auction.create
+      auction_record = FactoryGirl.create(:auction)
       get :index
       auction = assigns(:auctions).first
       expect(auction).to be_a(Presenter::Auction)
@@ -13,7 +13,7 @@ RSpec.describe AuctionsController, controller: true do
 
   describe '#show' do
     it 'assigns presented auction' do
-      auction_record = Auction.create
+      auction_record = FactoryGirl.create(:auction)
       get :show, id: auction_record.id
       auction = assigns(:auction)
       expect(auction).to be_a(Presenter::Auction)

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,26 +1,23 @@
 require 'rails_helper'
 
 RSpec.describe UsersController, type: :controller do
-  let(:user) { User.create }
+  let(:user) { FactoryGirl.create(:user) }
 
   describe '#edit' do
     it 'raises a ActiveRecord::RecordNotFound when user is not found' do
-      allow(controller).to receive(:current_user).and_return(user)
       expect {
-        get :edit, {id: user.id + 1000}
+        get :edit, {id: user.id + 1000}, {user_id: user.id}
       }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     it 'handles it as unauthorized when user is not in session' do
-      allow(controller).to receive(:current_user).and_return(User.create)
-      get :edit, {id: user.id}
+      get :edit, {id: user.id}, { user_id: FactoryGirl.create(:user).id }
       expect(response).to redirect_to('/')
       expect(flash[:error]).to match(/unauthorized/i)
     end
 
     it 'render the form when the user is found and same as in session' do
-      allow(controller).to receive(:current_user).and_return(user)
-      get :edit, {id: user.id}
+      get :edit, {id: user.id}, { user_id: user.id }
       expect(response.status).to eq(200)
       expect(response).to render_template(:edit)
     end
@@ -28,37 +25,32 @@ RSpec.describe UsersController, type: :controller do
 
   describe '#update' do
     it 'redirects to authenticate when not logged in' do
-      allow(controller).to receive(:current_user).and_return(nil)
       put :update, {id: user.id, user: {duns_number: '222'}}
       expect(response).to be_redirect
       expect(response.location).to eq('http://test.host/login')
     end
 
     it 'raises a ActiveRecord::RecordNotFound when user is not found' do
-      allow(controller).to receive(:current_user).and_return(user)
       user_id = user.id + 1000
       expect {
-        put :update, {id: user_id, user: {duns_number: '222'}}
+        put :update, {id: user_id, user: {duns_number: '222'}}, { user_id: user.id }
       }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     it 'handles as unauthorized when user is not in session' do
-      allow(controller).to receive(:current_user).and_return(User.create)
-      put :update, {id: user.id, user: {duns_number: '222'}}
+      put :update, {id: user.id, user: {duns_number: '222'}}, { user_id: FactoryGirl.create(:user).id }
       expect(response).to redirect_to('/')
       expect(flash[:error]).to match(/unauthorized/i)
     end
 
     it 'update the user when current user is the user' do
-      allow(controller).to receive(:current_user).and_return(user)
-      put :update, {id: user.id, user: {duns_number: '222'}}
+      put :update, {id: user.id, user: {duns_number: '222'}}, { user_id: user.id }
       user.reload
       expect(user.duns_number).to eq('222')
     end
 
     it 'redirects back home after successful edit' do
-      allow(controller).to receive(:current_user).and_return(user)
-      put :update, {id: user.id, user: {duns_number: '222'}}
+      put :update, {id: user.id, user: {duns_number: '222'}}, { user_id: user.id }
       expect(response).to be_redirect
       expect(response.location).to eq('http://test.host/')
     end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -7,6 +7,10 @@ FactoryGirl.define do
     name { Faker::Name.name }
     email { Faker::Internet.email }
     duns_number { Faker::Company.duns_number }
-    github_id
+    github_id 123456
+
+    factory :admin_user do
+      github_id { Admins.github_ids.first }
+    end
   end
 end


### PR DESCRIPTION
Continuing on the work from the prior `factory_girl` PR #142, this pull request reworks the controller tests to have a few changes:

* Create test objects using Factory Girl instead
* Instead of mocking `current_user` within the controller, pass up the session object as part of the test requests.