### PR TITLE
Use samwise 0.2.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'chronic'
 gem 'email_validator'
 gem 'redcarpet'
 gem 'puma'
-gem 'samwise', '~> 0.2.3'
+gem 'samwise', '~> 0.2.5'
 
 group :test do
   gem "codeclimate-test-reporter", require: nil

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -246,7 +246,7 @@ GEM
     ruby_parser (3.7.2)
       sexp_processor (~> 4.1)
     safe_yaml (1.0.4)
-    samwise (0.2.3)
+    samwise (0.2.5)
       faraday
       httpclient
     sass (3.4.20)
@@ -326,7 +326,7 @@ DEPENDENCIES
   redcarpet
   rspec-rails
   rubocop
-  samwise (~> 0.2.3)
+  samwise (~> 0.2.5)
   sass-rails (~> 5.0)
   timecop
   uglifier (>= 1.3.0)


### PR DESCRIPTION
Samwise 0.2.4 had an error causing: https://travis-ci.org/18F/micropurchase/builds/101174270#L477. This uses a fixed version of samwise.