### PR TITLE
Expand and test the API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,8 @@ gem 'active_model_serializers'
 
 group :test do
   gem "codeclimate-test-reporter", require: nil
+  gem 'webmock'
+  gem 'json-schema'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,8 @@ GEM
     commander (4.3.5)
       highline (~> 1.7.2)
     concurrent-ruby (1.0.0)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     cucumber (1.3.20)
       builder (>= 2.1.2)
       diff-lcs (>= 1.1.3)
@@ -132,6 +134,7 @@ GEM
       terminal-table
     haml (4.0.7)
       tilt
+    hashdiff (0.2.3)
     hashie (3.4.3)
     highline (1.7.8)
     http-cookie (1.0.2)
@@ -139,6 +142,8 @@ GEM
     httpclient (2.7.1)
     i18n (0.7.0)
     json (1.8.3)
+    json-schema (2.6.0)
+      addressable (~> 2.3.8)
     jwt (1.5.2)
     launchy (2.4.3)
       addressable (~> 2.3)
@@ -309,6 +314,10 @@ GEM
       binding_of_caller (>= 0.7.2)
       railties (>= 4.0)
       sprockets-rails (>= 2.0, < 4.0)
+    webmock (1.22.3)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -330,6 +339,7 @@ DEPENDENCIES
   factory_girl_rails
   faker
   hakiri
+  json-schema
   octokit (~> 4.0)
   omniauth
   omniauth-github
@@ -348,6 +358,7 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   us_web_design_standards
   web-console (~> 2.0)
+  webmock
 
 BUNDLED WITH
    1.10.6

--- a/app/controllers/admin/auctions_controller.rb
+++ b/app/controllers/admin/auctions_controller.rb
@@ -8,7 +8,7 @@ module Admin
       respond_to do |format|
         format.html
         format.json do
-          render json: @auctions, each_serializer: Admin::AuctionSerializer
+          render json: @auctions, each_serializer: AuctionSerializer
         end
       end
     end
@@ -19,7 +19,7 @@ module Admin
       respond_to do |format|
         format.html
         format.json do
-          render json: @auction, serializer: Admin::AuctionSerializer
+          render json: @auction, serializer: AuctionSerializer
         end
       end
     end
@@ -35,7 +35,7 @@ module Admin
       respond_to do |format|
         format.html { redirect_to "/admin/auctions" }
         format.json do
-          render json: auction, serializer: Admin::AuctionSerializer
+          render json: auction, serializer: AuctionSerializer
         end
       end
     rescue ArgumentError => e
@@ -66,7 +66,7 @@ module Admin
       respond_to do |format|
         format.html { redirect_to "/admin/auctions" }
         format.json do
-          render json: auction, serializer: Admin::AuctionSerializer
+          render json: auction, serializer: AuctionSerializer
         end
       end
     rescue ArgumentError => e

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,13 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   helper_method :current_user
 
+  # for actions that don't require_authentication or require_admin,
+  # we still need to set_current_user_to_api_user so that users can
+  # optionally have authenticated access to public routes.
+  # for example, /auctions/:id/bids will unveil bidder info about
+  # the authenticated user. but the page also works fine sans authentication.
+  before_action :set_current_user_to_api_user!, if: Proc.new { api_request? }
+
   def current_user
     @current_user ||= User.where(id: session[:user_id]).first
   end
@@ -12,7 +19,7 @@ class ApplicationController < ActionController::Base
     if html_request?
       redirect_if_not_logged_in!
     elsif api_request?
-      set_current_user_to_api_user!
+      set_current_user_to_api_user!(raise_errors: true)
     end
   end
 
@@ -71,10 +78,15 @@ class ApplicationController < ActionController::Base
     should_redirect
   end
 
-  def set_current_user_to_api_user!
+  def set_current_user_to_api_user!(raise_errors: false)
     user = User.where(github_id: github_id).first
-    if user.nil?
-      fail UnauthorizedError::UserNotFound
+
+    if raise_errors
+      if user.nil?
+        fail UnauthorizedError::UserNotFound
+      else
+        @current_user = user
+      end
     else
       @current_user = user
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -41,6 +41,11 @@ class ApplicationController < ActionController::Base
     handle_error(message)
   end
 
+  rescue_from 'UnauthorizedError::UserNotFound' do |error|
+    message = error.message || "User not found"
+    handle_error(message)
+  end
+
   def html_request?
     request.format.symbol == :html
   end

--- a/app/controllers/auctions_controller.rb
+++ b/app/controllers/auctions_controller.rb
@@ -12,5 +12,12 @@ class AuctionsController < ApplicationController
 
   def show
     @auction = Presenter::Auction.new(Auction.find(params[:id]))
+
+    respond_to do |format|
+      format.html
+      format.json do
+        render json: @auction, serializer: AuctionSerializer
+      end
+    end
   end
 end

--- a/app/controllers/auctions_controller.rb
+++ b/app/controllers/auctions_controller.rb
@@ -1,6 +1,13 @@
 class AuctionsController < ApplicationController
   def index
     @auctions = Auction.in_reverse_chron_order.with_bids.map {|auction| Presenter::Auction.new(auction) }
+
+    respond_to do |format|
+      format.html
+      format.json do
+        render json: @auctions, each_serializer: AuctionSerializer
+      end
+    end
   end
 
   def show

--- a/app/controllers/bids_controller.rb
+++ b/app/controllers/bids_controller.rb
@@ -27,12 +27,35 @@ class BidsController < ApplicationController
   end
 
   def create
-    fail UnauthorizedError, "You must have a valid SAM.gov account to place a bid" unless current_user.sam_account?
-    PlaceBid.new(params, current_user).perform
-    flash[:bid] = "success"
-    redirect_to "/auctions/#{params[:auction_id]}"
-  rescue UnauthorizedError => e
-    flash[:error] = e.message
-    redirect_to "/auctions/#{params[:auction_id]}/bids/new"
+    begin
+      fail UnauthorizedError, "You must have a valid SAM.gov account to place a bid" unless current_user.sam_account?
+      @bid = Presenter::Bid.new(PlaceBid.new(params, current_user).perform)
+
+      respond_to do |format|
+        format.html do
+          flash[:bid] = "success"
+          redirect_to "/auctions/#{params[:auction_id]}"
+        end
+        format.json do
+          render json: @bid, serializer: BidSerializer
+        end
+      end
+    rescue UnauthorizedError => e
+      respond_error(e, redirect_path: "/auctions/#{params[:auction_id]}/bids/new")
+    end
+  end
+
+  private
+
+  def respond_error(error, redirect_path: '/')
+    respond_to do |format|
+      format.html do
+        flash[:error] = error.message
+        redirect_to redirect_path
+      end
+      format.json do
+        render json: {error: error.message}, status: 403
+      end
+    end
   end
 end

--- a/app/models/presenter/bid.rb
+++ b/app/models/presenter/bid.rb
@@ -4,24 +4,28 @@ module Presenter
       Presenter::DcTime.convert_and_format(created_at)
     end
 
