### PR TITLE
Add a scope method to SamAccountReckoner

### DIFF
--- a/app/models/sam_account_reckoner.rb
+++ b/app/models/sam_account_reckoner.rb
@@ -3,15 +3,23 @@ class SamAccountReckoner < Struct.new(:user)
     user.sam_account = false if should_clear?
   end
 
+  def self.unreckoned
+    User.where(sam_account: false)
+  end
+
   def set
     return true if user.sam_account?
-    user.sam_account = client.duns_is_in_sam?(duns: user.duns_number)
+    user.sam_account = user_in_sam?
   end
 
   private
 
   def should_clear?
     user.persisted? && user.duns_number_changed?
+  end
+
+  def user_in_sam?
+    client.duns_is_in_sam?(duns: user.duns_number)
   end
 
   def client

--- a/lib/tasks/sam.rake
+++ b/lib/tasks/sam.rake
@@ -1,11 +1,12 @@
 namespace :sam do
   task check: :environment do
-    User.where(sam_account: false).each do |user|
+    SamAccountReckoner.unreckoned.each do |user|
       id = "#{user.name}/#{user.duns_number}: "
       begin
         sam_status = SamAccountReckoner.new(user).set
-        if sam_status == true
+        if sam_status
           id += 'DUNS *is* in SAM.gov'
+          user.save
         else
           id += 'DUNS *not* found in SAM.gov'
         end

--- a/spec/lib/tasks/sam_rake_spec.rb
+++ b/spec/lib/tasks/sam_rake_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe 'rake sam:check' do
 
   context 'when the sam_account is true for the user' do
     let!(:user) { FactoryGirl.create(:user, :with_duns_in_sam, sam_account: true) }
+    let(:reckoner) { SamAccountReckoner.new(user) }
 
     it 'does not use the reckoner and keeps the account as it is' do
       expect(reckoner).to_not receive(:set)


### PR DESCRIPTION
Also, the Rake task was not saving the user when sam_account was true and the test for the rake task was not checking that the user was saved after a successful call to `SamAccountReckoner.set`