### PR TITLE
Clarify wording about DUNS number and SAM.gov

### DIFF
--- a/app/views/logins/index.html.erb
+++ b/app/views/logins/index.html.erb
@@ -1,6 +1,6 @@
 <h2>Getting started</h2>
 
-<p>Before participating in this marketplace, you’ll first need to register your company with <a href="https://www.sam.gov/portal/SAM/##11">SAM.gov</a> to receive a DUNS number, and have a GitHub account. </p>
+<p>To participate in this marketplace, you’ll need a <a href="https://fedgov.dnb.com/webform" >DUNS number</a> (you can register your company with <a href="https://www.sam.gov/portal/SAM/##11">SAM.gov</a> if you don't have one already), and a GitHub account. </p>
 
 <p>Once you’re ready, continue with GitHub authorization (only public account information will be requested). If you encounter any issues, let us know at <%= mail_to 'micropurchase@gsa.gov' %>.</p>
 


### PR DESCRIPTION
On the login page, change wording to reflect the possibility that
the vendor may already have a DUNS number.