### PR TITLE
Don't hit the GitHub API if the api-key header is blank

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -66,6 +66,8 @@ class ApplicationController < ActionController::Base
   end
 
   def github_id_from_api_key(api_key)
+    return nil if api_key.nil?
+
     client = Octokit::Client.new(access_token: api_key)
     client.user.id
   rescue Octokit::Unauthorized => e


### PR DESCRIPTION
@harrisj, this was the rather simple solution to our rate limiting problem.

If there is not api key, don't hit the github api in hopes of authenticating.

If there is an api key, we'll hit the api. We might still risk some sort of rate limiting if we have many requests with invalid keys. I'll try to test this locally.