### PR TITLE
Add Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,34 +1,114 @@
 AllCops:
+  Include:
+    - 'Gemfile'
+    - 'Rakefile'
+    - 'lib/tasks/*'
+    - "**/*.rake"
+    - "**/Capfile"
+    - "**/Guardfile"
+    - "**/Vagrantfile"
+    - "**/Berksfile"
+    - "**/Cheffile"
   Exclude:
-    - 'bin/**/*'
-    - 'db/**/*'
-  RunRailsCops: true
+    - 'db/schema.rb'
+
+Lint/ParenthesesAsGroupedExpression:
+  Description: Checks for method calls with a space before the opening parenthesis.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#parens-no-spaces
+  Enabled: true
+
+Metrics/ClassLength:
+  Description: Avoid classes longer than 100 lines of code.
+  Enabled: true
+  CountComments: false
+  Max: 100
+
 Metrics/LineLength:
-  Enabled: false
-Style/CommentAnnotation:
-  Enabled: false
-Style/Documentation:
-  Enabled: false
-Style/DotPosition:
-  Enabled: false
-Style/EmptyElse:
-  Enabled: false
-Style/GuardClause:
-  Enabled: false
-Style/IfUnlessModifier:
-  # inline conditionals don't get picked up by simplecov, so preferable to avoid them
-  Enabled: false
-Style/RedundantBegin:
-  Enabled: false
-Style/RedundantSelf:
-  Enabled: false
-Style/SignalException:
-  Enabled: false
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/TrailingComma:
-  Enabled: false
+  Description: Limit lines to 120 characters.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#80-character-limits
+  Enabled: true
+  Max: 120
+  AllowURI: true
+  URISchemes:
+  - http
+  - https
+
+Metrics/MethodLength:
+  Description: Avoid methods longer than 20 lines of code.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#short-methods
+  Enabled: true
+  CountComments: false
+  Max: 20
+
+Metrics/ModuleLength:
+  Description: Avoid modules longer than 100 lines of code.
+  Enabled: true
+  CountComments: false
+  Max: 100
+
+Rails/HasAndBelongsToMany:
+  Description: Prefer has_many :through to has_and_belongs_to_many.
+  Enabled: true
+  Include:
+  - app/models/**/*.rb
+
+Rails/ScopeArgs:
+  Description: Checks the arguments of ActiveRecord scopes.
+  Enabled: true
+  Include:
+  - app/models/**/*.rb
+
+Rails/TimeZone:
+  # The value `always` means that `Time` should be used with `zone`.
+  # The value `acceptable` allows usage of `in_time_zone` instead of `zone`.
+  Enabled: true
+  EnforcedStyle: always
+  SupportedStyles:
+    - always
+    - acceptable
+
 Style/AndOr:
+  Description: Use &&/|| instead of and/or.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-and-or-or
+  Enabled: true
+  EnforcedStyle: conditionals
+  SupportedStyles:
+  - always
+  - conditionals
+
+Style/Documentation:
+  Description: Document classes and non-namespace modules.
   Enabled: false
-ClassLength:
-  Max: 250
+
+Style/DotPosition:
+  Description: Checks the position of the dot in multi-line method calls.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#consistent-multi-line-chains
+  Enabled: true
+  EnforcedStyle: trailing
+  SupportedStyles:
+  - leading
+  - trailing
+
+Style/ExtraSpacing:
+  Description: Do not use unnecessary spacing.
+  Enabled: false
+
+Style/TrailingWhitespace:
+  Description: 'Avoid trailing whitespace.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-whitespace'
+  Enabled: false
+
+Style/GuardClause:
+  Description: Check for conditionals that can be replaced with guard clauses
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-nested-conditionals
+  Enabled: true
+  MinBodyLength: 1
+
+Style/StringLiterals:
+  Description: Checks if uses of quotes match the configured preference.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#consistent-string-literals
+  Enabled: false
+  EnforcedStyle: single_quotes
+  SupportedStyles:
+  - single_quotes
+  - double_quotes

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,34 @@
+AllCops:
+  Exclude:
+    - 'bin/**/*'
+    - 'db/**/*'
+  RunRailsCops: true
+Metrics/LineLength:
+  Enabled: false
+Style/CommentAnnotation:
+  Enabled: false
+Style/Documentation:
+  Enabled: false
+Style/DotPosition:
+  Enabled: false
+Style/EmptyElse:
+  Enabled: false
+Style/GuardClause:
+  Enabled: false
+Style/IfUnlessModifier:
+  # inline conditionals don't get picked up by simplecov, so preferable to avoid them
+  Enabled: false
+Style/RedundantBegin:
+  Enabled: false
+Style/RedundantSelf:
+  Enabled: false
+Style/SignalException:
+  Enabled: false
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+Style/TrailingComma:
+  Enabled: false
+Style/AndOr:
+  Enabled: false
+ClassLength:
+  Max: 250

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,8 @@ AllCops:
     - "**/Cheffile"
   Exclude:
     - 'db/schema.rb'
+    - 'db/migrate/*'
+    - 'lib/tasks/cucumber.rake'
 
 Lint/ParenthesesAsGroupedExpression:
   Description: Checks for method calls with a space before the opening parenthesis.
@@ -22,6 +24,13 @@ Metrics/ClassLength:
   Enabled: true
   CountComments: false
   Max: 100
+
+
+Metrics/AbcSize:
+  # The ABC size is a calculated magnitude, so this number can be a Fixnum or
+  # a Float.
+  Max: 15
+  Enabled: false
 
 Metrics/LineLength:
   Description: Limit lines to 120 characters.
@@ -46,6 +55,10 @@ Metrics/ModuleLength:
   CountComments: false
   Max: 100
 
+Style/MultilineBlockLayout:
+  Description: 'Ensures newlines after multiline block do statements.'
+  Enabled: false
+  
 Rails/HasAndBelongsToMany:
   Description: Prefer has_many :through to has_and_belongs_to_many.
   Enabled: true
@@ -91,12 +104,12 @@ Style/DotPosition:
 
 Style/ExtraSpacing:
   Description: Do not use unnecessary spacing.
-  Enabled: false
+  Enabled: true
 
 Style/TrailingWhitespace:
   Description: 'Avoid trailing whitespace.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-whitespace'
-  Enabled: false
+  Enabled: true
 
 Style/GuardClause:
   Description: Check for conditionals that can be replaced with guard clauses
@@ -112,3 +125,35 @@ Style/StringLiterals:
   SupportedStyles:
   - single_quotes
   - double_quotes
