### PR TITLE
Floats to ints

### DIFF
--- a/app/models/place_bid.rb
+++ b/app/models/place_bid.rb
@@ -1,6 +1,6 @@
 class PlaceBid < Struct.new(:params,:current_user)
-  BID_LIMIT = 3500.00
-  BID_INCREMENT = 1.0
+  BID_LIMIT = 3500
+  BID_INCREMENT = 1
 
   attr_reader :bid
 

--- a/db/migrate/20151222023133_floats_to_ints.rb
+++ b/db/migrate/20151222023133_floats_to_ints.rb
@@ -1,0 +1,6 @@
+class FloatsToInts < ActiveRecord::Migration
+  def change
+    change_column :auctions, :start_price, :integer, default: 3500
+    change_column :bids, :amount, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,28 +11,28 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151210200402) do
+ActiveRecord::Schema.define(version: 20151222023133) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "auctions", force: :cascade do |t|
     t.string   "issue_url"
-    t.float    "start_price",    default: 3500.0
+    t.integer  "start_price",    default: 3500
     t.datetime "start_datetime"
     t.datetime "end_datetime"
     t.string   "title"
     t.text     "description"
     t.string   "github_repo"
     t.integer  "published"
-    t.datetime "created_at",                      null: false
-    t.datetime "updated_at",                      null: false
+    t.datetime "created_at",                    null: false
+    t.datetime "updated_at",                    null: false
   end
 
   create_table "bids", force: :cascade do |t|
     t.integer  "bidder_id"
     t.integer  "auction_id"
-    t.float    "amount"
+    t.integer  "amount"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
This is an IRREVERSIBLE MIGRATION, but I decided it might be a good time to convert the DB bid fields to integers instead of floats. Since we are not allowing sub-dollar bids, this is just straight up dollar fields, but if we eventually allow a lower level of granularity, then we will have to rename to `_cents` fields and make a few more changes.