-    def veiled_bidder_duns_number(show_user = nil)
+    # def bidder
+    #   Presenter::User.new(model.bidder)
+    # end
+
+    def veiled_bidder_attribute(attribute, show_user = nil, message: nil)
       if presenter_auction.available? && bidder != show_user
-        '[Withheld]'
+        message
       else
-        bidder_duns_number
+        bidder.send(attribute) || null
+      end
+    end
+
+    def veiled_bidder(show_user = nil, message: nil)
+      if presenter_auction.available? && bidder != show_user
+        Presenter::VeiledBidder.new(message: message)
+      else
+        bidder
       end
     end
 
     def bidder_duns_number
       bidder.duns_number || null
-    end
-
-    def veiled_bidder_name(show_user = nil)
-      if presenter_auction.available? && bidder != show_user
-        '[Name withheld until the auction ends]'
-      else
-        bidder_name
-      end
     end
 
     def bidder_name
@@ -34,6 +38,10 @@ module Presenter
 
     def null
       Null::NULL
+    end
+
+    def model
+      __getobj__
     end
 
     class Null

--- a/app/models/presenter/bid.rb
+++ b/app/models/presenter/bid.rb
@@ -4,10 +4,6 @@ module Presenter
       Presenter::DcTime.convert_and_format(created_at)
     end
 
-    # def bidder
-    #   Presenter::User.new(model.bidder)
-    # end
-
     def veiled_bidder_attribute(attribute, show_user = nil, message: nil)
       if presenter_auction.available? && bidder != show_user
         message

--- a/app/models/presenter/veiled_bidder.rb
+++ b/app/models/presenter/veiled_bidder.rb
@@ -1,0 +1,41 @@
+module Presenter
+  class VeiledBidder
+    include ActiveModel::SerializerSupport
+
+    def initialize(message: nil)
+      @message
+    end
+
+    def id
+      @message
+    end
+
+    def created_at
+      @message
+    end
+
+    def updated_at
+      @message
+    end
+
+    def github_id
+      @message
+    end
+
+    def duns_number
+      @message
+    end
+
+    def name
+      @message
+    end
+
+    def email
+      @message
+    end
+
+    def sam_account
+      @message
+    end
+  end
+end

--- a/app/serializers/admin/admin_report_serializer.rb
+++ b/app/serializers/admin/admin_report_serializer.rb
@@ -1,6 +1,7 @@
 module Admin
   class AdminReportSerializer < ActiveModel::Serializer
-    attributes :quick_stats, :non_admin_users,
+    attributes :quick_stats,
+               :non_admin_users,
                :admin_users
   end
 end

--- a/app/serializers/admin/auction_serializer.rb
+++ b/app/serializers/admin/auction_serializer.rb
@@ -2,10 +2,32 @@ module Admin
   class AuctionSerializer < ActiveModel::Serializer
     has_many :bids, serializer: Admin::BidSerializer
 
-    attributes :issue_url,      :start_price,
-               :start_datetime, :end_datetime,
-               :title,          :description,
-               :created_at,     :updated_at,
-               :summary,        :id
+    attributes :issue_url,
+               :github_repo,
+               :start_price,
+               :start_datetime,
+               :end_datetime,
+               :title,
+               :description,
+               :id,
+               :created_at,
+               :updated_at,
+               :summary
+
+    def created_at
+     object.created_at.iso8601
+    end
+
+    def updated_at
+     object.created_at.iso8601
+    end
+
+    def end_datetime
+      object.end_datetime.iso8601
+    end
+
+    def start_datetime
+      object.start_datetime.iso8601
+    end
   end
 end

--- a/app/serializers/admin/bid_serializer.rb
+++ b/app/serializers/admin/bid_serializer.rb
@@ -2,8 +2,19 @@ module Admin
   class BidSerializer < ActiveModel::Serializer
     has_one :bidder, class_name: 'User', serializer: Admin::UserSerializer
 
-    attributes :bidder_id,  :auction_id,
-               :amount,     :created_at,
-               :updated_at, :id
+    attributes :bidder_id,
+               :auction_id,
+               :amount,
+               :created_at,
+               :updated_at,
+               :id
+
+    def created_at
+      object.created_at.iso8601
+    end
+
+    def updated_at
+      object.created_at.iso8601
+    end
   end
 end

--- a/app/serializers/admin/user_serializer.rb
+++ b/app/serializers/admin/user_serializer.rb
@@ -1,8 +1,19 @@
 module Admin
   class UserSerializer < ActiveModel::Serializer
-    attributes :github_id,  :duns_number,
-               :name,       :created_at,
-               :updated_at, :email,
-               :sam_account
+    attributes :github_id,
+               :duns_number,
+               :name,
+               :email,
+               :sam_account,
+               :created_at,
+               :updated_at
+
+     def created_at
+       object.created_at.iso8601
+     end
+
+     def updated_at
+       object.created_at.iso8601
+     end
   end
 end

--- a/app/serializers/admin/user_serializer.rb
+++ b/app/serializers/admin/user_serializer.rb
@@ -6,7 +6,8 @@ module Admin
                :email,
                :sam_account,
                :created_at,
-               :updated_at
+               :updated_at,
+               :id
 
     def created_at
       object.created_at.iso8601 rescue nil

--- a/app/serializers/admin/user_serializer.rb
+++ b/app/serializers/admin/user_serializer.rb
@@ -8,12 +8,12 @@ module Admin
                :created_at,
                :updated_at
 
-     def created_at
-       object.created_at.iso8601
-     end
+    def created_at
+      object.created_at.iso8601 rescue nil
+    end
 
-     def updated_at
-       object.created_at.iso8601
-     end
+    def updated_at
+      object.updated_at.iso8601 rescue nil
+    end
   end
 end

--- a/app/serializers/auction_serializer.rb
+++ b/app/serializers/auction_serializer.rb
@@ -1,0 +1,31 @@
+class AuctionSerializer < ActiveModel::Serializer
+  has_many :bids, serializer: BidSerializer
+
+  attributes :issue_url,
+             :github_repo,
+             :start_price,
+             :start_datetime,
+             :end_datetime,
+             :title,
+             :description,
+             :id,
+             :created_at,
+             :updated_at,
+             :summary
+
+  def created_at
+   object.created_at.iso8601
+  end
+
+  def updated_at
+   object.created_at.iso8601
+  end
+
+  def end_datetime
+    object.end_datetime.iso8601
+  end
+
+  def start_datetime
+    object.start_datetime.iso8601
+  end
+end

--- a/app/serializers/bid_serializer.rb
+++ b/app/serializers/bid_serializer.rb
@@ -1,0 +1,26 @@
+class BidSerializer < ActiveModel::Serializer
+  has_one :bidder, class_name: 'User', serializer: UserSerializer
+
+  attributes :bidder_id,
+             :auction_id,
+             :amount,
+             :created_at,
+             :updated_at,
+             :id
+
+  def bidder_id
+    object.veiled_bidder_attribute(:id, scope)
+  end
+
+  def bidder
+    object.veiled_bidder
+  end
+
+  def created_at
+    object.created_at.iso8601
+  end
+
+  def updated_at
+    object.created_at.iso8601
+  end
+end

