### PR TITLE
Show the current user in open auction bids

### DIFF
--- a/app/models/presenter/bid.rb
+++ b/app/models/presenter/bid.rb
@@ -4,8 +4,8 @@ module Presenter
       Presenter::DcTime.convert_and_format(created_at)
     end
 
-    def veiled_bidder_duns_number
-      if presenter_auction.available?
+    def veiled_bidder_duns_number(show_user = nil)
+      if presenter_auction.available? && bidder != show_user
         '[Withheld]'
       else
         bidder_duns_number
@@ -16,8 +16,8 @@ module Presenter
       bidder.duns_number || null
     end
 
-    def veiled_bidder_name
-      if presenter_auction.available?
+    def veiled_bidder_name(show_user = nil)
+      if presenter_auction.available? && bidder != show_user
         '[Name withheld until the auction ends]'
       else
         bidder_name

--- a/app/views/bids/index.html
+++ b/app/views/bids/index.html
@@ -14,8 +14,8 @@
   <tbody>
     <% @auction.bids.each_with_index do |bid, i| %>
       <tr>
-        <td><%= bid.veiled_bidder_name %></td>
-        <td><%= bid.veiled_bidder_duns_number %></td>
+        <td><%= bid.veiled_bidder_name(current_user) %></td>
+        <td><%= bid.veiled_bidder_duns_number(current_user) %></td>
         <td><%= content_for_row(i, bid) %></td>
         <td><%= Presenter::DcTime.convert_and_format(bid.created_at) %></td>
       </tr>


### PR DESCRIPTION
When a user is logged in, they should be able to see themselves in the current bid list even when all other users are redacted. Fixes issue #219 