### PR TITLE
Adjust Spacing on Auction Details Page

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -66,7 +66,25 @@ textarea#auction_description {
 }
 
 .github-issue {
-  white-space: pre-line;
+  h1 {
+	  line-height: 1.1em;
+	  margin-top: 0.2em;
+	  margin-bottom: 0.5em;
+  }
+
+  h2, h3, h4, h5, h6 {
+	  line-height: 1.1em;
+	  margin-top: 0.2em;
+	  margin-bottom: 0.1em;
+  }
+
+  p, li {
+	  line-height: 1.3em;
+  }
+
+  ul {
+	  margin-bottom: 0.5em;
+  }
 }
 
 .auction-detail-panel {


### PR DESCRIPTION
Reduce vertical spacing in description on auction details page.

Fixes #216.

How does this look?

![2016-01-13-114251_936x1245_scrot](https://cloud.githubusercontent.com/assets/387035/12305763/332665f0-b9eb-11e5-99a0-463ab687e271.png)