### PR TITLE
add meta tags

### DIFF
--- a/app/views/auctions/index.html.erb
+++ b/app/views/auctions/index.html.erb
@@ -1,4 +1,12 @@
+<% content_for :data_tags do %>
+  <meta name="twitter:label1" value="Active Auctions">
+  <meta name="twitter:data1" value="<%= @auctions.count { |i| i.start_datetime < Time.now && Time.now < i.end_datetime } %>">
+  <meta name="twitter:label2" value="Coming Auctions">
+  <meta name="twitter:data2" value="<%= @auctions.count { |i| Time.now < i.start_datetime } %>">
+<% end %>
+
 <div class="usa-width-full">
+
   <h1>Welcome!</h1>
   <div class="usa-font-lead">
     <p>The Micro-purchase Marketplace is the place to bid on open-source issues from the 18F team. <a href="https://18f.gsa.gov/2015/11/06/micro-purchase-lessons/">Learn more about this experiment »</a></p>

--- a/app/views/auctions/show.html.erb
+++ b/app/views/auctions/show.html.erb
@@ -1,3 +1,10 @@
+<% content_for :title do %>18F Micro-purchase - <%= @auction.title %><% end %>
+<% content_for :description do %><%= @auction.summary %><% end %>
+<% content_for :data_tags do %>
+<%= render partial: '/components/data_tags', locals: {auction: @auction} %>
+<% end %>
+
+
 <% if current_user && !current_user.sam_account? %>
   <%= render partial: 'components/no_sam_header' %>
 <% else %>

--- a/app/views/bids/index.html
+++ b/app/views/bids/index.html
@@ -1,3 +1,9 @@
+<% content_for :title do %>18F Micro-purchase - Bids on <%= @auction.title %><% end %>
+<% content_for :description do %>Auction <%= @auction.id %> has <%= @auction.bids.length %> bids.<% end %>
+<% content_for :data_tags do %>
+<%= render partial: '/components/data_tags', locals: {auction: @auction} %>
+<% end %>
+
 <h1>Bids for "<%= @auction.title %>"</h1>
 
 <a href="<%= auction_path(@auction) %>">« Back to auction</a>

--- a/app/views/bids/my_bids.erb
+++ b/app/views/bids/my_bids.erb
@@ -1,3 +1,6 @@
+<% content_for :title do %>18F Micro-purchase - Your bids<% end %>
+<% content_for :description do %>View your bids across Micro-purchase auctions.<% end %>
+
 <h1>My Bids</h1>
 
 <a href="/">« Back to open issues</a>

--- a/app/views/bids/new.html.erb
+++ b/app/views/bids/new.html.erb
@@ -1,3 +1,15 @@
+<% content_for :title do %>18F Micro-purchase - New bid<% end %>
+<% content_for :description do %>
+<% if @auction.available? %>
+Place a bid for "<%= @auction.title %>". The current bid is <%= number_to_currency(@auction.current_bid_amount) %>.
+<% else %>
+Bidding on this auction closed on <%= @auction.end_datetime %>. The winning bid was <%= number_to_currency(@auction.current_bid_amount) %>.
+<% end %>
+<% end %>
+<% content_for :data_tags do %>
+<%= render partial: '/components/data_tags', locals: {auction: @auction} %>
+<% end %>
+
 <h1>Bidding on...</h1>
 
 <hr>

