### PR TITLE
Added veiled methods for use in non-admin views

### DIFF
--- a/app/models/presenter/bid.rb
+++ b/app/models/presenter/bid.rb
@@ -4,20 +4,28 @@ module Presenter
       Presenter::DcTime.convert_and_format(created_at)
     end
 
-    def bidder_duns_number
+    def veiled_bidder_duns_number
       if presenter_auction.available?
         '[Witheld]'
       else
-        bidder.duns_number || null
+        bidder_duns_number
+      end
+    end
+
+    def bidder_duns_number
+      bidder.duns_number || null
+    end
+
+    def veiled_bidder_name
+      if presenter_auction.available?
+        '[Name witheld until the auction ends]'
+      else
+        bidder_name
       end
     end
 
     def bidder_name
-      if presenter_auction.available?
-        '[Name witheld until the auction ends]'
-      else
-        bidder.name || null
-      end
+      bidder.name || null
     end
 
     def presenter_auction

--- a/app/views/bids/index.html
+++ b/app/views/bids/index.html
@@ -14,8 +14,8 @@
   <tbody>
     <% @auction.bids.each_with_index do |bid, i| %>
       <tr>
-        <td><%= bid.bidder_name %></td>
-        <td><%= bid.bidder_duns_number %></td>
+        <td><%= bid.veiled_bidder_name %></td>
+        <td><%= bid.veiled_bidder_duns_number %></td>
         <td><%= content_for_row(i, bid) %></td>
         <td><%= Presenter::DcTime.convert_and_format(bid.created_at) %></td>
       </tr>


### PR DESCRIPTION
Renamed the existing `bidder_name` and `bidder_duns_number` to `veiled_` equivalents and provided an access for the underlying value so the admin views can just call the direct display equivalents.

After a discussion with @baccigalupi, we decided this would be a better approach than relying on polymorphism and creating an `AdminAuction` and `AdminBid` presenters. Should there be more specialized distinctions between both views down the road, we might reconsider this approach.