+
+Style/SpaceBeforeBlockBraces:
+  EnforcedStyle: space
+  SupportedStyles:
+    - space
+    - no_space
+
+Style/SpaceInsideBlockBraces:
+  EnforcedStyle: space
+  SupportedStyles:
+    - space
+    - no_space
+  # Valid values are: space, no_space
+  EnforcedStyleForEmptyBraces: no_space
+  # Space between { and |. Overrides EnforcedStyle if there is a conflict.
+  SpaceBeforeBlockParameters: false
+
+Style/SpaceInsideHashLiteralBraces:
+  EnforcedStyle: no_space
+  EnforcedStyleForEmptyBraces: no_space
+  SupportedStyles:
+    - space
+    - no_space
+
+Style/SpaceInsideStringInterpolation:
+  EnforcedStyle: no_space
+  SupportedStyles:
+    - space
+    - no_space
+    
+Style/StructInheritance:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.4'
 gem 'pg'
@@ -41,7 +40,7 @@ group :development, :test do
   gem 'faker'
   gem 'timecop'
   gem 'brakeman', require: false
-  gem 'hakiri',  require: false
+  gem 'hakiri', require: false
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ end
 group :development do
   gem 'web-console', '~> 2.0'
   gem 'rails-erd'
+  gem 'rubocop'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,9 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.4.0)
     arel (6.0.3)
+    ast (2.1.0)
+    astrolabe (1.3.1)
+      parser (~> 2.2)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     brakeman (3.1.3)
@@ -158,7 +161,10 @@ GEM
     omniauth-oauth2 (1.4.0)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
+    parser (2.2.3.0)
+      ast (>= 1.1, < 3.0)
     pg (0.18.4)
+    powerpack (0.1.1)
     pry (0.10.3)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -200,6 +206,7 @@ GEM
       activesupport (= 4.2.4)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
+    rainbow (2.0.0)
     rake (10.4.2)
     redcarpet (3.3.3)
     rest-client (1.8.0)
@@ -223,7 +230,14 @@ GEM
       rspec-mocks (~> 3.4.0)
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
+    rubocop (0.34.2)
+      astrolabe (~> 1.3)
+      parser (>= 2.2.2.5, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.4)
     ruby-graphviz (1.2.2)
+    ruby-progressbar (1.7.5)
     ruby2ruby (2.2.0)
       ruby_parser (~> 3.1)
       sexp_processor (~> 4.0)
@@ -305,6 +319,7 @@ DEPENDENCIES
   rails_12factor
   redcarpet
   rspec-rails
+  rubocop
   sass-rails (~> 5.0)
   timecop
   uglifier (>= 1.3.0)

--- a/Rakefile
+++ b/Rakefile
@@ -3,4 +3,9 @@
 
 require File.expand_path('../config/application', __FILE__)
 
+if Rails.env.development?
+  require 'rubocop/rake_task'
+  RuboCop::RakeTask.new
+end
+
 Rails.application.load_tasks

--- a/app/controllers/admin/auctions_controller.rb
+++ b/app/controllers/admin/auctions_controller.rb
@@ -3,7 +3,7 @@ module Admin
     before_filter :require_admin
 
     def index
-      @auctions = Auction.all.map{|auction| Presenter::Auction.new(auction) }
+      @auctions = Auction.all.map {|auction| Presenter::Auction.new(auction) }
     end
 
     def show

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -3,13 +3,12 @@ module Admin
     before_filter :require_admin
 
     def index
-      all_users = User.all.map {|user| Presenter::User.new(user)}
-      @admins, @users = all_users.partition {|u| u.is_admin?}
+      all_users = User.all.map {|user| Presenter::User.new(user) }
+      @admins, @users = all_users.partition(&:admin?)
     end
 
     def show
       @user = Presenter::User.new(User.find(params[:id]))
     end
-
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,7 +17,7 @@ class ApplicationController < ActionController::Base
   def require_admin
     require_authentication and return
     is_admin = Admins.verify?(current_user.github_id)
-    raise UnauthorizedError, 'must be an admin' unless is_admin
+    fail UnauthorizedError, 'must be an admin' unless is_admin
     is_admin
   end
 

--- a/app/controllers/auctions_controller.rb
+++ b/app/controllers/auctions_controller.rb
@@ -1,6 +1,6 @@
 class AuctionsController < ApplicationController
   def index
-    @auctions = Auction.all.includes(:bids).map{|auction| Presenter::Auction.new(auction) }
+    @auctions = Auction.all.includes(:bids).map {|auction| Presenter::Auction.new(auction) }
   end
 
   def show

--- a/app/controllers/bids_controller.rb
+++ b/app/controllers/bids_controller.rb
@@ -8,11 +8,11 @@ class BidsController < ApplicationController
   end
 
   def my_bids
-    @auctions = Auction
-      .joins(:bids)
-      .where(bids: {bidder_id: current_user.id})
-      .uniq
-      .map {|auction| Presenter::Auction.new(auction) }
+    @auctions = Auction.
+                joins(:bids).
+                where(bids: {bidder_id: current_user.id}).
+                uniq.
+                map {|auction| Presenter::Auction.new(auction) }
   end
 
   def new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,14 +1,14 @@
 class UsersController < ApplicationController
   def edit
     @user = User.find(params[:id])
-    raise UnauthorizedError if current_user != @user
+    fail UnauthorizedError if current_user != @user
   end
 
   def update
     require_authentication and return
 
     @user = User.find(params[:id])
-    raise UnauthorizedError if current_user != @user
+    fail UnauthorizedError if current_user != @user
     @user.update(user_params)
 
     if @user.save
@@ -18,7 +18,6 @@ class UsersController < ApplicationController
       render :edit
     end
   end
-
 
   private
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,6 +13,7 @@ module ApplicationHelper
       end
     end
     flash.clear
-    return result
+
+    result
   end
 end

--- a/app/models/auction_parser.rb
+++ b/app/models/auction_parser.rb
@@ -28,8 +28,9 @@ class AuctionParser < Struct.new(:params)
 
   def parse_time(time)
     parsed_time = Chronic.parse(time)
-    raise ArgumentError.new("Missing or poorly formatted time: '#{time}'") if !parsed_time
-    if !time.match(/\d{1,2}:\d{2}/)
+    fail ArgumentError, "Missing or poorly formatted time: '#{time}'" unless parsed_time
+
+    unless time.match(/\d{1,2}:\d{2}/)
       parsed_time = parsed_time.beginning_of_day
     end
     parsed_time.utc
@@ -37,9 +38,8 @@ class AuctionParser < Struct.new(:params)
 
   def start_price
     price = params[:auction][:start_price].to_f
-    if price > PlaceBid::BID_LIMIT || price <= 0
-      price = PlaceBid::BID_LIMIT
-    end
+    price = PlaceBid::BID_LIMIT if price > PlaceBid::BID_LIMIT || price <= 0
+
     price
   end
 end