--- a/app/views/components/_data_tags.erb
+++ b/app/views/components/_data_tags.erb
@@ -1,0 +1,18 @@
+<meta name="twitter:label1" value="Status">
+<% if @auction.expiring? %>
+  <meta name="twitter:data1" value="<%= distance_of_time_in_words(Time.now, @auction.end_datetime) %> left">
+  <meta name="twitter:label2" value="Bidding">
+  <meta name="twitter:data2" value="<%= number_to_currency(@auction.current_bid_amount) %> - <%= @auction.bids.length %> bids">
+<% elsif @auction.over? %>
+  <meta name="twitter:data1" value="<%= auction_label(@auction) %>">
+  <meta name="twitter:label2" value="Winning Bid">
+  <meta name="twitter:data2" value="<%= number_to_currency(@auction.current_bid_amount) %>">
+<% elsif @auction.future? %>
+  <meta name="twitter:data1" value="Starts <%= auction_human_start_time(@auction.start_datetime) %>">
+  <meta name="twitter:label2" value="Starting bid">
+  <meta name="twitter:data2" value="<%= number_to_currency(@auction.start_price) %>">
+<% else %>
+  <meta name="twitter:data1" value="<%= distance_of_time_in_words(Time.now, @auction.end_datetime) %> left">
+  <meta name="twitter:label2" value="Bidding">
+  <meta name="twitter:data2" value="<%= number_to_currency(@auction.current_bid_amount) %> - <%= @auction.bids.length %> bids">
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,11 +2,28 @@
 <html lang="en">
 <head>
   <!-- test content -->
-  <title>Micro-purchase</title>
+  <meta charset="utf-8">
+  <title><%= yield(:title).presence || "18F - Micro-purchase" %></title>
+  <meta property="og:title" content="<%= yield(:title).presence || "18F - Micro-purchase" %>">
   <%= stylesheet_link_tag    'application', media: 'all', debug: true %>
   <%= javascript_include_tag "application", debug: true %>
   <%= csrf_meta_tags %>
   <%= favicon_link_tag %>
+
+  <!-- Meta tags -->
+  <meta name="twitter:site" content="@18F">
+  <meta name="twitter:creator" content="@18F">
+  <meta property="og:site_name" content="18F - Micro-purchase" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://micropurchase.18f.gov" />
+  <link rel="canonical" href="https://micropurchase.18f.gov" />
+
+  <meta name="description" content="<%= yield(:description).presence || "The Micro-purchase Marketplace is the place to bid on open-source issues from the 18F team." %>">
+  <meta property="og:description" content="<%= yield(:description).presence || "The Micro-purchase Marketplace is the place to bid on open-source issues from the 18F team." %>">
+
+  <meta name="twitter:card" content="summary">
+
+  <%= yield :data_tags %>
 
   <!-- Add 18F GA snippet -->
   <script>

--- a/app/views/logins/faq.html.erb
+++ b/app/views/logins/faq.html.erb
@@ -1,3 +1,6 @@
+<% content_for :title do %>18F Micro-purchase - Policies and Guidelines<% end %>
+<% content_for :description do %>Important information and frequently asked questions about the Micro-purchase platform.<% end %>
+
 <h1>Policies and Guidelines</h1>
 
 <p>Participation in the micro-purchase experiment allows individuals and vendors of all types to bid on and complete open source software work for the federal government. If you&rsquo;re interested in participating, here is some helpful information to get you ready!</p>

--- a/app/views/logins/index.html.erb
+++ b/app/views/logins/index.html.erb
@@ -1,3 +1,6 @@
+<% content_for :title do %>18F Micro-purchase - Login<% end %>
+<% content_for :description do %>Login or create an account to participate in Micro-purchase auctions.<% end %>
+
 <h2>Getting started</h2>
 
 <p>Before participating in this marketplace, you’ll first need to register your company with <a href="https://www.sam.gov/portal/SAM/##11">SAM.gov</a>, enter a DUNS number, and have a GitHub account. </p>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,3 +1,6 @@
+<% content_for :title do %>18F Micro-purchase - Edit user: <%= @user.name %><% end %>
+<% content_for :description do %>Edit your Micro-purchase user account.<% end %>
+
 <h1>Complete your account</h1>
 
 <% if flash[:notice] %>

