### PR TITLE
Removes white-space: pre-line css from auction details (#216)

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -65,10 +65,6 @@ textarea#auction_description {
   }
 }
 
-.github-issue {
-  white-space: pre-line;
-}
-
 .auction-detail-panel {
   border: 1px solid #ccc;
 


### PR DESCRIPTION
This is causing line breaks wherever the source html includes line breaks. It was introduced by https://github.com/18F/micropurchase/commit/81f3213ab01674a57169ae980721649810daeae0, but doesn't look like it's needed. Fixes #216 

Before:

![image](https://cloud.githubusercontent.com/assets/848347/12248741/32e76ebc-b870-11e5-8da1-b93b9826e93a.png)

After:

![image](https://cloud.githubusercontent.com/assets/848347/12248751/45ea74a0-b870-11e5-9fb3-44077a38f0d8.png)