--- a/app/models/authenticator.rb
+++ b/app/models/authenticator.rb
@@ -15,9 +15,7 @@ class Authenticator < Struct.new(:auth_hash, :session)
   end
 
   def update_user
-    user.update_attributes({
-      name: name
-    })
+    user.update_attribute(:name, name)
   end
 
   def sign_in

--- a/app/models/place_bid.rb
+++ b/app/models/place_bid.rb
@@ -1,4 +1,4 @@
-class PlaceBid < Struct.new(:params,:current_user)
+class PlaceBid < Struct.new(:params, :current_user)
   BID_LIMIT = 3500
   BID_INCREMENT = 1
 
@@ -10,11 +10,11 @@ class PlaceBid < Struct.new(:params,:current_user)
   end
 
   def create_bid
-    @bid ||= Bid.create({
+    @bid ||= Bid.create(
       amount: amount,
       bidder_id: current_user.id,
       auction_id: auction.id
-    })
+    )
   end
 
   private
@@ -31,27 +31,29 @@ class PlaceBid < Struct.new(:params,:current_user)
     Presenter::Auction.new(auction).current_max_bid
   end
 
+  # rubocop:disable Style/IfUnlessModifier, Style/GuardClause
   def validate_bid_data
     if amount.to_i != amount
-      raise UnauthorizedError, 'Bids must be in increments of one dollar'
+      fail UnauthorizedError, 'Bids must be in increments of one dollar'
     end
 
-    if !auction_available?
-      raise UnauthorizedError, 'Auction not available'
+    unless auction_available?
+      fail UnauthorizedError, 'Auction not available'
     end
 
     if amount > BID_LIMIT
-      raise UnauthorizedError, 'Bid too high'
+      fail UnauthorizedError, 'Bid too high'
     end
 
     if amount <= 0
-      raise UnauthorizedError, 'Bid amount out of range'
+      fail UnauthorizedError, 'Bid amount out of range'
     end
 
     if amount > current_max_bid
-      raise UnauthorizedError, "Bids cannot be greater than the current max bid"
+      fail UnauthorizedError, "Bids cannot be greater than the current max bid"
     end
   end
+  # rubocop:enable Style/IfUnlessModifier, Style/GuardClause
 
   def amount
     (params[:bid] && params[:bid][:amount]).to_f.round(2)

--- a/app/models/presenter/auction.rb
+++ b/app/models/presenter/auction.rb
@@ -1,7 +1,7 @@
 module Presenter
   class Auction < SimpleDelegator
     def current_bid?
-      !!current_bid_record
+      current_bid_record != nil
     end
 
     def current_bid
@@ -38,10 +38,10 @@ module Presenter
     end
 
     def bids
-      model.bids.to_a
-        .map {|bid| Presenter::Bid.new(bid)}
-        .sort_by {|bid| bid.created_at}
-        .reverse
+      model.bids.to_a.
+        map {|bid| Presenter::Bid.new(bid) }.
+        sort_by(&:created_at).
+        reverse
     end
 
     def starts_at
@@ -52,26 +52,28 @@ module Presenter
       Presenter::DcTime.convert_and_format(model.end_datetime)
     end
 
+    # rubocop:disable Style/DoubleNegation
     def available?
       !!(
         (model.start_datetime && (model.start_datetime <= Time.now)) &&
           (model.end_datetime && (model.end_datetime >= Time.now))
       )
     end
+    # rubocop:enable Style/DoubleNegation
 
     def over?
       model.end_datetime < Time.now
     end
 
     def user_is_winning_bidder?(user)
-      return false if !current_bid?
+      return false unless current_bid?
       user.id == current_bid.bidder_id
     end
 
     def user_is_bidder?(user)
       bids.detect {|b| user.id == b.bidder_id } != nil
     end
-    
+
     def html_description
       return '' if description.blank?
       markdown.render(description)
@@ -85,7 +87,7 @@ module Presenter
     private
 
     def current_bid_record
-      @current_bid_record ||= bids.sort_by{|bid| [bid.amount, bid.created_at, bid.id]}.first
+      @current_bid_record ||= bids.sort_by {|bid| [bid.amount, bid.created_at, bid.id] }.first
     end
 
     def markdown

--- a/app/models/presenter/bid.rb
+++ b/app/models/presenter/bid.rb
@@ -23,7 +23,7 @@ module Presenter
     def presenter_auction
       @presenter_auction ||= Presenter::Auction.new(auction)
     end
-    
+
     def null
       Null::NULL
     end

--- a/app/models/presenter/dc_time.rb
+++ b/app/models/presenter/dc_time.rb
@@ -6,7 +6,7 @@ module Presenter
       time.in_time_zone(ActiveSupport::TimeZone['Eastern Time (US & Canada)'])
     end
 
-    def convert_and_format(format=FORMAT)
+    def convert_and_format(format = FORMAT)
       return Bid::Null::NULL unless time
       convert.strftime(format)
     end
@@ -15,7 +15,7 @@ module Presenter
       new(time).convert
     end
 
-    def self.convert_and_format(time, format=FORMAT)
+    def self.convert_and_format(time, format = FORMAT)
       new(time).convert_and_format(format)
     end
   end

--- a/app/models/presenter/user.rb
+++ b/app/models/presenter/user.rb
@@ -4,7 +4,7 @@ module Presenter
       "https://api.github.com/user/#{github_id}"
     end
 
-    def is_admin?
+    def admin?
       Admins.verify?(model.github_id)
     end
 

--- a/bin/setup
+++ b/bin/setup
@@ -2,7 +2,7 @@
 require 'pathname'
 
 # path to your application root.
-APP_ROOT = Pathname.new File.expand_path('../../',  __FILE__)
+APP_ROOT = Pathname.new File.expand_path('../../', __FILE__)
 
 Dir.chdir APP_ROOT do
   # This script is a starting point to setup your application.

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,7 +23,7 @@ module Micropurchase
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
-     config.time_zone = "Etc/UTC"
+    config.time_zone = "Etc/UTC"
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
@@ -40,4 +40,3 @@ module Micropurchase
     end
   end
 end
-

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -11,4 +11,3 @@ Rails.application.config.assets.version = '1.0'
 # Rails.application.config.assets.precompile += %w( search.js )
 
 Rails.application.config.assets.paths << Rails.root.join('app', 'assets', 'images')
-

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,5 +1,5 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
-   provider :github,
+  provider :github,
            ENV['MPT_3500_GITHUB_KEY'],
            ENV['MPT_3500_GITHUB_SECRET']
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -56,4 +56,3 @@ end
 # The :transaction strategy is faster, but might give you threading problems.
 # See https://github.com/cucumber/cucumber-rails/blob/master/features/choose_javascript_database_strategy.feature
 Cucumber::Rails::Database.javascript_strategy = :truncation