--- a/app/serializers/bid_serializer.rb
+++ b/app/serializers/bid_serializer.rb
@@ -13,7 +13,7 @@ class BidSerializer < ActiveModel::Serializer
   end
 
   def bidder
-    object.veiled_bidder
+    object.veiled_bidder(scope)
   end
 
   def created_at

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -5,7 +5,8 @@ class UserSerializer < ActiveModel::Serializer
              :email,
              :sam_account,
              :created_at,
-             :updated_at
+             :updated_at,
+             :id
 
   def created_at
     object.created_at.iso8601 rescue nil

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,0 +1,17 @@
+class UserSerializer < ActiveModel::Serializer
+  attributes :github_id,
+             :duns_number,
+             :name,
+             :email,
+             :sam_account,
+             :created_at,
+             :updated_at
+
+  def created_at
+    object.created_at.iso8601 rescue nil
+  end
+
+  def updated_at
+    object.updated_at.iso8601 rescue nil
+  end
+end

--- a/app/views/bids/index.html
+++ b/app/views/bids/index.html
@@ -14,8 +14,24 @@
   <tbody>
     <% @auction.bids.each_with_index do |bid, i| %>
       <tr>
-        <td><%= bid.veiled_bidder_name(current_user) %></td>
-        <td><%= bid.veiled_bidder_duns_number(current_user) %></td>
+        <td>
+          <%=
+            bid.veiled_bidder_attribute(
+              :name,
+              current_user,
+              message: '[Name withheld until the auction ends]'
+            )
+          %>
+        </td>
+        <td>
+          <%=
+            bid.veiled_bidder_attribute(
+              :duns_number,
+              current_user,
+              message: '[Withheld]'
+            )
+          %>
+        </td>
         <td><%= content_for_row(i, bid) %></td>
         <td><%= Presenter::DcTime.convert_and_format(bid.created_at) %></td>
       </tr>

--- a/spec/controllers/admin/auctions_controller.rb
+++ b/spec/controllers/admin/auctions_controller.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe Admin::AuctionsController, controller: true do
+  describe '#index' do
+    it 'assigns presented auctions' do
+      auction_record = FactoryGirl.create(:auction)
+      get :index
+      auction = assigns(:auctions).first
+      expect(auction).to be_a(Presenter::Auction)
+      expect(auction.id).to eq(auction_record.id)
+    end
+  end
+
+  describe '#show' do
+    it 'assigns presented auction' do
+      auction_record = FactoryGirl.create(:auction)
+      get :show, id: auction_record.id
+      auction = assigns(:auction)
+      expect(auction).to be_a(Presenter::Auction)
+      expect(auction.id).to eq(auction_record.id)
+    end
+  end
+end

--- a/spec/factories/auctions.rb
+++ b/spec/factories/auctions.rb
@@ -9,6 +9,10 @@ FactoryGirl.define do
     github_repo 'https://github.com/18F/calc'
 
     trait :with_bidders do
+      ignore do
+        bidder_ids []
+      end
+
       after(:build) do |instance|
         Timecop.freeze(instance.start_datetime) do
           Timecop.scale(3600)
@@ -16,6 +20,14 @@ FactoryGirl.define do
             amount = 3499 - (20 * i) - rand(10)
             instance.bids << FactoryGirl.create(:bid, auction: instance, amount: amount)
           end
+        end
+      end
+
+      after(:create) do |auction, evaluator|
+        evaluator.bidder_ids.each_with_index do |bidder_id, index|
+          lowest_bid = auction.bids.sort_by {|b| b.amount}.first
+          amount = lowest_bid.amount - (10 * index) - rand(10)
+          auction.bids << FactoryGirl.create(:bid, bidder_id: bidder_id, auction: auction, amount: amount)
         end
       end
     end

--- a/spec/models/presenter/auction_spec.rb
+++ b/spec/models/presenter/auction_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Presenter::Auction do
-  let(:auction) { Presenter::Auction.new(ar_auction) }
   let(:ar_auction) { FactoryGirl.create(:auction) }
+  let(:auction) { Presenter::Auction.new(ar_auction) }
 
   describe '#current_bid when there are no bids' do
     it 'return a null bid' do

--- a/spec/requests/admin/auctions_spec.rb
+++ b/spec/requests/admin/auctions_spec.rb
@@ -19,51 +19,45 @@ RSpec.describe Admin::AuctionsController do
     }
   end
 
-  context 'when the API key is invalid' do
-    let(:api_key) { FakeGitHub::INVALID_API_KEY }
-
+  describe 'GET /admin/auctions' do
     before do
-      get '/admin/auctions', nil, headers
+      get admin_auctions_path, nil, headers
     end
 
-    it 'returns a 404 HTTP response' do
-      expect(response.status).to eq 404
+    context 'when the API key is invalid' do
+      let(:api_key) { FakeGitHub::INVALID_API_KEY }
+
+      it 'returns a 404 HTTP response' do
+        expect(response.status).to eq 404
+      end
+    end
+
+    context 'when the API key is missing' do
+      let(:api_key) { nil }
+
+      it 'returns a 404 HTTP response' do
+        expect(response.status).to eq 404
+      end
+    end
+
+    context 'when the API key is valid' do
+      let(:api_key) { FakeGitHub::VALID_API_KEY }
+
+      it 'returns a 200 HTTP response' do
+        expect(response.status).to eq 200
+      end
+
+      it 'returns valid auctions' do
+        expect(response).to match_response_schema('admin/auctions')
+      end
+
+      it 'returns iso8601 dates' do
+        expect(json_auctions.map {|a| a['created_at']}).to all(be_iso8601)
+        expect(json_auctions.map {|a| a['updated_at']}).to all(be_iso8601)
+        expect(json_auctions.map {|a| a['start_datetime']}).to all(be_iso8601)
+        expect(json_auctions.map {|a| a['end_datetime']}).to all(be_iso8601)
+      end
     end
   end
 
-  context 'when the API key is missing' do
-    let(:api_key) { nil }
-
-    before do
-      get '/admin/auctions', nil, headers
-    end
-
-    it 'returns a 404 HTTP response' do
-      expect(response.status).to eq 404
-    end
-  end
-
-  context 'when the API key is valid' do
-    let(:api_key) { FakeGitHub::VALID_API_KEY }
-
-    before do
-      get '/admin/auctions', nil, headers
-    end
-
-    it 'returns a 200 HTTP response' do
-      expect(response.status).to eq 200
-    end
-
-    it 'returns valid auctions' do
-      expect(response).to match_response_schema('admin/auctions')
-    end
-
-    it 'returns iso8601 dates' do
-      # until I can figure out how to validate iso8601 with json-schema:
-      expect(json_auctions.first['created_at']).to eq(auctions.first.created_at.iso8601)
-      expect(json_auctions.first['updated_at']).to eq(auctions.first.updated_at.iso8601)
-      expect(json_auctions.first['start_datetime']).to eq(auctions.first.start_datetime.iso8601)
-      expect(json_auctions.first['end_datetime']).to eq(auctions.first.end_datetime.iso8601)
-    end
-  end
 end

