### PR TITLE
Wrap auction description in auctions#show view.

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -28,6 +28,10 @@ textarea#auction_description {
   }
 }
 
+.github-issue {
+  white-space: pre-line;
+}
+
 .auction-detail-panel {
   border: 1px solid #ccc;
 

--- a/app/views/auctions/show.html.erb
+++ b/app/views/auctions/show.html.erb
@@ -8,8 +8,8 @@
 <% end %>
 
 <div class="usa-grid-full">
-    <p><a href="<%= root_path %>">« Back to open projects</a></p>
-    <div class="usa-width-two-thirds auction-description">
+  <p><a href="<%= root_path %>">« Back to open projects</a></p>
+  <div class="usa-width-two-thirds auction-description">
     <h1>Auction Details</h1>
     <div class="github-issue">
       <%=h raw @auction.html_description %>
@@ -20,7 +20,6 @@
       <div class="auction-info">
       <p class="auction-label">Status:</p>
       <p class="auction-label-info"><% if @auction.available? %>Open<% else %>Closed<% end %></p>
-<!--       <hr/> -->
       <p class="auction-label">Current Bid:</p>
       <p class="auction-label-info"><span class="bid-amount"><%= number_to_currency(@auction.current_bid_amount) %></span>
         <span class=""><%=
@@ -31,26 +30,21 @@
         %>
         </span>
       </p>
-  <!--     <hr/> -->
       <p class="auction-label">Bid deadline:</p>
       <p class="auction-label-info"><%= @auction.end_datetime.strftime("%m/%d/%Y at %I:%M %Z") %></p>
-   <!--    <hr/> -->
       <p>
         <a href="<%= new_auction_bid_path(@auction) %>" class='usa-button usa-button'>BID »</a>
       </p>
     </div>
       <div class="auction-more-info">
-<!--         <p><a href="#">Ask a Question »</a></p> -->
         <p>
           <i class="fa fa-github"></i>
           <a href="<%= @auction.issue_url %>">View on GitHub »</a>
         </p>
         <p>
-          <!-- <i class="fa fa-envelope"></i> -->
           <a href="mailto:micropurchase@gsa.gov">Have feedback? Email micropurchase@gsa.gov</a>
         </p>
       </div>
     </div>
   </div>
-
 </div>


### PR DESCRIPTION
Showcasing my l33t CSS skills, I added a `white-space: pre-line;` property to prevent the auction description text from running into the auction description box in the `auctions#show` view.

In sum, this code makes 
<img width="1276" alt="screen shot 2015-12-28 at 10 13 22 am" src="https://cloud.githubusercontent.com/assets/86790/12021588/d8418800-ad55-11e5-81c4-7155c6ed5b02.png">

Look like

<img width="1277" alt="screen shot 2015-12-28 at 11 22 28 am" src="https://cloud.githubusercontent.com/assets/86790/12021590/de629580-ad55-11e5-9dc6-778311bfb592.png">

This still leaves some extra styling to be desired: the line breaks below the `h` tags is probably too much and should be reduced. But that can happen in a subsequent PR.

Iterative improvements ftw!