-

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 RSpec.describe ApplicationController, controller: true do
   describe '#require_admin' do
     let(:current_user) { nil }
-    
     before do
       allow(controller).to receive(:current_user).and_return(current_user)
     end
@@ -19,9 +18,7 @@ RSpec.describe ApplicationController, controller: true do
       let(:current_user) { FactoryGirl.create(:user) }
 
       it 'raises an authorization error' do
-        expect {
-          controller.require_admin
-        }.to raise_error(UnauthorizedError)
+        expect { controller.require_admin }.to raise_error(UnauthorizedError)
       end
     end
 
@@ -30,9 +27,7 @@ RSpec.describe ApplicationController, controller: true do
 
       it 'lets the request pass through' do
         expect(controller).to_not receive(:redirect_to)
-        expect {
-          controller.require_admin
-        }.not_to raise_error
+        expect { controller.require_admin }.not_to raise_error
       end
     end
   end

--- a/spec/controllers/auctions_controller_spec.rb
+++ b/spec/controllers/auctions_controller_spec.rb
@@ -21,4 +21,3 @@ RSpec.describe AuctionsController, controller: true do
     end
   end
 end
-

--- a/spec/controllers/authentications_controller_spec.rb
+++ b/spec/controllers/authentications_controller_spec.rb
@@ -23,9 +23,7 @@ RSpec.describe AuthenticationsController do
 
     it 'should create a new user' do
       request.env["omniauth.auth"] = OmniAuth.config.mock_auth[:github]
-      expect {
-        get :create, provider: 'github'
-      }.to change { User.count }.by(1)
+      expect { get :create, provider: 'github' }.to change { User.count }.by(1)
       user = User.last
       expect(user.github_id).to eq(current_user_uid)
     end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -5,19 +5,18 @@ RSpec.describe UsersController, type: :controller do
 
   describe '#edit' do
     it 'raises a ActiveRecord::RecordNotFound when user is not found' do
-      expect {
-        get :edit, {id: user.id + 1000}, {user_id: user.id}
-      }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { get :edit, {id: user.id + 1000}, user_id: user.id }.
+        to raise_error(ActiveRecord::RecordNotFound)
     end
 
     it 'handles it as unauthorized when user is not in session' do
-      get :edit, {id: user.id}, { user_id: FactoryGirl.create(:user).id }
+      get :edit, {id: user.id}, user_id: FactoryGirl.create(:user).id
       expect(response).to redirect_to('/')
       expect(flash[:error]).to match(/unauthorized/i)
     end
 
     it 'render the form when the user is found and same as in session' do
-      get :edit, {id: user.id}, { user_id: user.id }
+      get :edit, {id: user.id}, user_id: user.id
       expect(response.status).to eq(200)
       expect(response).to render_template(:edit)
     end
@@ -25,32 +24,31 @@ RSpec.describe UsersController, type: :controller do
 
   describe '#update' do
     it 'redirects to authenticate when not logged in' do
-      put :update, {id: user.id, user: {duns_number: '222'}}
+      put :update, id: user.id, user: {duns_number: '222'}
       expect(response).to be_redirect
       expect(response.location).to eq('http://test.host/login')
     end
 
     it 'raises a ActiveRecord::RecordNotFound when user is not found' do
       user_id = user.id + 1000
-      expect {
-        put :update, {id: user_id, user: {duns_number: '222'}}, { user_id: user.id }
-      }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { put :update, {id: user_id, user: {duns_number: '222'}}, user_id: user.id }.
+        to raise_error(ActiveRecord::RecordNotFound)
     end
 
     it 'handles as unauthorized when user is not in session' do
-      put :update, {id: user.id, user: {duns_number: '222'}}, { user_id: FactoryGirl.create(:user).id }
+      put :update, {id: user.id, user: {duns_number: '222'}}, user_id: FactoryGirl.create(:user).id
       expect(response).to redirect_to('/')
       expect(flash[:error]).to match(/unauthorized/i)
     end
 
     it 'update the user when current user is the user' do
-      put :update, {id: user.id, user: {duns_number: '222'}}, { user_id: user.id }
+      put :update, {id: user.id, user: {duns_number: '222'}}, user_id: user.id
       user.reload
       expect(user.duns_number).to eq('222')
     end
 
     it 'redirects back home after successful edit' do
-      put :update, {id: user.id, user: {duns_number: '222'}}, { user_id: user.id }
+      put :update, {id: user.id, user: {duns_number: '222'}}, user_id: user.id
       expect(response).to be_redirect
       expect(response.location).to eq('http://test.host/')
     end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,12 +2,12 @@ FactoryGirl.define do
   sequence :github_id do |n|
     n
   end
-  
+
   factory :user do
     name { Faker::Name.name }
     email { Faker::Internet.email }
     duns_number { Faker::Company.duns_number }
-    github_id 123456
+    github_id 123_456
 
     factory :admin_user do
       github_id { Admins.github_ids.first }

--- a/spec/features/admin_users_spec.rb
+++ b/spec/features/admin_users_spec.rb
@@ -22,6 +22,6 @@ RSpec.feature "AdminUsers", type: :feature do
     number_of_users.times { create_user }
     visit "/admin/users"
     expect(page).to have_text("Users (#{number_of_users}")
-    expect(page).to have_text("Admins (#{1}")
+    expect(page).to have_text("Admins (1)")
   end
 end

--- a/spec/features/bidder_interacts_with_auction_spec.rb
+++ b/spec/features/bidder_interacts_with_auction_spec.rb
@@ -5,7 +5,8 @@ RSpec.feature "bidder interacts with auction", type: :feature do
   scenario "There are no auctions" do
     visit "/"
 
-    expect(page).to have_content("There are no current open auctions on the site. Please check back soon to view micropurchase opportunities.")
+    expect(page).to have_content("There are no current open auctions on the site. " \
+                                 "Please check back soon to view micropurchase opportunities.")
   end
 
   scenario "Viewing auction list and navigating to bid history" do
@@ -108,8 +109,6 @@ RSpec.feature "bidder interacts with auction", type: :feature do
     expect(page).to have_content("You currently have the winning bid.")
   end
 
-
-
   scenario "Is not the current winning bidder with no bids" do
     create_bidless_auction
 
@@ -153,14 +152,14 @@ RSpec.feature "bidder interacts with auction", type: :feature do
   end
 
   scenario "Viewing bid history for running auction" do
-    Timecop.scale(36000) do
+    Timecop.scale(3_600) do
       create_current_auction
     end
     path = auction_bids_path(@auction.id)
     visit path
 
     # sort the bids so that newest is first