--- a/spec/requests/admin/auctions_spec.rb
+++ b/spec/requests/admin/auctions_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe Admin::AuctionsController do
+  before do
+    stub_github('/user') do
+      github_response_for_user(admin)
+    end
+  end
+  let!(:auctions) do
+    10.times.to_a.map { FactoryGirl.create(:auction, :with_bidders) }
+  end
+  let(:admin)         { FactoryGirl.create(:admin_user, github_id: 86790) }
+  let(:json_response) { JSON.parse(response.body) }
+  let(:json_auctions) { json_response['auctions'] }
+  let(:headers) do
+    {
+      'HTTP_ACCEPT' => 'text/x-json',
+      'HTTP_API_KEY' => api_key
+    }
+  end
+
+  context 'when the API key is invalid' do
+    let(:api_key) { FakeGitHub::INVALID_API_KEY }
+
+    before do
+      get '/admin/auctions', nil, headers
+    end
+
+    it 'returns a 404 HTTP response' do
+      expect(response.status).to eq 404
+    end
+  end
+
+  context 'when the API key is missing' do
+    let(:api_key) { nil }
+
+    before do
+      get '/admin/auctions', nil, headers
+    end
+
+    it 'returns a 404 HTTP response' do
+      expect(response.status).to eq 404
+    end
+  end
+
+  context 'when the API key is valid' do
+    let(:api_key) { FakeGitHub::VALID_API_KEY }
+
+    before do
+      get '/admin/auctions', nil, headers
+    end
+
+    it 'returns a 200 HTTP response' do
+      expect(response.status).to eq 200
+    end
+
+    it 'returns valid auctions' do
+      expect(response).to match_response_schema('admin/auctions')
+    end
+
+    it 'returns iso8601 dates' do
+      # until I can figure out how to validate iso8601 with json-schema:
+      expect(json_auctions.first['created_at']).to eq(auctions.first.created_at.iso8601)
+      expect(json_auctions.first['updated_at']).to eq(auctions.first.updated_at.iso8601)
+      expect(json_auctions.first['start_datetime']).to eq(auctions.first.start_datetime.iso8601)
+      expect(json_auctions.first['end_datetime']).to eq(auctions.first.end_datetime.iso8601)
+    end
+  end
+end

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -28,50 +28,43 @@ RSpec.describe Admin::UsersController do
     }
   end
 
-  context 'when the API key is invalid' do
-    let(:api_key) { FakeGitHub::INVALID_API_KEY }
-
+  describe 'GET /admin/users' do
     before do
-      get '/admin/users', nil, headers
+      get admin_users_path, nil, headers
     end
 
-    it 'returns a 404 HTTP response' do
-      expect(response.status).to eq 404
-    end
-  end
+    context 'when the API key is invalid' do
+      let(:api_key) { FakeGitHub::INVALID_API_KEY }
 
-  context 'when the API key is missing' do
-    let(:api_key) { nil }
-
-    before do
-      get '/admin/users', nil, headers
+      it 'returns a 404 HTTP response' do
+        expect(response.status).to eq 404
+      end
     end
 
-    it 'returns a 404 HTTP response' do
-      expect(response.status).to eq 404
-    end
-  end
+    context 'when the API key is missing' do
+      let(:api_key) { nil }
 
-  context 'when the API key is valid' do
-    let(:api_key) { FakeGitHub::VALID_API_KEY }
-
-    before do
-      get '/admin/users', nil, headers
+      it 'returns a 404 HTTP response' do
+        expect(response.status).to eq 404
+      end
     end
 
-    it 'returns a 200 HTTP response' do
-      expect(response.status).to eq 200
-    end
+    context 'when the API key is valid' do
+      let(:api_key) { FakeGitHub::VALID_API_KEY }
 
-    it 'returns a valid admin report of users' do
-      expect(response).to match_response_schema('admin/users')
-    end
+      it 'returns a 200 HTTP response' do
+        expect(response.status).to eq 200
+      end
 
-    it 'returns iso8601 dates' do
-      skip 'until the bug can be solved'
-      # until I can figure out how to validate iso8601 with json-schema:
-      expect(json_non_admin_users.first['created_at']).to eq(non_admin_users.first.created_at.iso8601)
-      expect(json_non_admin_users.first['updated_at']).to eq(non_admin_users.first.updated_at.iso8601)
+      it 'returns a valid admin report of users' do
+        expect(response).to match_response_schema('admin/users')
+      end
+
+      it 'returns iso8601 dates' do
+        skip 'until the bug can be solved'
+        expect(json_non_admin_users.map {|a| a['created_at']}).to all(be_iso8601)
+        expect(json_non_admin_users.map {|a| a['updated_at']}).to all(be_iso8601)
+      end
     end
   end
 end

--- a/spec/requests/auctions_spec.rb
+++ b/spec/requests/auctions_spec.rb
@@ -19,6 +19,130 @@ RSpec.describe AuctionsController do
     }
   end
 
