### PR TITLE
Add auction start time to #index and #show

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -156,8 +156,6 @@ textarea#auction_description {
     }
 
     .bid-deadline-box {
-      height: 5rem;
-      position: relative;
 
       .bid-deadline-box-children {
         position: relative;

--- a/app/helpers/auction_helper.rb
+++ b/app/helpers/auction_helper.rb
@@ -30,4 +30,12 @@ module AuctionHelper
       'Open'
     end
   end
+
+  def auction_human_start_time(auction_time)
+    if auction_time < Time.now
+      "#{distance_of_time_in_words(Time.now, auction_time)} ago"
+    else
+      "in #{distance_of_time_in_words(Time.now, auction_time)}"
+    end
+  end
 end

--- a/app/views/auctions/_bids_and_form.html.erb
+++ b/app/views/auctions/_bids_and_form.html.erb
@@ -20,6 +20,9 @@
   <div class="bid-deadline-box-children">
   <span class="bid-deadline">
     Bid Deadline:  <%= distance_of_time_in_words(Time.now, auction.end_datetime) %> left
+  </span><br/>
+  <span class="bid-deadline">
+    Bid start time: <%= auction_human_start_time(auction.start_datetime) %>
   </span>
 </div>
 </div>

--- a/app/views/auctions/_winning_bid.html.erb
+++ b/app/views/auctions/_winning_bid.html.erb
@@ -5,3 +5,8 @@
 <% else %>
   <p>No bids</p>
 <% end %>
+<% unless auction.over? %>
+  <span class="bid-deadline">
+    Bid start time: <%= auction_human_start_time(auction.start_datetime) %>
+  </span>
+<% end %>

--- a/app/views/auctions/show.html.erb
+++ b/app/views/auctions/show.html.erb
@@ -34,6 +34,8 @@
       </p>
       <p class="auction-label"><% if @auction.over? %>Auction ended at:<% else %>Bid deadline:<% end %></p>
       <p class="auction-label-info"><%= @auction.end_datetime.strftime("%m/%d/%Y at %I:%M %p %Z") %></p>
+      <p class="auction-label"><% if @auction.over? %>Auction started at:<% else %>Bid start time:<% end %></p>
+      <p class="auction-label-info"><%= @auction.start_datetime.strftime("%m/%d/%Y at %I:%M %p %Z") %></p>
       <p>
         <a href="<%= new_auction_bid_path(@auction) %>" class='usa-button usa-button'>BID »</a>
       </p>

--- a/spec/features/bidder_interacts_with_auction_spec.rb
+++ b/spec/features/bidder_interacts_with_auction_spec.rb
@@ -79,6 +79,7 @@ RSpec.feature "bidder interacts with auction", type: :feature do
 
       expect(page).to have_content("Open")
       expect(page).to have_content(current_auction.end_datetime.strftime('%m/%d/%Y at %I:%M %p %Z'))
+      expect(page).to have_content(current_auction.start_datetime.strftime('%m/%d/%Y at %I:%M %p %Z'))
     end
 
     scenario "Viewing a closed auction" do


### PR DESCRIPTION
## What does this PR do?

This PR adds the auction start time to the auction #index and #show page. 

A few questions I raised in the issue #217 before:

## Auction not yet started (#index)
I assume you want to show the time left in _human words_ when a auction is not yet started:
<img width="784" alt="bildschirmfoto 2016-01-14 um 12 04 53" src="https://cloud.githubusercontent.com/assets/688980/12322854/0f3148aa-bab7-11e5-829b-5f46ecf69e15.png">

## Auction is finished (#index)
I assume you _don't_ want to display the start time once a auction is finished:
<img width="769" alt="bildschirmfoto 2016-01-14 um 12 06 13" src="https://cloud.githubusercontent.com/assets/688980/12322885/471e4a60-bab7-11e5-833a-cb5ddca5c0a9.png">

## Auction is currently running (#index)
I assume you want to display the start time _below_ the end time when a bid is currently running:
<img width="789" alt="bildschirmfoto 2016-01-14 um 12 07 09" src="https://cloud.githubusercontent.com/assets/688980/12322901/6db1f6e0-bab7-11e5-9060-332bc67c3175.png">

## Auction Detail Page
I assume you want to display the start time _below_ the end time on the detail page:
<img width="256" alt="bildschirmfoto 2016-01-14 um 12 08 53" src="https://cloud.githubusercontent.com/assets/688980/12322934/ae953f6e-bab7-11e5-86a2-212efe5de1f0.png">


__Could you please provide guidance on the wording: e.g. `Bid start time`__

### Styling

For which browsers should the code be optimized? Do you still support IE6/7?
I assume you want to vertical align the text in the center?
<img width="787" alt="bildschirmfoto 2016-01-14 um 12 12 27" src="https://cloud.githubusercontent.com/assets/688980/12323064/c27c9788-bab8-11e5-965b-f6fec044b723.png">


### Related Issue

fixes #217 