-    bids = @auction.bids.sort_by {|bid| bid.created_at}.reverse
+    bids = @auction.bids.sort_by(&:created_at).reverse
 
     # ensure the table has the correct content, in the correct order
     bids.each_with_index do |bid, i|
@@ -190,7 +189,6 @@ RSpec.feature "bidder interacts with auction", type: :feature do
       within(:xpath, cel_xpath(row_number, 4)) do
         expect(page).to have_content(bid.time)
       end
-
     end
   end
 
@@ -220,7 +218,7 @@ RSpec.feature "bidder interacts with auction", type: :feature do
     end
     expect(bid).to be_valid
     @auction.reload
-    
+
     auction = Presenter::Auction.new(@auction)
 
     expect(auction.current_bidder_name).to eq(@bidder.name)
@@ -248,7 +246,6 @@ RSpec.feature "bidder interacts with auction", type: :feature do
       bid = @auction.bids.create(bidder_id: @bidder.id, amount: 3498)
     end
     expect(bid).to be_valid
-    
     visit auction_path(auction.id)
 
     expect(page).to have_css('.usa-alert-error')
@@ -257,10 +254,10 @@ RSpec.feature "bidder interacts with auction", type: :feature do
     expect(page).not_to have_content("Current bid:")
 
     expect(page).to have_content("Auction ended at:")
-    expect(page).not_to have_content("Bid deadline:")    
+    expect(page).not_to have_content("Bid deadline:")
   end
 
-scenario "Viewing auction page for a closed auction where authenticated user has not placed bids" do
+  scenario "Viewing auction page for a closed auction where authenticated user has not placed bids" do
     create_closed_auction
     auction = Presenter::Auction.new(@auction)
 
@@ -275,7 +272,7 @@ scenario "Viewing auction page for a closed auction where authenticated user has
     expect(page).not_to have_content("Current bid:")
 
     expect(page).to have_content("Auction ended at:")
-    expect(page).not_to have_content("Bid deadline:")    
+    expect(page).not_to have_content("Bid deadline:")
   end
 
   scenario "Viewing auction page for a closed auction with no bidders" do
@@ -290,16 +287,15 @@ scenario "Viewing auction page for a closed auction where authenticated user has
     expect(page).not_to have_content("Bid deadline:")
   end
 
-
   scenario "Viewing bid history for a closed auction" do
-    Timecop.scale(36000) do
+    Timecop.scale(3_600) do
       create_closed_auction
     end
     path = auction_bids_path(@auction.id)
     visit path
 
     # sort the bids so that newest is first
-    bids = @auction.bids.sort_by {|bid| bid.created_at}.reverse
+    bids = @auction.bids.sort_by(&:created_at).reverse
 
     # ensure the table has the correct content, in the correct order
     bids.each_with_index do |bid, i|
@@ -336,7 +332,6 @@ scenario "Viewing auction page for a closed auction where authenticated user has
       within(:xpath, cel_xpath(row_number, 4)) do
         expect(page).to have_content(bid.time)
       end
-
     end
   end
 end

--- a/spec/features/security_spec.rb
+++ b/spec/features/security_spec.rb
@@ -14,7 +14,8 @@ RSpec.feature "Security" do
     let(:ruby_rails_vulns) { @ruby_rails_vulns }
 
     scenario "The site has zero Brakeman security warnings" do
-      expect(brakeman_warnings.length).to eq(0), "Expected 0 security warnings, got: \n #{brakeman_warnings.map(&:to_s)}."
+      expect(brakeman_warnings.length).
+        to eq(0), "Expected 0 security warnings, got: \n #{brakeman_warnings.map(&:to_s)}."
     end
 
     scenario "The Gemfile does not depend on vulnerable gems" do

--- a/spec/models/auction_parser_spec.rb
+++ b/spec/models/auction_parser_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe AuctionParser do
 
   describe '#perform' do
     context 'when the price is too high' do
-      let(:params) {
+      let(:params) do
         {
           auction: {
             title: 'title',
@@ -18,7 +18,7 @@ RSpec.describe AuctionParser do
             start_price: 3500.01
           }
         }
-      }
+      end
 
       it 'drops the price down to the bid upper limit' do
         expect(attributes[:start_price]).to eq(3500.00)
@@ -26,7 +26,7 @@ RSpec.describe AuctionParser do
     end
 
     context 'when the price is too low' do
-      let(:params) {
+      let(:params) do
         {
           auction: {
             title: 'title',
@@ -37,7 +37,7 @@ RSpec.describe AuctionParser do
             start_price: 0
           }
         }
-      }
+      end
 
       it 'bumps the price to the bid upper limit' do
         expect(attributes[:start_price]).to eq(3500.00)
@@ -45,17 +45,17 @@ RSpec.describe AuctionParser do
     end
 
     context 'when the price is not present' do
-      let(:params) {
+      let(:params) do
         {
           auction: {
             title: 'title',
             description: 'description',
             github_repo: 'github url',
             start_datetime: 'Nov 3, 2015',
-            end_datetime: '11/10/2015',
+            end_datetime: '11/10/2015'
           }
         }
-      }
+      end
 
       it 'makes the price the bid upper limit' do
         expect(attributes[:start_price]).to eq(3500.00)
@@ -63,65 +63,65 @@ RSpec.describe AuctionParser do
     end
 
     context 'when an exact time is passed for start/end time' do
-      let(:params) {
+      let(:params) do
         {
           auction: {
             title: 'title',
             description: 'description',
             github_repo: 'github url',
             start_datetime: 'Nov 3, 2015 15:15',
-            end_datetime: '11/10/2015 2:15pm',
+            end_datetime: '11/10/2015 2:15pm'
           }
         }
-      }
+      end
 
       it 'uses the time and date' do
-        expect(attributes[:start_datetime].utc.to_s).to  eq(Time.parse('Nov 3, 2015 15:15 EST').utc.to_s)
-        expect(attributes[:end_datetime].utc.to_s).to    eq(Time.parse("Nov 10, 2015 14:15 EST").utc.to_s)
+        expect(attributes[:start_datetime].utc.to_s).
+          to eq(Time.parse('Nov 3, 2015 15:15 EST').utc.to_s)
+        expect(attributes[:end_datetime].utc.to_s).
+          to eq(Time.parse("Nov 10, 2015 14:15 EST").utc.to_s)
       end
     end
 
     context 'when only a date is passed for start/end time' do