+  describe 'GET /auctions/:id' do
+    let(:auction)      { auctions.first }
+    let(:json_auction) { json_response['auction'] }
+
+    before do
+      get auction_path(auction), nil, headers
+    end
+
+    context 'when the API key is invalid' do
+      let(:api_key) { FakeGitHub::INVALID_API_KEY }
+
+      it 'ignores the key and returns a 200 HTTP response' do
+        expect(response.status).to eq 200
+      end
+    end
+
+    context 'when the API key is missing' do
+      let(:api_key) { nil }
+
+      it 'returns a 200 HTTP response' do
+        expect(response.status).to eq 200
+      end
+    end
+
+    context 'when the API key is valid' do
+      let(:api_key) { FakeGitHub::VALID_API_KEY }
+
+      it 'returns a 200 HTTP response' do
+        expect(response.status).to eq 200
+      end
+
+      it 'returns a valid auction' do
+        expect(response).to match_response_schema('auction')
+      end
+
+      it 'returns iso8601 dates' do
+        expect(json_auction['created_at']).to be_iso8601
+        expect(json_auction['updated_at']).to be_iso8601
+        expect(json_auction['start_datetime']).to be_iso8601
+        expect(json_auction['end_datetime']).to be_iso8601
+      end
+
+      context 'and the auction is running' do
+        let!(:auction)     { FactoryGirl.create(:auction, :running) }
+        let(:json_bids)    { json_auction['bids'] }
+
+        it 'veils all bidder information' do
+          json_bids.each do |bid|
+            expect(bid['bidder_id']).to eq(nil)
+            bidder = bid['bidder']
+            expect(bidder['id']).to          eq(nil)
+            expect(bidder['github_id']).to   eq(nil)
+            expect(bidder['created_at']).to  eq(nil)
+            expect(bidder['updated_at']).to  eq(nil)
+            expect(bidder['email']).to       eq(nil)
+            expect(bidder['sam_account']).to eq(nil)
+          end
+        end
+
+        context 'and the authenticated user is one of the bidders' do
+          let(:api_key)  { FakeGitHub::VALID_API_KEY }
+          let!(:auction) do
+            FactoryGirl.create(:auction, :running, bidder_ids: [user.id])
+          end
+
+          let(:authenticated_users_bid) do
+            json_response['auction']['bids'].find {|b| b['bidder_id'] == user.id}
+          end
+          let(:all_the_other_bids) do
+            json_response['auction']['bids'].select {|b| b['bidder_id'] != user.id}
+          end
+
+          it 'does not veil the bids from the authenticated user' do
+            expect(authenticated_users_bid['bidder_id']).to_not eq(nil)
+
+            bidder = authenticated_users_bid['bidder']
+
+            expect(bidder['id']).to_not          eq(nil)
+            expect(bidder['github_id']).to_not   eq(nil)
+            expect(bidder['created_at']).to_not  eq(nil)
+            expect(bidder['updated_at']).to_not  eq(nil)
+            expect(bidder['email']).to_not       eq(nil)
+            expect(bidder['sam_account']).to_not eq(nil)
+          end
+
+          it 'veils the bids not created by the authenticated user' do
+            all_the_other_bids.each do |bid|
+              expect(bid['bidder_id']).to eq(nil)
+
+              bidder = bid['bidder']
+
+              expect(bidder['id']).to          eq(nil)
+              expect(bidder['github_id']).to   eq(nil)
+              expect(bidder['created_at']).to  eq(nil)
+              expect(bidder['updated_at']).to  eq(nil)
+              expect(bidder['email']).to       eq(nil)
+              expect(bidder['sam_account']).to eq(nil)
+            end
+          end
+        end
+      end
+
+      context 'and the auction is closed' do
+        let!(:auctions) do
+          [FactoryGirl.create(:auction, :closed)]
+        end
+        let(:json_bids) { json_auction['bids'] }
+
+        it 'unveils all bidder information' do
+          json_bids.each do |bid|
+            expect(bid['bidder_id']).to_not eq(nil)
+            bidder = bid['bidder']
+            expect(bidder['id']).to_not          eq(nil)
+            expect(bidder['github_id']).to_not   eq(nil)
+            expect(bidder['created_at']).to_not  eq(nil)
+            expect(bidder['updated_at']).to_not  eq(nil)
+            expect(bidder['email']).to_not       eq(nil)
+            expect(bidder['sam_account']).to_not eq(nil)
+          end
+        end
+      end
+    end
+  end
+
   describe 'GET /auctions' do
     before do
       get auctions_path, nil, headers

--- a/spec/requests/auctions_spec.rb
+++ b/spec/requests/auctions_spec.rb
@@ -1,0 +1,102 @@
+require 'rails_helper'
+
+RSpec.describe AuctionsController do
+  before do
+    stub_github('/user') do
+      github_response_for_user(user)
+    end
+  end
+  let!(:auctions) do
+    10.times.to_a.map { FactoryGirl.create(:auction, :with_bidders) }
+  end
+  let(:user)          { FactoryGirl.create(:user, github_id: 86790) }
+  let(:json_response) { JSON.parse(response.body) }
+  let(:json_auctions) { json_response['auctions'] }
+  let(:headers) do
+    {
+      'HTTP_ACCEPT' => 'text/x-json',
+      'HTTP_API_KEY' => api_key
+    }
+  end
+
+  describe 'GET /auctions' do
+    before do
+      get auctions_path, nil, headers
+    end
+
+    context 'when the API key is invalid' do
+      let(:api_key) { FakeGitHub::INVALID_API_KEY }
+
+      it 'ignores the key and returns a 200 HTTP response' do
+        expect(response.status).to eq 200
+      end
+    end
+
+    context 'when the API key is missing' do
+      let(:api_key) { nil }
+
+      it 'returns a 200 HTTP response' do
+        expect(response.status).to eq 200
+      end
+    end
+
+    context 'when the API key is valid' do
+      let(:api_key) { FakeGitHub::VALID_API_KEY }
+
+      it 'returns a 200 HTTP response' do
+        expect(response.status).to eq 200
+      end
+
+      it 'returns valid auctions' do
+        expect(response).to match_response_schema('auctions')
+      end
+
+      it 'returns iso8601 dates' do
+        expect(json_auctions.map {|a| a['created_at']}).to all(be_iso8601)
+        expect(json_auctions.map {|a| a['updated_at']}).to all(be_iso8601)
+        expect(json_auctions.map {|a| a['start_datetime']}).to all(be_iso8601)
+        expect(json_auctions.map {|a| a['end_datetime']}).to all(be_iso8601)
+      end
+
+      context 'and the auction is running' do
+        let!(:auctions) do
+          [FactoryGirl.create(:auction, :running)]
+        end
+        let(:json_bids) { json_auctions.first['bids'] }
+
+        it 'veils all bidder information' do
+          json_bids.each do |bid|
+            expect(bid['bidder_id']).to eq(nil)
+            bidder = bid['bidder']
+            expect(bidder['id']).to          eq(nil)
+            expect(bidder['github_id']).to   eq(nil)
+            expect(bidder['created_at']).to  eq(nil)
+            expect(bidder['updated_at']).to  eq(nil)
+            expect(bidder['email']).to       eq(nil)
+            expect(bidder['sam_account']).to eq(nil)
+          end
+        end
+
+        context 'and the auction is closed' do
+          let!(:auctions) do
+            [FactoryGirl.create(:auction, :closed)]
+          end
+          let(:json_bids) { json_auctions.first['bids'] }
+
+          it 'unveils all bidder information' do
+            json_bids.each do |bid|
+              expect(bid['bidder_id']).to_not eq(nil)
+              bidder = bid['bidder']
+              expect(bidder['id']).to_not          eq(nil)
+              expect(bidder['github_id']).to_not   eq(nil)
+              expect(bidder['created_at']).to_not  eq(nil)
+              expect(bidder['updated_at']).to_not  eq(nil)
+              expect(bidder['email']).to_not       eq(nil)
+              expect(bidder['sam_account']).to_not eq(nil)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/bids_spec.rb
+++ b/spec/requests/bids_spec.rb
@@ -1,0 +1,191 @@
+require 'rails_helper'
+
+RSpec.describe AuctionsController do
+  before do
+    stub_github('/user') do
+      github_response_for_user(user)
+    end
+  end
+  let(:user) { FactoryGirl.create(:user, :with_duns_in_sam) }
+  let(:headers) do
+    {
+      'HTTP_ACCEPT' => 'text/x-json',
+      'HTTP_API_KEY' => api_key
+    }
+  end
+  let(:json_response) { JSON.parse(response.body) }
+  let(:params) do
+    {
+      bid: {
+        amount: bid_amount
+      }
+    }
+  end
+  let(:status) { response.status }
+
+
+  describe 'POST /auctions/:auction_id/bids' do
+    before do
+      post auction_bids_path(auction), params, headers
+    end
+    let(:json_bid) { json_response['bid'] }
+
+    context 'when the API key is missing' do
+      let(:api_key) { nil }
+      let(:auction) { FactoryGirl.create(:auction, :running) }
+      let(:current_auction_price) do
+         auction.bids.sort_by {|b| b.amount}.first.amount
+      end
+      let(:bid_amount) { current_auction_price - 10 }
+
+      it 'returns a json error' do
+        expect(json_response['error']).to eq('User not found')
+      end
+
+      it 'returns a 404 status code' do
+        expect(status).to eq(404)
+      end
+    end
+
+    context 'when the API key is invalid' do
+      let(:api_key) { FakeGitHub::INVALID_API_KEY }
+      let(:auction) { FactoryGirl.create(:auction, :running) }
+      let(:current_auction_price) do
+         auction.bids.sort_by {|b| b.amount}.first.amount
+      end
+      let(:bid_amount) { current_auction_price - 10 }
+
+      it 'returns a json error' do
+        expect(json_response['error']).to eq('User not found')
+      end
+
+      it 'returns a 404 status code' do
+        expect(status).to eq(404)
+      end
+    end
+
+    context 'when the auction has ended' do
+      let(:api_key) { FakeGitHub::VALID_API_KEY }
+      let(:auction) { FactoryGirl.create(:auction, :closed, :with_bidders) }
+      let(:current_auction_price) do
+         auction.bids.sort_by {|b| b.amount}.first.amount
+      end
+      let(:bid_amount) { current_auction_price - 10 }
+
+      it 'returns a json error' do
+        expect(json_response['error']).to eq('Auction not available')
+      end
+
+      it 'returns a 403 status code' do
+        expect(status).to eq(403)
+      end
+    end
+
+    context 'when the auction has not yet started' do
+      let(:api_key) { FakeGitHub::VALID_API_KEY }
+      let(:auction) { FactoryGirl.create(:auction, :future, :with_bidders) }
+      let(:current_auction_price) do
+         auction.bids.sort_by {|b| b.amount}.first.amount
+      end
+      let(:bid_amount) { current_auction_price - 10 }
+
+      it 'returns a json error' do
+        expect(json_response['error']).to eq('Auction not available')
+      end
+
+      it 'returns a 403 status code' do
+        expect(status).to eq(403)
+      end
+    end
+
+    context 'when the auction is running' do
+      let(:api_key) { FakeGitHub::VALID_API_KEY }
+      let(:auction) { FactoryGirl.create(:auction, :running) }
+      let(:current_auction_price) do
+         auction.bids.sort_by {|b| b.amount}.first.amount
+      end
+
+      context 'and the bid amount is the lowest' do
+        let(:bid_amount) { current_auction_price - 10 }
+
+        it 'creates a new bid' do
+          expect(json_bid['amount']).to eq(bid_amount)
+          expect(json_bid['bidder_id']).to eq(user.id)
+        end
+
+        it 'returns a 200 status code' do
+          expect(status).to eq(200)
+        end
+      end
+
+      context 'and the bid amount is not the lowest' do
+        let(:bid_amount) { current_auction_price + 10 }
+
+        it 'returns a json error' do
+          expect(json_response['error']).to eq('Bids cannot be greater than the current max bid')
+        end
+
+        it 'returns a 403 status code' do
+          expect(status).to eq(403)
+        end
+      end
+
+      context 'and the user has a false #sam_account' do
+        let(:user) { FactoryGirl.create(:user, :with_duns_not_in_sam, sam_account: false) }
+        let(:bid_amount) { current_auction_price - 10 }
+
+        it 'returns a json error' do
+          expect(json_response['error']).to eq('You must have a valid SAM.gov account to place a bid')
+        end
+
+        it 'returns a 403 status code' do
+          expect(status).to eq(403)
+        end
+      end
+
+      context 'and the bid amount is a float' do
+        let(:bid_amount) { (current_auction_price - 10).to_f }
+
+        it 'ignores the floatiness' do
+          expect(json_bid['amount']).to eq(bid_amount)
+        end
+      end
+
+      context 'and the bid amount is letters' do
+        let(:bid_amount) { 'clearly not a valid bid' }
+
+        it 'returns a json error' do
+          expect(json_response['error']).to eq('Bid amount out of range')
+        end
+
+        it 'returns a 403 status code' do
+          expect(status).to eq(403)
+        end
+      end
+
+      context 'and the bid amount is a negative number' do
+        let(:bid_amount) { -1000 }
+
+        it 'returns a json error' do
+          expect(json_response['error']).to eq('Bid amount out of range')
+        end
+
+        it 'returns a 403 status code' do
+          expect(status).to eq(403)
+        end
+      end
+
+      context 'and the bid amount contains cents' do
+        let(:bid_amount) { 1.99 }
+
+        it 'returns a json error' do
+          expect(json_response['error']).to eq('Bids must be in increments of one dollar')
+        end
+
+        it 'returns a 403 status code' do
+          expect(status).to eq(403)
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -91,4 +91,9 @@ RSpec.configure do |config|
   # test failures related to randomization by passing the same `--seed` value
   # as the one that triggered the failure.
   # Kernel.srand config.seed