--- a/spec/features/meta_tags_spec.rb
+++ b/spec/features/meta_tags_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+require 'action_view'
+
+RSpec.feature "Pages have meta tags", type: :feature do
+  include ActionView::Helpers::DateHelper
+  include ActionView::Helpers::NumberHelper
+  include AuctionHelper
+  scenario 'Main page meta tags' do
+    create_closed_and_current_auctions
+    @auction = FactoryGirl.create(:auction, :future)
+
+    visit "/"
+
+    expect(page).to have_css("title", :visible => false, :text => "18F - Micro-purchase")
+    expect(page).to have_css("meta[property='og:title'][content='18F - Micro-purchase']", :visible => false)
+    expect(page).to have_css("meta[name='description'][content='The Micro-purchase Marketplace is the place to bid on open-source issues from the 18F team.']", :visible => false)
+    expect(page).to have_css("meta[property='og:description'][content='The Micro-purchase Marketplace is the place to bid on open-source issues from the 18F team.']", :visible => false)
+    expect(page).to have_css("meta[name='twitter:label1'][value='Active Auctions']", :visible => false)
+    expect(page).to have_css("meta[name='twitter:data1'][value='5']", :visible => false)
+    expect(page).to have_css("meta[name='twitter:label2'][value='Coming Auctions']", :visible => false)
+    expect(page).to have_css("meta[name='twitter:data2'][value='1']", :visible => false)
+  end
+
+  scenario "Open auction meta tags" do
+    current_auction, _bids = create_current_auction
+    visit auction_path(current_auction)
+
+    @auction = Presenter::Auction.new(@auction)
+
+    expect(page).to have_css("title", :visible => false, :text => "18F Micro-purchase - #{@auction.title}")
+    expect(page).to have_css("meta[property='og:title'][content='18F Micro-purchase - #{@auction.title}']", :visible => false)
+    expect(page).to have_css("meta[name='description'][content='#{@auction.summary}']", :visible => false)
+    expect(page).to have_css("meta[property='og:description'][content='#{@auction.summary}']", :visible => false)
+    expect(page).to have_css("meta[name='twitter:label1'][value='Status']", :visible => false)
+    expect(page).to have_css("meta[name='twitter:data1'][value='#{distance_of_time_in_words(Time.now, @auction.end_datetime)} left']", :visible => false)
+    expect(page).to have_css("meta[name='twitter:label2'][value='Bidding']", :visible => false)
+    expect(page).to have_css("meta[name='twitter:data2'][value='#{number_to_currency(@auction.current_bid_amount)} - #{@auction.bids.length} bids']", :visible => false)
+  end
+
+  scenario "Closed auction meta tags" do
+    closed_auction, _bids = create_closed_auction
+    visit auction_path(closed_auction)
+
+    @auction = Presenter::Auction.new(@auction)
+
+    expect(page).to have_css("title", :visible => false, :text => "18F Micro-purchase - #{@auction.title}")
+    expect(page).to have_css("meta[property='og:title'][content='18F Micro-purchase - #{@auction.title}']", :visible => false)
+    expect(page).to have_css("meta[name='description'][content='#{@auction.summary}']", :visible => false)
+    expect(page).to have_css("meta[property='og:description'][content='#{@auction.summary}']", :visible => false)
+    expect(page).to have_css("meta[name='twitter:label1'][value='Status']", :visible => false)
+    expect(page).to have_css("meta[name='twitter:data1'][value='#{auction_label(@auction)}']", :visible => false)
+    expect(page).to have_css("meta[name='twitter:label2'][value='Winning Bid']", :visible => false)
+    expect(page).to have_css("meta[name='twitter:data2'][value='#{number_to_currency(@auction.current_bid_amount)}']", :visible => false)
+  end
+
+  scenario "Edit profile meta tags" do
+    visit "/"
+
+    create_authed_bidder
+
+    click_on "Login"
+    click_on("Authorize with GitHub")
+    click_on("Edit Profile")
+
+    expect(page).to have_css("title", :visible => false, :text => "18F Micro-purchase - Edit user: Doris Doogooder")
+  end
+end


### PR DESCRIPTION
This should add meta tags for all pages. I added content for all of them, but can definitely revise as appropriate.

The use of the `twitter:label` and `twitter:data` tags is probably the least common thing. I don't know if they're used by Twitter any longer, but they are used in things like Slack. To see what it looks like, check out a Medium post on Slack.

I don't think that there's anything else required to get sites to actually use these tags, but unfortunately that can only be checked after they're up and running. Facebook might be the longest lag time, but a scan can be run through their dev console, I believe.