-      let(:params) {
+      let(:params) do
         {
           auction: {
             title: 'title',
             description: 'description',
             github_repo: 'github url',
             start_datetime: 'Nov 3, 2015',
-            end_datetime: '11/10/2015',
+            end_datetime: '11/10/2015'
           }
         }
-      }
+      end
 
       it 'uses the time and date' do
         expect(attributes[:start_datetime].utc.to_s).to eq(Time.parse('Nov 3, 2015 0:00 EST').utc.to_s)
-        expect(attributes[:end_datetime].utc.to_s).to   eq(Time.parse("Nov 10, 2015 0:00 EST").utc.to_s)
+        expect(attributes[:end_datetime].utc.to_s).to eq(Time.parse("Nov 10, 2015 0:00 EST").utc.to_s)
       end
     end
 
     context 'when the start or end date is missing' do
-      let(:params) {
+      let(:params) do
         {
           auction: {
             title: 'title',
             description: 'description',
             github_repo: 'github url',
             start_datetime: '',
-            end_datetime: '',
+            end_datetime: ''
           }
         }
-      }
+      end
 
       it 'raise an error' do
-        expect {
-          attributes
-        }.to raise_error(ArgumentError)
+        expect { attributes }.to raise_error(ArgumentError)
       end
     end
 
     context 'with other data' do
-      let(:params) {
+      let(:params) do
         {
           auction: {
             title: 'title',
@@ -132,7 +132,7 @@ RSpec.describe AuctionParser do
             issue_url: 'issue url'
           }
         }
-      }
+      end
 
       it 'stores the right stuff' do
         expect(attributes[:title]).to eq(params[:auction][:title])

--- a/spec/models/authenticator_spec.rb
+++ b/spec/models/authenticator_spec.rb
@@ -3,21 +3,18 @@ require 'rails_helper'
 RSpec.describe Authenticator do
   let(:authenticator) { Authenticator.new(auth_hash, session) }
 
