### PR TITLE
Refactor: Skinnier User Junks

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -13,26 +13,13 @@ class UsersController < ApplicationController
   def update
     require_authentication and return
 
-    @user = User.find(params[:id])
-    fail UnauthorizedError if current_user != @user
-    @user.update(user_params)
-
-    if @user.save
+    updater = UpdateUser.new(params, current_user)
+    if updater.save
       redirect_to root_path
     else
-      flash[:error] = @user.errors.full_messages.to_sentence
+      @user = updater.user
+      flash[:error] = updater.errors
       render :edit
     end
-  end
-
-  private
-
-  def redirect_back_or_default
-    redirect_to(session[:return_to] || root_path)
-    session[:return_to] = nil
-  end
-
-  def user_params
-    params.require(:user).permit(:duns_number, :email)
   end
 end

--- a/app/models/sam_account_reckoner.rb
+++ b/app/models/sam_account_reckoner.rb
@@ -1,0 +1,20 @@
+class SamAccountReckoner < Struct.new(:user)
+  def clear
+    user.sam_account = false if should_clear?
+  end
+
+  def set
+    return true if user.sam_account?
+    user.sam_account = client.duns_is_in_sam?(duns: user.duns_number)
+  end
+
+  private
+
+  def should_clear?
+    user.persisted? && user.duns_number_changed?
+  end
+
+  def client
+    @client ||= Samwise::Client.new
+  end
+end

--- a/app/models/update_user.rb
+++ b/app/models/update_user.rb
@@ -1,0 +1,33 @@
+class UpdateUser < Struct.new(:params, :current_user)
+  attr_reader :status
+
+  def save
+    fail UnauthorizedError if !allowed_to_edit?
+
+    update_user
+  end
+
+  def errors
+    user.errors.full_messages.to_sentence
+  end
+
+  def user
+    @user ||= User.find(params[:id])
+  end
+
+  private
+
+  def update_user
+    user.assign_attributes(user_params)
+    SamAccountReckoner.new(user).clear
+    @status = user.save
+  end
+
+  def allowed_to_edit?
+    current_user == user
+  end
+
+  def user_params
+    params.require(:user).permit(:duns_number, :email)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,32 +1,5 @@
 class User < ActiveRecord::Base
   has_many :bids
   validates :email, email: true, allow_blank: true
-  before_save :clear_sam_status_if_duns_changed
-
-  scope :not_in_sam, -> { where(sam_account: false) }
   scope :blank_name, -> { where(name: [nil, '']) }
-
-  def save_sam_status
-    return if sam_account?
-    self.sam_account = registered_on_sam?
-    save!
-
-    sam_account
-  end
-
-  private
-
-  def clear_sam_status_if_duns_changed
-    self.sam_account = false if persisted? && duns_number_changed?
-    true
-  end
-
-  def registered_on_sam?
-    self.class.registered_on_sam?(duns: duns_number)
-  end
-
-  def self.registered_on_sam?(duns: nil)
-    client = Samwise::Client.new
-    client.duns_is_in_sam?(duns: duns)
-  end
 end

--- a/lib/tasks/sam.rake
+++ b/lib/tasks/sam.rake
@@ -1,9 +1,9 @@
 namespace :sam do
   task check: :environment do
-    User.not_in_sam.each do |user|
+    User.where(sam_account: false).each do |user|
       id = "#{user.name}/#{user.duns_number}: "
       begin
-        sam_status = user.save_sam_status
+        sam_status = SamAccountReckoner.new(user).set
         if sam_status == true
           id += 'DUNS *is* in SAM.gov'
         else

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -29,26 +29,19 @@ RSpec.describe UsersController, type: :controller do
       expect(response.location).to eq('http://test.host/login')
     end
 
-    it 'raises a ActiveRecord::RecordNotFound when user is not found' do
-      user_id = user.id + 1000
-      expect { put :update, {id: user_id, user: {duns_number: '222'}}, user_id: user.id }.
-        to raise_error(ActiveRecord::RecordNotFound)
+    it 'uses the UpdateUser class to update the user' do
+      expect_any_instance_of(UpdateUser).to receive(:save).and_return(false)
+      put :update, {id: user.id, user: {duns_number: '222'}}, user_id: user.id
     end
 
-    it 'handles as unauthorized when user is not in session' do
-      put :update, {id: user.id, user: {duns_number: '222'}}, user_id: FactoryGirl.create(:user).id
-      expect(response).to redirect_to('/')
-      expect(flash[:error]).to match(/unauthorized/i)
-    end
-
-    it 'update the user when current user is the user' do
-      new_name = Faker::Name.name
-      put :update, {id: user.id, user: {name: new_name, duns_number: '222'}}, user_id: user.id
-      user.reload
-      expect(user.duns_number).to eq('222')
+    it 'rerenders edit when the update fails' do
+      expect_any_instance_of(UpdateUser).to receive(:save).and_return(false)
+      put :update, {id: user.id, user: {duns_number: '222'}}, user_id: user.id
+      expect(response).to render_template(:edit)
     end
 
     it 'redirects back home after successful edit' do
+      expect_any_instance_of(UpdateUser).to receive(:save).and_return(true)
       put :update, {id: user.id, user: {duns_number: '222'}}, user_id: user.id
       expect(response).to be_redirect
       expect(response.location).to eq('http://test.host/')

