### PR TITLE
Add name to the user profile form

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ActiveRecord::Base
   before_save :clear_sam_status_if_duns_changed
 
   scope :not_in_sam, -> { where(sam_account: false) }
-
+  scope :blank_name, -> { where(name: [nil, '']) }
   def save_sam_status
     return if sam_account?
     self.sam_account = registered_on_sam?

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -13,6 +13,9 @@
 
 <%= form_for @user, method: :put do |f| %>
 
+  <%= f.label :name, 'Name' %>
+  <%= f.text_field :name %>
+
   <%= f.label :duns_number, 'DUNS Number' %>
   <%= f.text_field :duns_number %>
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -42,7 +42,8 @@ RSpec.describe UsersController, type: :controller do
     end
 
     it 'update the user when current user is the user' do
-      put :update, {id: user.id, user: {duns_number: '222'}}, user_id: user.id
+      new_name = Faker::Name.name
+      put :update, {id: user.id, user: {name: new_name, duns_number: '222'}}, user_id: user.id
       user.reload
       expect(user.duns_number).to eq('222')
     end

--- a/spec/features/logging_in_and_out_spec.rb
+++ b/spec/features/logging_in_and_out_spec.rb
@@ -15,6 +15,7 @@ RSpec.feature "logging in and out of the app", type: :feature do
     click_on("Edit Profile")
 
     expect(page).to have_content("Complete your account")
+    expect(page).to have_content("Name")
     expect(page).to have_content("DUNS Number")
     expect(page).to have_content("Email Address")
   end
@@ -29,7 +30,9 @@ RSpec.feature "logging in and out of the app", type: :feature do
     expect(page).to have_content("Doris Doogooder")
     expect(page).to have_content("Logout")
 
+    new_name = Faker::Name.name
     expect(page).to have_content("Enter your DUNS number")
+    fill_in("user_name", with: new_name)
     fill_in("user_duns_number", with: "123-duns")
     fill_in("user_email", with: "doris@doogooder.io")
     click_on('Submit')
@@ -37,7 +40,7 @@ RSpec.feature "logging in and out of the app", type: :feature do
     expect(page.current_path).to eq("/")
 
     click_on("Logout")
-    expect(page).not_to have_content("Doris Doogooder")
+    expect(page).not_to have_content(new_name)
     expect(page).to have_content("Login")
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -12,4 +12,38 @@ RSpec.describe User do
       expect(u).to_not be_sam_account
     end
   end
+
+  describe 'named scopes' do
+    describe 'not_in_sam' do
+      it 'should return users where sam_account is false' do
+        u = FactoryGirl.create(:user, sam_account: false)
+        expect(User.not_in_sam).to include(u)
+      end
+
+      it 'should not return users where sam_account is true' do
+        u = FactoryGirl.create(:user, sam_account: true)
+        expect(User.not_in_sam).to_not include(u)
+      end
+    end
+
+    describe 'blank_name' do
+      it 'should return NULL names' do
+        u = FactoryGirl.create(:user)
+        u.update_attribute(:name, nil)
+
+        expect(User.blank_name).to include(u)
+      end
+
+      it 'should return blank string names' do
+        u = FactoryGirl.create(:user, name: '')
+        expect(User.blank_name).to include(u)
+      end
+
+      it 'should not return set names' do
+        u = FactoryGirl.create(:user)
+        expect(u.name).to_not be_blank
+        expect(User.blank_name).to_not include(u)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Since Github is sometimes returning blank for user names, add functionality for editing the user's name as well