-  let(:auth_hash) {
-    OmniAuth::AuthHash.new({
-      :provider => 'github',
-      :uid => '12345',
-      :info => {
+  let(:auth_hash) do
+    OmniAuth::AuthHash.new(
+      provider: 'github',
+      uid: '12345',
+      info: {
         name: 'Kane',
         email: 'email@gemal.com',
         image: 'github-image.png'
       }
-    })
-  }
-
-  let(:session) {
-    {}
-  }
+    )
+  end
+  let(:session) { {} }
 
   before do
     User.delete_all
@@ -27,9 +24,7 @@ RSpec.describe Authenticator do
     let!(:user) { User.create(github_id: '12345') }
 
     it 'does not create a new user' do
-      expect {
-        authenticator.perform
-      }.to_not change { User.count }
+      expect { authenticator.perform }.to_not change { User.count }
     end
 
     it 'updates the user with additional data' do
@@ -44,12 +39,11 @@ RSpec.describe Authenticator do
     end
 
     it 'returns the redirect path' do
-      expect(authenticator.perform).to(eq({
-        controller: :users,
-        action: :edit,
-        id: user.id,
-        only_path: true
-      }))
+      expect(authenticator.perform).
+        to eq(controller: :users,
+              action: :edit,
+              id: user.id,
+              only_path: true)
     end
   end
 
@@ -57,9 +51,7 @@ RSpec.describe Authenticator do
     let(:user) { User.where(github_id: '12345').first }
 
     it 'creates a new user' do
-      expect {
-        authenticator.perform
-      }.to change { User.count }
+      expect { authenticator.perform }.to change { User.count }
       expect(user.name).to eq('Kane')
     end
 
@@ -69,37 +61,32 @@ RSpec.describe Authenticator do
     end
 
     it 'returns the redirect path' do
-      expect(authenticator.perform).to(eq({
-        controller: :users,
-        action: :edit,
-        id: user.id,
-        only_path: true
-      }))
+      expect(authenticator.perform).
+        to eq(controller: :users,
+              action: :edit,
+              id: user.id,
+              only_path: true)
     end
   end
 
   context 'when the user is an admin' do
     let(:admin_uid) { Admins.github_ids.first }
 
-    let(:auth_hash) {
-      OmniAuth::AuthHash.new({
-        :provider => 'github',
-        :uid => admin_uid,
-        :info => {
+    let(:auth_hash) do
+      OmniAuth::AuthHash.new(
+        provider: 'github',
+        uid: admin_uid,
+        info: {
           name: 'Kane',
           email: 'email@gemal.com',
-          image: 'github-image.png'
-        }
-      })
-    }
-
+          image: 'github-image.png'})
+    end
 
     it 'has the redirect url as home' do
-      expect(authenticator.perform).to(eq({
-        controller: :auctions,
-        action: :index,
-        only_path: true
-      }))
+      expect(authenticator.perform).
+        to eq(controller: :auctions,
+              action: :index,
+              only_path: true)
     end
   end
 end

--- a/spec/models/place_bid_spec.rb
+++ b/spec/models/place_bid_spec.rb
@@ -4,60 +4,58 @@ RSpec.describe PlaceBid do
   let(:place_bid) { PlaceBid.new(params, current_user) }
   let(:current_user) { FactoryGirl.create(:user) }
   let(:amount) { 1005 }
-  let(:params) {
+  let(:params) do
     {
       auction_id: auction_id,
       bid: {
         amount: amount
       }
     }
-  }
+  end
   let(:auction_id) { auction.id }
-  let(:auction) { FactoryGirl.create(:auction,
-                                     start_datetime: Time.now - 3.days,
-                                     end_datetime: Time.now + 7.days) }
+  let(:auction) do
+    FactoryGirl.create(:auction,
+                       start_datetime: Time.now - 3.days,
+                       end_datetime: Time.now + 7.days)
+  end
 
   context 'when auction cannot be found' do
     let(:auction) { double('auction', id: 1000) }
 
     it 'should raise a not found' do
-      expect {
-        place_bid.perform
-      }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { place_bid.perform }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 
   context 'when the auction has expired' do
-    let(:auction) { FactoryGirl.create(:auction,
-                                       start_datetime: Time.now - 5.days,
-                                       end_datetime: Time.now - 3.day) }
+    let(:auction) do
+      FactoryGirl.create(:auction,
+                         start_datetime: Time.now - 5.days,
+                         end_datetime: Time.now - 3.day)
+    end
 
     it 'should raise an authorization error (because we have that baked in)' do
-      expect {
-        place_bid.perform
-      }.to raise_error(UnauthorizedError)
+      expect { place_bid.perform }.to raise_error(UnauthorizedError)
     end
   end
 
   context 'when the auction has not started yet' do
-    let(:auction) { FactoryGirl.create(:auction,
-                                       start_datetime: Time.now + 5.days,
-                                       end_datetime: Time.now + 7.days) }
+    let(:auction) do
+      FactoryGirl.create(:auction,
+                         start_datetime: Time.now + 5.days,
+                         end_datetime: Time.now + 7.days)
+    end
 
     it 'should raise an authorization error (same as above)' do
-      expect {
-        place_bid.perform
-      }.to raise_error(UnauthorizedError)
+      expect { place_bid.perform }.to raise_error(UnauthorizedError)
     end
   end
 
   context 'when the bid amount is in increments small than one dollar' do
-    let(:amount) {1000.99}
+    let(:amount) { 1_000.99 }
 
     it 'should raise an authorization error' do
-      expect {
-        place_bid.perform
-      }.to raise_error(UnauthorizedError)
+      expect { place_bid.perform }.to raise_error(UnauthorizedError)
     end
   end
 
@@ -65,9 +63,7 @@ RSpec.describe PlaceBid do
     let(:amount) { 3600 }
 
     it 'should raise an authorization error' do
-      expect {
-        place_bid.perform
-      }.to raise_error(UnauthorizedError)
+      expect { place_bid.perform }.to raise_error(UnauthorizedError)
     end
   end
 
@@ -76,9 +72,7 @@ RSpec.describe PlaceBid do
 
     it 'should raise an authorization error' do
       FactoryGirl.create(:bid, auction: auction, amount: amount - 5)
-      expect {
-        place_bid.perform
-      }.to raise_error(UnauthorizedError)
+      expect { place_bid.perform }.to raise_error(UnauthorizedError)
     end
   end
 
@@ -86,9 +80,7 @@ RSpec.describe PlaceBid do
     let(:amount) { 3600 }
 
     it 'should raise an authorization error' do
-      expect {
-        place_bid.perform
-      }.to raise_error(UnauthorizedError)
+      expect { place_bid.perform }.to raise_error(UnauthorizedError)
     end
   end
 
@@ -97,9 +89,7 @@ RSpec.describe PlaceBid do
 
     it 'should raise an authorization error' do
       FactoryGirl.create(:bid, auction: auction, amount: amount)
-      expect {
-        place_bid.perform
-      }.to raise_error(UnauthorizedError)
+      expect { place_bid.perform }.to raise_error(UnauthorizedError)
     end
   end
 
@@ -107,9 +97,7 @@ RSpec.describe PlaceBid do
     let(:amount) { 3500 }
 
     it 'should raise an authorization error' do
-      expect {
-        place_bid.perform
-      }.to raise_error(UnauthorizedError)
+      expect { place_bid.perform }.to raise_error(UnauthorizedError)
     end
   end
 
@@ -117,9 +105,7 @@ RSpec.describe PlaceBid do
     let(:amount) { '-10' }
 
     it 'should raise an authorization error' do
-      expect {
-        place_bid.perform
-      }.to raise_error(UnauthorizedError)
+      expect { place_bid.perform }.to raise_error(UnauthorizedError)
     end
   end
 
@@ -127,9 +113,7 @@ RSpec.describe PlaceBid do
     let(:amount) { 0 }
 
     it 'should raise an authorization error' do
-      expect {
-        place_bid.perform
-      }.to raise_error(UnauthorizedError)
+      expect { place_bid.perform }.to raise_error(UnauthorizedError)
     end
   end
 
@@ -137,9 +121,7 @@ RSpec.describe PlaceBid do
     let(:bid) { place_bid.bid }
 
     it 'creates a bid' do
-      expect {
-        place_bid.perform
-      }.to change { Bid.count }.by(1)
+      expect { place_bid.perform }.to change { Bid.count }.by(1)
       expect(bid.auction_id).to eq(auction.id)
       expect(bid.bidder_id).to eq(current_user.id)
     end

--- a/spec/models/presenter/auction_spec.rb
+++ b/spec/models/presenter/auction_spec.rb
@@ -19,12 +19,12 @@ RSpec.describe Presenter::Auction do
   end
 
   describe '#current_bid when there are multiple bids of different amounts' do
-    let!(:bids) {
+    let!(:bids) do
       [
         FactoryGirl.create(:bid, auction_id: ar_auction.id, amount: 20),
         FactoryGirl.create(:bid, auction_id: ar_auction.id, amount: 10)
       ]
-    }
+    end
 
     it 'return the bid with the lowest amount' do
       expect(auction.current_bid).to eq(bids.last)
@@ -32,7 +32,7 @@ RSpec.describe Presenter::Auction do
   end
 
   describe '#current_bid when there are multiple bids with the same amount' do
-    let!(:bids) {
+    let!(:bids) do
       collection = [
         FactoryGirl.create(:bid, auction_id: ar_auction.id, amount: 10.00),
         FactoryGirl.create(:bid, auction_id: ar_auction.id, amount: 10.00),
@@ -40,7 +40,7 @@ RSpec.describe Presenter::Auction do
       ]
       collection[1].update_attribute(:created_at, (Time.now - 3.hours).utc)
       collection
-    }
+    end
 
     it 'return the bid with the lowest amount' do
       expect(auction.current_bid).to eq(bids[1])
@@ -69,7 +69,7 @@ RSpec.describe Presenter::Auction do
 
   describe '#user_is_bidder?' do
     let(:ar_auction) { FactoryGirl.create(:auction, :with_bidders) }
-    
+
     context 'when the user has placed a bid on the project' do
       let(:bidder) { auction.bids.last.bidder }
 
@@ -86,7 +86,7 @@ RSpec.describe Presenter::Auction do
       end
     end
   end
-  
+
   describe '#available?' do
     context 'when the auction has expired' do
       let(:ar_auction) { FactoryGirl.create(:auction, :closed) }
@@ -132,7 +132,7 @@ RSpec.describe Presenter::Auction do
 
     context 'when the auction has not started' do
       let(:ar_auction) { FactoryGirl.create(:auction, :future) }
-      
+
       it 'should be false' do
         expect(auction).to_not be_over
       end
@@ -141,7 +141,7 @@ RSpec.describe Presenter::Auction do
 
   describe "#html_summary" do
     let(:summary) { nil }
-    let(:auction) { Presenter::Auction.new(FactoryGirl.build(:auction,  summary: summary)) }
+    let(:auction) { Presenter::Auction.new(FactoryGirl.build(:auction, summary: summary)) }
 
     it 'should return an empty string if the summary is blank' do
       expect(auction.html_summary).to be_blank
@@ -180,7 +180,7 @@ RSpec.describe Presenter::Auction do
     end
 
     context 'table rendering' do
-      let(:summary) { "First Header  | Second Header\n------------- | -------------\nContent Cell  | Content Cell\nContent Cell  | Content Cell\n" }
+      let(:summary) { "First Header|Second Header\n------------- | -------------\nContent Cell  | Content Cell\n" }
 
       it 'should render a table element' do
         expect(auction.html_summary).to match('<table>')
@@ -229,7 +229,7 @@ RSpec.describe Presenter::Auction do
     end
 
     context 'table rendering' do
-      let(:description) { "First Header  | Second Header\n------------- | -------------\nContent Cell  | Content Cell\nContent Cell  | Content Cell\n" }
+      let(:description) { "First Header|Second Header\n------------- | -------------\nContent Cell  | Content Cell\n" }
 
       it 'should render a table element' do
         expect(auction.html_description).to match('<table>')

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -23,7 +23,7 @@ require 'capybara-screenshot/rspec'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec/support/**/*.rb')].each {|f| require f }
 
 # Checks for pending migrations before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
@@ -55,7 +55,6 @@ RSpec.configure do |config|
 
   OmniAuth.config.test_mode = true
   DatabaseCleaner.strategy = :transaction
-  
   #  config.include FactoryGirl::Syntax::Methods
 
   config.before(:suite) do
@@ -66,7 +65,7 @@ RSpec.configure do |config|
       DatabaseCleaner.clean
     end
   end
-  
+
   config.before do
     mock_github
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,7 +21,6 @@ require "codeclimate-test-reporter"
 CodeClimate::TestReporter.start
 
 RSpec.configure do |config|
-
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.
@@ -45,53 +44,51 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
   # These two settings work together to allow you to limit a spec run
   # to individual examples or groups you care about by tagging them with
   # `:focus` metadata. When nothing is tagged with `:focus`, all examples
   # get run.
-  config.filter_run :focus
-  config.run_all_when_everything_filtered = true
+  # config.filter_run :focus
+  # config.run_all_when_everything_filtered = true
 
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options. We recommend
   # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
+  # config.example_status_persistence_file_path = "spec/examples.txt"
 
   # Limits the available syntax to the non-monkey patched syntax that is
   # recommended. For more details, see:
   #   - http://myronmars.to/n/dev-blog/2012/06/rspecs-new-expectation-syntax
   #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
   #   - http://myronmars.to/n/dev-blog/2014/05/notable-changes-in-rspec-3#new__config_option_to_disable_rspeccore_monkey_patching
-  config.disable_monkey_patching!
+  # config.disable_monkey_patching!
 
   # Many RSpec users commonly either run the entire suite or an individual
   # file, and it's useful to allow more verbose output when running an
   # individual spec file.
-  if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    config.default_formatter = 'doc'
-  end
+  # if config.files_to_run.one?
+  #  # Use the documentation formatter for detailed output,
+  #  # unless a formatter has already been configured
+  #  # (e.g. via a command-line flag).
+  #  # config.default_formatter = 'doc'
+  # end
 
   # Print the 10 slowest examples and example groups at the
   # end of the spec run, to help surface which specs are running
   # particularly slow.
-  config.profile_examples = 10
+  # config.profile_examples = 10
 
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing
   # the seed, which is printed after each run.
   #     --seed 1234
-  config.order = :random
+  # config.order = :random
 
   # Seed global randomization in this process using the `--seed` CLI option.
   # Setting this allows you to use `--seed` to deterministically reproduce
   # test failures related to randomization by passing the same `--seed` value
   # as the one that triggered the failure.
-  Kernel.srand config.seed
-=end
+  # Kernel.srand config.seed
 end

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -2,10 +2,11 @@ def create_user
   @user = FactoryGirl.create(:user)
 end
 
+# rubocop:disable Style/RedundantReturn
 def create_bidless_auction(end_datetime: Time.now + 3.days)
   @auction = FactoryGirl.create(:auction, end_datetime: end_datetime)
   @bidders = []
-  
+
   return @auction, @bidders
 end
 
@@ -18,15 +19,17 @@ end
 def create_current_auction
   @auction = FactoryGirl.create(:auction, :with_bidders)
   @bidders = @auction.bids
-  
+
   return @auction, @bidders
 end
 
 def create_closed_auction
   @auction = FactoryGirl.create(:auction, :closed, :with_bidders)
   @bidders = @auction.bids
+
   return @auction, @bidders
 end
+# rubocop:enable Style/RedundantReturn
 
 def sign_in_admin
   mock_github(uid: Admins.github_ids.first)
@@ -51,7 +54,7 @@ def show_page
   # requires the local server to be running
   # for more info: https://coderwall.com/p/jsutlq/capybara-s-save_and_open_page-with-css-and-js
   save_page Rails.root.join('public', 'capybara.html')
-  %x(launchy http://localhost:3000/capybara.html)
+  `launchy http://localhost:3000/capybara.html`
 end
 
 def cel_xpath(row_number, column_number)

--- a/spec/support/omniauth.rb
+++ b/spec/support/omniauth.rb
@@ -2,17 +2,16 @@ def current_user_uid
   '12345'
 end
 
-def github_auth_hash(opts={})
+def github_auth_hash(opts = {})
   OmniAuth::AuthHash.new({
-    :provider => 'github',
-    :uid => current_user_uid,
-    :info => {
-      :name => 'Doris Doogooder'
+    provider: 'github',
+    uid: current_user_uid,
+    info: {
+      name: 'Doris Doogooder'
     }
   }.merge(opts))
 end
 
-def mock_github(opts={})
+def mock_github(opts = {})
   OmniAuth.config.mock_auth[:github] = github_auth_hash(opts)
 end
-


### PR DESCRIPTION
Here is what Rubocop wants to fix. I tweaked the [default configuration](https://github.com/bbatsov/rubocop/blob/master/config/default.yml) to disable some things that were triggered all over the place (like using single ' instead of " if there is no interpolation), modify a few other things like the maximum line length, and there are a few places where I just needed to disable specific rubocop checks, but this should give you a rough idea of what is involved. Look at the attached config to this PR as well to see what it is disabling and tweaking.

To run this manually, run `bundle exec rubocop` at the root and it'll print out the issues it finds. But, to make this more effective, I recommend installing a Rubocop-compatible linter in your favorite editor:

* [Sublime Edit](https://sunlightfoundation.com/blog/2015/03/31/making-sublimelinter-work-with-rbenv-and-rubocop/)
* [Atom](https://atom.io/packages/linter-rubocop)
* [vim](https://github.com/scrooloose/syntastic)
* Emacs (who am I kidding, this is just me)

If we are cool with this, we can then enable [Hound CI](https://houndci.com/) on the project to nitpick on future commits. [This can be annoying](https://github.com/18F/myusa/pull/713) if people push up WIPs or PRs without checking the style, but it does annotate the specific problems in a PR. Alternatively, we could add a scenario to make the build fail if Rubocop flags any errors much like we do for Brakeman. Or we could just leave it unenforced and clean it up regularly.