--- a/spec/models/sam_account_reckoner_spec.rb
+++ b/spec/models/sam_account_reckoner_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+RSpec.describe SamAccountReckoner do
+  let(:reckoner) { SamAccountReckoner.new(user) }
+  let(:client) { double('samwise client', duns_is_in_sam?: in_sam?) }
+  let(:in_sam?) { false }
+
+  before do
+    allow(Samwise::Client).to receive(:new).and_return(client)
+  end
+
+  describe '#set' do
+    context 'when user has a valid duns number' do
+      let(:user) { User.new(duns_number: 'i-am-here-yo') }
+      let(:in_sam?) { true }
+
+      it 'use the client to find determine if there is a sams account' do
+        expect(client).to receive(:duns_is_in_sam?).with(duns: user.duns_number).and_return(in_sam?)
+        reckoner.set
+        expect(user.sam_account).to eq(true)
+      end
+    end
+
+    context 'when sam_account is already set to true' do
+      let(:user) { User.new(sam_account: true) }
+
+      it 'does not check for an account via the client' do
+        expect(client).not_to receive(:duns_is_in_sam?)
+        reckoner.set
+      end
+    end
+
+    context 'when the duns number is not present in sam' do
+      let(:user) { User.new(duns_number: 'scamming') }
+
+      it 'use the client to find determine if there is a sams account' do
+        expect(client).to receive(:duns_is_in_sam?).with(duns: user.duns_number).and_return(in_sam?)
+        reckoner.set
+        expect(user.sam_account).to eq(false)
+      end
+    end
+  end
+
+  describe '#clear' do
+    let(:user) { User.create(sam_account: true, duns_number: 'foo') }
+
+    context 'when the user is not persisted' do
+      it 'does not change the sam account' do
+        reckoner.clear
+        expect(user.sam_account).to eq(true)
+      end
+    end
+
+    context 'when the duns number has not changed' do
+      before do
+        user.save
+      end
+
+      it 'does not change the sam account' do
+        reckoner.clear
+        expect(user.sam_account).to eq(true)
+      end
+    end
+
+    context 'when the duns number has changed' do
+      before do
+        user.save
+        user.duns_number = 'bar'
+      end
+
+      it 'clears the sam account validation' do
+        reckoner.clear
+        expect(user.sam_account).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/models/update_user_spec.rb
+++ b/spec/models/update_user_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.describe UpdateUser do
+  let(:updater) { UpdateUser.new(params, current_user) }
+  let(:current_user) { User.create(duns_number: '12341', sam_account: true) }
+
+  let(:params) {
+    ActionController::Parameters.new({
+      id: user_id,
+      user: {
+        duns_number: 'new-new'
+      }
+    })
+  }
+
+  context 'when current user is not the same as the user being edited' do
+    let(:user) { User.create }
+    let(:user_id) { user.id }
+
+    it 'raises UnauthorizedError' do
+      expect { updater.save }.to raise_error(UnauthorizedError)
+    end
+  end
+
+  context 'when the user being edited does not exist' do
+    let(:user_id) { current_user.id + 1000 }
+
+    it 'raises a ActiveRecord::RecordNotFound when user is not found' do
+      expect { updater.save }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
+  context 'when the params are insufficient' do
+    let(:user_id) { current_user.id }
+    let(:params) {
+      ActionController::Parameters.new({
+        id: user_id
+      })
+    }
+
+    it 'raises some param related error' do
+      expect { updater.save }.to raise_error(ActionController::ParameterMissing)
+    end
+  end
+
+  context 'when user is found and can be edited by current user' do
+    let(:user_id) { user.id }
+    let(:user) { current_user }
+
+    it 'update the user when current user is the user' do
+      updater.save
+      user.reload
+      expect(user.duns_number).to eq('new-new')
+    end
+
+    it 'clears the sam id, when it has changed' do
+      updater.save
+      user.reload
+      expect(user.sam_account).to eq(false)
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,32 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe User do
-  describe 'sam_account?' do
-    it 'should be set to false if the DUNS number is changed' do
-      u = FactoryGirl.create(:user)
-      expect(u).to be_sam_account
-
-      u.duns_number = Faker::Company.duns_number
-      u.save!
-
-      expect(u).to_not be_sam_account
-    end
-  end
-
   describe 'named scopes' do
-    describe 'not_in_sam' do
-      it 'should return users where sam_account is false' do
-        u = FactoryGirl.create(:user, sam_account: false)
-        expect(User.not_in_sam).to include(u)
-      end
-
-      it 'should not return users where sam_account is true' do
-        u = FactoryGirl.create(:user, sam_account: true)
-        expect(User.not_in_sam).to_not include(u)
-      end
-    end
-
-    describe 'blank_name' do
+    describe '.blank_name' do
       it 'should return NULL names' do
         u = FactoryGirl.create(:user)
         u.update_attribute(:name, nil)


### PR DESCRIPTION
        * Extracts sam account related checks and user modifications to
          own class: SamAccountReckoner (?rename?)
        * Removes scope from User and moves logic into sam related rake
          task.
        * Removes save related hook from User and moves it to the
          controller update action for users. This is the only place it
          is needed.
        * Extracts update related logic from UserController and into
          UpdateUser class. Moves tests to less expensive place in
          models, stubs updater in controller tests. Also, removes
          unused redirect related private method.

@harrisj You were asking about this area and what to do in slack. Had a couple extra hours yesterday ... Tell me what you think. Also thinking still about your auction types, and it seems like there isn't enough product detail to build the right abstraction, but I am pretty in the dark about it.

@adelevie your review too please

In the air today, so do whatever you want with it!