+
+  # see https://docs.travis-ci.com/user/code-climate/#Common-Problems
+  config.after(:suite) do
+    WebMock.disable_net_connect!(:allow => 'codeclimate.com')
+  end
 end

--- a/spec/support/api/schemas/admin/auctions.json
+++ b/spec/support/api/schemas/admin/auctions.json
@@ -1,0 +1,152 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "",
+  "type": "object",
+  "properties": {
+    "auctions": {
+      "type": "array",
+      "uniqueItems": true,
+      "minItems": 1,
+      "items": {
+        "required": [
+          "issue_url",
+          "github_repo",
+          "start_price",
+          "start_datetime",
+          "end_datetime",
+          "title",
+          "description",
+          "created_at",
+          "updated_at",
+          "summary",
+          "id"
+        ],
+        "properties": {
+          "issue_url": {
+            "type": "string",
+            "minLength": 1
+          },
+          "github_repo": {
+            "type": "string",
+            "minLength": 1
+          },
+          "start_price": {
+            "type": "number"
+          },
+          "start_datetime": {
+            "type": "date-time",
+            "minLength": 1
+          },
+          "end_datetime": {
+            "type": "date-time",
+            "minLength": 1
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1
+          },
+          "created_at": {
+            "type": "date-time",
+            "minLength": 1
+          },
+          "updated_at": {
+            "type": "date-time",
+            "minLength": 1
+          },
+          "summary": {
+            "type": "string",
+            "minLength": 1
+          },
+          "id": {
+            "type": "number"
+          },
+          "bids": {
+            "type": "array",
+            "uniqueItems": true,
+            "minItems": 1,
+            "items": {
+              "required": [
+                "bidder_id",
+                "auction_id",
+                "amount",
+                "created_at",
+                "updated_at",
+                "id"
+              ],
+              "properties": {
+                "bidder_id": {
+                  "type": "number"
+                },
+                "auction_id": {
+                  "type": "number"
+                },
+                "amount": {
+                  "type": "number"
+                },
+                "created_at": {
+                  "type": "date-time",
+                  "minLength": 1
+                },
+                "updated_at": {
+                  "type": "date-time",
+                  "minLength": 1
+                },
+                "id": {
+                  "type": "number"
+                },
+                "bidder": {
+                  "type": "object",
+                  "properties": {
+                    "github_id": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "duns_number": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "name": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "created_at": {
+                      "type": "date-time",
+                      "minLength": 1
+                    },
+                    "updated_at": {
+                      "type": "date-time",
+                      "minLength": 1
+                    },
+                    "email": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "sam_account": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "github_id",
+                    "duns_number",
+                    "name",
+                    "created_at",
+                    "updated_at",
+                    "email",
+                    "sam_account"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "required": [
+    "auctions"
+  ]
+}

--- a/spec/support/api/schemas/admin/auctions.json
+++ b/spec/support/api/schemas/admin/auctions.json
@@ -101,6 +101,9 @@
                 "bidder": {
                   "type": "object",
                   "properties": {
+                    "id": {
+                      "type": ["number", "null"]
+                    },
                     "github_id": {
                       "type": "string",
                       "minLength": 1
@@ -136,7 +139,8 @@
                     "created_at",
                     "updated_at",
                     "email",
-                    "sam_account"
+                    "sam_account",
+                    "id"
                   ]
                 }
               }

--- a/spec/support/api/schemas/admin/users.json
+++ b/spec/support/api/schemas/admin/users.json
@@ -1,0 +1,141 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "",
+  "type": "object",
+  "properties": {
+    "admin_report": {
+      "type": "object",
+      "properties": {
+        "quick_stats": {
+          "type": "object",
+          "properties": {
+            "total_users": {
+              "type": "number"
+            },
+            "users_with_duns": {
+              "type": "number"
+            },
+            "users_in_sam": {
+              "type": "number"
+            },
+            "notes": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "required": [
+            "total_users",
+            "users_with_duns",
+            "users_in_sam",
+            "notes"
+          ]
+        },
+        "non_admin_users": {
+          "type": "array",
+          "uniqueItems": true,
+          "minItems": 1,
+          "items": {
+            "required": [
+              "id",
+              "github_id",
+              "duns_number",
+              "name",
+              "created_at",
+              "updated_at",
+              "email",
+              "sam_account"
+            ],
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "github_id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "duns_number": {
+                "type": "string",
+                "minLength": 1
+              },
+              "name": {
+                "type": "string",
+                "minLength": 1
+              },
+              "created_at": {
+                "type": "date-time",
+                "minLength": 1
+              },
+              "updated_at": {
+                "type": "date-time",
+                "minLength": 1
+              },
+              "email": {
+                "type": "string",
+                "minLength": 1
+              },
+              "sam_account": {
+                "type": "boolean"
+              }
+            }
+          }
+        },
+        "admin_users": {
+          "type": "array",
+          "uniqueItems": true,
+          "minItems": 1,
+          "items": {
+            "required": [
+              "id",
+              "github_id",
+              "duns_number",
+              "name",
+              "created_at",
+              "updated_at",
+              "email",
+              "sam_account"
+            ],
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "github_id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "duns_number": {
+                "type": "string",
+                "minLength": 1
+              },
+              "name": {
+                "type": "string",
+                "minLength": 1
+              },
+              "created_at": {
+                "type": "date-time",
+                "minLength": 1
+              },
+              "updated_at": {
+                "type": "date-time",
+                "minLength": 1
+              },
+              "email": {
+                "type": "string"
+              },
+              "sam_account": {
+                "type": "boolean"
+              }
+            }
+          }
+        }
+      },
+      "required": [
+        "quick_stats",
+        "non_admin_users",
+        "admin_users"
+      ]
+    }
+  },
+  "required": [
+    "admin_report"
+  ]
+}

--- a/spec/support/api/schemas/auction.json
+++ b/spec/support/api/schemas/auction.json
@@ -1,0 +1,153 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "",
+  "type": "object",
+  "properties": {
+    "auction": {
+      "type": "object",
+      "properties": {
+        "issue_url": {
+          "type": "string",
+          "minLength": 1
+        },
+        "github_repo": {
+          "type": "string",
+          "minLength": 1
+        },
+        "start_price": {
+          "type": "number"
+        },
+        "start_datetime": {
+          "type": "string",
+          "minLength": 1
+        },
+        "end_datetime": {
+          "type": "string",
+          "minLength": 1
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "id": {
+          "type": "number"
+        },
+        "created_at": {
+          "type": "string",
+          "minLength": 1
+        },
+        "updated_at": {
+          "type": "string",
+          "minLength": 1
+        },
+        "summary": {
+          "type": "string",
+          "minLength": 1
+        },
+        "bids": {
+          "type": "array",
+          "uniqueItems": true,
+          "minItems": 1,
+          "items": {
+            "required": [
+              "bidder_id",
+              "auction_id",
+              "amount",
+              "created_at",
+              "updated_at",
+              "id"
+            ],
+            "properties": {
+              "bidder_id": {
+                "type": ["number", "null"]
+              },
+              "auction_id": {
+                "type": "number"
+              },
+              "amount": {
+                "type": "number"
+              },
+              "created_at": {
+                "type": "string",
+                "minLength": 1
+              },
+              "updated_at": {
+                "type": "string",
+                "minLength": 1
+              },
+              "id": {
+                "type": "number"
+              },
+              "bidder": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": ["number", "null"]
+                  },
+                  "github_id": {
+                    "type": ["string", "null"],
+                    "minLength": 1
+                  },
+                  "duns_number": {
+                    "type": ["string", "null"],
+                    "minLength": 1
+                  },
+                  "name": {
+                    "type": ["string", "null"],
+                    "minLength": 1
+                  },
+                  "email": {
+                    "type": ["string", "null"],
+                    "minLength": 1
+                  },
+                  "sam_account": {
+                    "type": ["boolean", "null"]
+                  },
+                  "created_at": {
+                    "type": ["string", "null"],
+                    "minLength": 1
+                  },
+                  "updated_at": {
+                    "type": ["string", "null"],
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "github_id",
+                  "duns_number",
+                  "name",
+                  "email",
+                  "sam_account",
+                  "created_at",
+                  "updated_at",
+                  "id"
+                ]
+              }
+            }
+          }
+        }
+      },
+      "required": [
+        "issue_url",
+        "github_repo",
+        "start_price",
+        "start_datetime",
+        "end_datetime",
+        "title",
+        "description",
+        "id",
+        "created_at",
+        "updated_at",
+        "summary",
+        "bids"
+      ]
+    }
+  },
+  "required": [
+    "auction"
+  ]
+}

--- a/spec/support/api/schemas/auctions.json
+++ b/spec/support/api/schemas/auctions.json
@@ -1,0 +1,151 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "",
+  "type": "object",
+  "properties": {
+    "auctions": {
+      "type": "array",
+      "uniqueItems": true,
+      "minItems": 1,
+      "items": {
+        "required": [
+          "issue_url",
+          "github_repo",
+          "start_price",
+          "start_datetime",
+          "end_datetime",
+          "title",
+          "description",
+          "id",
+          "created_at",
+          "updated_at",
+          "summary"
+        ],
+        "properties": {
+          "issue_url": {
+            "type": "string",
+            "minLength": 1
+          },
+          "github_repo": {
+            "type": "string",
+            "minLength": 1
+          },
+          "start_price": {
+            "type": "number"
+          },
+          "start_datetime": {
+            "type": "date-time",
+            "minLength": 1
+          },
+          "end_datetime": {
+            "type": "date-time",
+            "minLength": 1
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1
+          },
+          "id": {
+            "type": "number"
+          },
+          "created_at": {
+            "type": "date-time",
+            "minLength": 1
+          },
+          "updated_at": {
+            "type": "date-time",
+            "minLength": 1
+          },
+          "summary": {
+            "type": "string",
+            "minLength": 1
+          },
+          "bids": {
+            "type": "array",
+            "uniqueItems": true,
+            "minItems": 1,
+            "items": {
+              "required": [
+                "bidder_id",
+                "auction_id",
+                "amount",
+                "created_at",
+                "updated_at",
+                "id"
+              ],
+              "properties": {
+                "bidder_id": {
+                  "type": ["number", "null"]
+                },
+                "auction_id": {
+                  "type": "number"
+                },
+                "amount": {
+                  "type": "number"
+                },
+                "created_at": {
+                  "type": "date-time",
+                  "minLength": 1
+                },
+                "updated_at": {
+                  "type": "date-time",
+                  "minLength": 1
+                },
+                "id": {
+                  "type": "number"
+                },
+                "bidder": {
+                  "type": "object",
+                  "properties": {
+                    "github_id": {
+                      "type": ["string", "null"],
+                      "minLength": 1
+                    },
+                    "duns_number": {
+                      "type": ["string", "null"],
+                      "minLength": 1
+                    },
+                    "name": {
+                      "type": ["string", "null"],
+                      "minLength": 1
+                    },
+                    "email": {
+                      "type": ["string", "null"]
+                    },
+                    "sam_account": {
+                      "type": ["boolean", "null"]
+                    },
+                    "created_at": {
+                      "type": ["date-time", "null"],
+                      "minLength": 1
+                    },
+                    "updated_at": {
+                      "type": ["date-time", "null"],
+                      "minLength": 1
+                    }
+                  },
+                  "required": [
+                    "github_id",
+                    "duns_number",
+                    "name",
+                    "email",
+                    "sam_account",
+                    "created_at",
+                    "updated_at"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "required": [
+    "auctions"
+  ]
+}

--- a/spec/support/api/schemas/auctions.json
+++ b/spec/support/api/schemas/auctions.json
@@ -101,6 +101,9 @@
                 "bidder": {
                   "type": "object",
                   "properties": {
+                    "id": {
+                      "type": ["number", "null"]
+                    },
                     "github_id": {
                       "type": ["string", "null"],
                       "minLength": 1
@@ -135,7 +138,8 @@
                     "email",
                     "sam_account",
                     "created_at",
-                    "updated_at"
+                    "updated_at",
+                    "id"
                   ]
                 }
               }

--- a/spec/support/api_schema_matcher.rb
+++ b/spec/support/api_schema_matcher.rb
@@ -1,0 +1,7 @@
+RSpec::Matchers.define :match_response_schema do |schema|
+  match do |response|
+    schema_directory = "#{Dir.pwd}/spec/support/api/schemas"
+    schema_path = "#{schema_directory}/#{schema}.json"
+    JSON::Validator.validate!(schema_path, response.body, strict: true)
+  end
+end

--- a/spec/support/iso8601_matcher.rb
+++ b/spec/support/iso8601_matcher.rb
@@ -1,0 +1,12 @@
+RSpec::Matchers.define :be_iso8601 do |expected|
+  def to_iso8601(string)
+    DateTime.parse(string).iso8601
+  end
+
+  match do |actual|
+    actual == to_iso8601(actual) #DateTime.parse(actual).iso8601
+  end
+  failure_message do |actual|
+    "expected that #{actual} would be a valid iso8601 date (#{to_iso8601(actual)})"
+  end
+end

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -1,0 +1,89 @@
+module FakeGitHub
+  INVALID_API_KEY = "invalidKey5678ijklmnop"
+  VALID_API_KEY = "validKeyAbcdfgh123"
+end
+
+def github_request_headers
+  {
+    'Accept'          => 'application/vnd.github.v3+json',
+    'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+    'Content-Type'    => 'application/json',
+    'User-Agent'      => 'Octokit Ruby Gem 4.2.0'
+  }
+end
+
+def handle_request(request, response_body: nil)
+  response_headers = {'Content-Type' => 'application/json'}
+  bad_credentials  = "{\"message\":\"Bad Credentials\"}"
+  token            = request.headers['Authorization'].split[1] rescue nil
+
+  if token != FakeGitHub::VALID_API_KEY
+    response_body = bad_credentials
+    response_status = 401
+  end
+
+  {status: response_status, body: response_body, headers: response_headers}
+end
+
+def stub_github(path, response_status: 200, &block)
+  url                          = "https://api.github.com#{path}"
+  request_headers_without_auth = github_request_headers
+  request_headers_with_auth    = github_request_headers.merge({'Authorization' => /token ()/})
+  default_response_body        = JSON.generate(block.call)
+
+  # stub requests where no Authorization header is set
+  WebMock.stub_request(:get, url)
+    .with(headers: request_headers_without_auth)
+    .to_return {|request| handle_request(request, response_body: default_response_body)}
+
+  # stub requests that include an Authorization header
+  WebMock.stub_request(:get, url)
+    .with(headers: request_headers_with_auth)
+    .to_return {|request| handle_request(request, response_body: default_response_body)}
+end
+
+def github_response_for_user(user)
+  {
+    "login": Faker::Internet.user_name,
+    "id": user.github_id,
+    "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/octocat",
+    "html_url": "https://github.com/octocat",
+    "followers_url": "https://api.github.com/users/octocat/followers",
+    "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+    "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+    "organizations_url": "https://api.github.com/users/octocat/orgs",
+    "repos_url": "https://api.github.com/users/octocat/repos",
+    "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/octocat/received_events",
+    "type": "User",
+    "site_admin": false,
+    "name": "monalisa octocat",
+    "company": "GitHub",
+    "blog": "https://github.com/blog",
+    "location": "San Francisco",
+    "email": "octocat@github.com",
+    "hireable": false,
+    "bio": "There once was...",
+    "public_repos": 2,
+    "public_gists": 1,
+    "followers": 20,
+    "following": 0,
+    "created_at": "2008-01-14T04:33:35Z",
+    "updated_at": "2008-01-14T04:33:35Z",
+    "total_private_repos": 100,
+    "owned_private_repos": 100,
+    "private_gists": 81,
+    "disk_usage": 10000,
+    "collaborators": 8,
+    "plan": {
+      "name": "Medium",
+      "space": 400,
+      "private_repos": 20,
+      "collaborators": 0
+    }
+  }
+end


### PR DESCRIPTION
This PR is pretty big and is the culmination of some smaller PRs.

- creates a robust requests spec suite for the API
- allows controllers to be completely agnostic of request type (API or web UI is all the same)
- ensures that bidder info is properly veiled/redacted for running auctions
- adds the following routes:

GET `/admin/auctions`
GET `/admin/users`
GET `/auctions`
GET `/auctions/:id`
POST `/auctions/:id/bids` (yes, you can now bid via API).
