### PR TITLE
Fix bid overflow issue

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -122,7 +122,6 @@ textarea#auction_description {
 
     p {
       padding: 1rem 3rem 0 3rem;
-      font-size: 1.7rem;
       margin: 0;
     }
 

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -13,6 +13,18 @@ $color-gold: #fdb81e;
 $color-cool-blue: #205493;
 $color-purple: #4c2c92;
 
+html {
+    font-size: 16px;
+}
+
+body {
+    font-size: 1.0625rem;
+}
+
+p,li,span,label,input,button {
+    font-size: 1.0625rem;
+}
+
 textarea#auction_summary {
   width: 500px;
   height: 150px;
@@ -150,43 +162,44 @@ textarea#auction_description {
   }
   .issue-bid-details {
     background-color: $color-gray;
-    padding: 1.5rem 3rem;
+    padding: 2rem 3rem;
 
     .current-bid-box {
-      height: 5rem;
       position: relative;
 
       .current-bid-box-children {
         position: relative;
         top: 50%;
-        margin-top: -2rem;
+        /* margin-top: -1rem; */
 
 
         .current-bid-header {
           font-weight: 400;
         }
         .current-bid {
-          font-size: 3rem;
+          font-size: 1.3rem;
           font-weight: 700;
+        }
+
+        .current-bid-link {
+            white-space: nowrap;
         }
 
       }
     }
 
     .bid-deadline-box {
-
       .bid-deadline-box-children {
         position: relative;
         top: 50%;
-        margin-top: -0.5rem;
-
+        margin-bottom: 0.5rem;
       }
     }
 
     a.usa-button {
-      margin-top: 1.5rem;
-      padding: 0.5rem 2rem;
-      white-space: nowrap;
+        margin-top: 0;
+        padding: 0.5rem 2rem;
+        white-space: nowrap;
     }
 
     p {

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -79,23 +79,23 @@ textarea#auction_description {
 
 .github-issue {
   h1 {
-	  line-height: 1.1em;
-	  margin-top: 0.2em;
-	  margin-bottom: 0.5em;
+	  line-height: 1.1rem;
+	  margin-top: 0.2rem;
+	  margin-bottom: 0.5rem;
   }
 
   h2, h3, h4, h5, h6 {
-	  line-height: 1.1em;
-	  margin-top: 0.2em;
-	  margin-bottom: 0.1em;
+	  line-height: 1.1rem;
+	  margin-top: 0.2rem;
+	  margin-bottom: 0.1rem;
   }
 
   p, li {
-	  line-height: 1.3em;
+	  line-height: 1.3rem;
   }
 
   ul {
-	  margin-bottom: 0.5em;
+	  margin-bottom: 0.5rem;
   }
 }
 
@@ -169,8 +169,6 @@ textarea#auction_description {
       .current-bid-box-children {
         position: relative;
         top: 50%;
-        /* margin-top: -1rem; */
-
 
         .current-bid-header {
           font-weight: 400;
@@ -330,7 +328,7 @@ footer {
 
 .make-bid-grid p {
   margin: 0;
-  line-height: 1.2em;
+  line-height: 1.129411765rem;
 }
 
 .current-bid-amount {

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -21,8 +21,12 @@ body {
     font-size: 1.0625rem;
 }
 
-p,li,span,label,input,button {
+p,li,span,button {
     font-size: 1.0625rem;
+}
+
+.usa-font-lead p {
+    font-size: 1.882352941rem;
 }
 
 textarea#auction_summary {

--- a/app/views/auctions/_bids_and_form.html.erb
+++ b/app/views/auctions/_bids_and_form.html.erb
@@ -2,8 +2,8 @@
   <div class="current-bid-box-children">
 <% if auction.bids? %>
     <span class="current-bid-header">Current bid:</span>
-    <span class="current-bid"><%= number_to_currency(auction.current_bid_amount) %>  </span>
-    <span class=""><%=
+    <span class="current-bid"><%= number_to_currency(auction.current_bid_amount) %>  </span><br/>
+    <span class="current-bid-link"><%=
     link_to(
       pluralize(auction.bids.length, 'bid'),
       auction_bids_path(auction.id)
@@ -22,7 +22,7 @@
     Bid Deadline:  <%= distance_of_time_in_words(Time.now, auction.end_datetime) %> left
   </span><br/>
   <span class="bid-deadline">
-    Bid start time: <%= auction_human_start_time(auction.start_datetime) %>
+    Auction Start: <%= auction_human_start_time(auction.start_datetime) %>
   </span>
 </div>
 </div>

--- a/app/views/auctions/_list_item.html.erb
+++ b/app/views/auctions/_list_item.html.erb
@@ -2,7 +2,7 @@
   <div class="usa-grid">
     <div class='usa-width-one-whole issue-label'>
       <h3 class='issue-title'>
-        <span class="usa-label-big <%= auction_label_class(auction) %>"><%= auction_label(auction) %></span> <a href="<%= auction_path(auction) %>"><%= auction.title %></a>
+        <span class="usa-label <%= auction_label_class(auction) %>"><%= auction_label(auction) %></span> <a href="<%= auction_path(auction) %>"><%= auction.title %></a>
       </h3>
       <p class='issue-description'>
         <%=h raw auction.html_summary %><a href="<%= auction_path(auction) %>">View details »</a>

--- a/spec/factories/auctions.rb
+++ b/spec/factories/auctions.rb
@@ -4,7 +4,7 @@ FactoryGirl.define do
     end_datetime { Time.now + 3.days }
     title { Faker::Company.catch_phrase }
     summary { Faker::Lorem.paragraph }
-    description { Faker::Lorem.paragraphs(3, true) }
+    description { Faker::Lorem.paragraphs(3, true).join("\n\n") }
     issue_url 'https://github.com/18F/calc/issues/255'
     github_repo 'https://github.com/18F/calc'
 

--- a/spec/features/bidder_interacts_with_auction_spec.rb
+++ b/spec/features/bidder_interacts_with_auction_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature "bidder interacts with auction", type: :feature do
       visit '/'
 
       within(:css, 'div.issue-list-item') do
-        within(:css, 'span.usa-label-big') do
+        within(:css, 'span.usa-label') do
           expect(page).to have_content('Closed')
         end
       end
@@ -45,7 +45,7 @@ RSpec.feature "bidder interacts with auction", type: :feature do
       visit '/'
 
       within(:css, 'div.issue-list-item') do
-        within(:css, 'span.usa-label-big') do
+        within(:css, 'span.usa-label') do
           expect(page).to have_content('Expiring')
         end
       end
@@ -59,7 +59,7 @@ RSpec.feature "bidder interacts with auction", type: :feature do
       visit '/'
 
       within(:css, 'div.issue-list-item') do
-        within(:css, 'span.usa-label-big') do
+        within(:css, 'span.usa-label') do
           expect(page).to have_content('Coming Soon')
         end
       end


### PR DESCRIPTION
After some discussion with @msecret, I have made a few changes to the baseline CSS as part of fixing this issue in addition to some specific HTML/CSS issues. These changes can be summarized as follows:

* Set the base font-size to `16px`;
* Set the font size for other elements to `1.0625rem` (17px) since works better with Source Sans Pro
* Rescale most `rem` measurements for different sizing
* Eliminate use of the `em` measurements when possible
* Eliminate the use of negative margins, since those are what cause overwriting on mobile view

Because our CSS is not necessarily scoped to single views, these changes can have effects across the whole site. But I've been looking at things and I think we're in a good place. This does not fix two issues that are solved in prior PRs or should be a new PR:

* The buttons on the submit bid page are stacked (see #278 for solution)
* The login / edit profile buttons look terrible on mobile

I can apply fixes for those as well here, but I wanted to put this here first.