### PR TITLE
Toggles sam warning with cookie for memory

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,10 @@ group :development, :test do
   gem 'timecop'
   gem 'brakeman', require: false
   gem 'hakiri', require: false
+
+  gem 'dotenv-rails'
+
+  gem 'jasmine'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,6 @@ group :development, :test do
   gem 'rspec-rails'
 
   gem 'cucumber-rails', require: false
-  gem 'poltergeist'
 
   gem 'capybara'
   gem 'capybara-screenshot'

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ group :development, :test do
   gem 'rspec-rails'
 
   gem 'cucumber-rails', require: false
+  gem 'poltergeist'
 
   gem 'capybara'
   gem 'capybara-screenshot'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,7 +79,6 @@ GEM
     cf-app-utils (0.6)
     choice (0.2.0)
     chronic (0.10.2)
-    cliver (0.3.2)
     codeclimate-test-reporter (0.4.8)
       simplecov (>= 0.7.1, < 1.0.0)
     coderay (1.1.0)
@@ -194,11 +193,6 @@ GEM
       ast (>= 1.1, < 3.0)
     pg (0.18.4)
     phantomjs (2.1.1.0)
-    poltergeist (1.9.0)
-      capybara (~> 2.1)
-      cliver (~> 0.3.1)
-      multi_json (~> 1.0)
-      websocket-driver (>= 0.2.0)
     powerpack (0.1.1)
     pry (0.10.3)
       coderay (~> 1.1.0)
@@ -335,9 +329,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
-    websocket-driver (0.6.3)
-      websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.2)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -366,7 +357,6 @@ DEPENDENCIES
   omniauth
   omniauth-github
   pg
-  poltergeist
   pry
   puma
   rails (= 4.2.5.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,7 @@ GEM
     cf-app-utils (0.6)
     choice (0.2.0)
     chronic (0.10.2)
+    cliver (0.3.2)
     codeclimate-test-reporter (0.4.8)
       simplecov (>= 0.7.1, < 1.0.0)
     coderay (1.1.0)
@@ -182,6 +183,11 @@ GEM
     parser (2.2.3.0)
       ast (>= 1.1, < 3.0)
     pg (0.18.4)
+    poltergeist (1.9.0)
+      capybara (~> 2.1)
+      cliver (~> 0.3.1)
+      multi_json (~> 1.0)
+      websocket-driver (>= 0.2.0)
     powerpack (0.1.1)
     pry (0.10.3)
       coderay (~> 1.1.0)
@@ -318,6 +324,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
+    websocket-driver (0.6.3)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.2)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -344,6 +353,7 @@ DEPENDENCIES
   omniauth
   omniauth-github
   pg
+  poltergeist
   pry
   puma
   rails (= 4.2.5.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,6 +106,10 @@ GEM
     docile (1.1.5)
     domain_name (0.5.25)
       unf (>= 0.0.5, < 1.0.0)
+    dotenv (2.1.0)
+    dotenv-rails (2.1.0)
+      dotenv (= 2.1.0)
+      railties (>= 4.0, < 5.1)
     email_validator (1.6.0)
       activemodel
     erubis (2.7.0)
@@ -142,6 +146,12 @@ GEM
       domain_name (~> 0.5)
     httpclient (2.7.1)
     i18n (0.7.0)
+    jasmine (2.4.0)
+      jasmine-core (~> 2.4)
+      phantomjs
+      rack (>= 1.2.1)
+      rake
+    jasmine-core (2.4.1)
     json (1.8.3)
     json-schema (2.6.0)
       addressable (~> 2.3.8)
@@ -183,6 +193,7 @@ GEM
     parser (2.2.3.0)
       ast (>= 1.1, < 3.0)
     pg (0.18.4)
+    phantomjs (2.1.1.0)
     poltergeist (1.9.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -344,10 +355,12 @@ DEPENDENCIES
   codeclimate-test-reporter
   cucumber-rails
   database_cleaner
+  dotenv-rails
   email_validator
   factory_girl_rails
   faker
   hakiri
+  jasmine
   json-schema
   octokit (~> 4.0)
   omniauth

--- a/README.md
+++ b/README.md
@@ -28,8 +28,13 @@ Updating the ERD requires Graphiz. Installation instructions are [here](http://v
 
 ### Setting up and running the app
 
-The application is running Ruby 2.2.3 and Rails 4.2.4. Libraries are all
-available via gems.
+The application is running Ruby 2.2.3 and Rails 4.2.4. Most of the
+libraries are avalilable as gems.
+
+Testing with javascript and capybara on Travis CI requires some
+[Poltergeist](https://github.com/teampoltergeist/poltergeist).
+
+You can install poltergeist via `brew install phantomjs`
 
 ```
 git clone git@github.com:18F/micropurchase.git

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,4 +1,6 @@
 /*
  * = require vendor/jquery-1.11.3.min.js
  * = require components.js
+ * = require js.cookies.js
+ * = require sam_warning.js
  */

--- a/app/assets/javascripts/sam_warning.js
+++ b/app/assets/javascripts/sam_warning.js
@@ -1,0 +1,57 @@
+(function (root) {
+  var SamWarner = function () {
+    this.$warning = $('.auction-alert')
+    this.$hideTrigger = $('.warning-hide-trigger')
+    this.$showTrigger = $('.warning-show-trigger')
+  };
+
+  SamWarner.prototype.setup = function () {
+    if (Cookies.get('hideWarning')) {
+      this.hide()
+    } else {
+      this.show()
+    }
+    this.listen()
+  }
+
+  SamWarner.prototype.show = function () {
+    if (this.$warning.is(':visible')) { return }
+
+    this.$warning.show()
+    this.$showTrigger.hide()
+
+    Cookies.remove('hideWarning')
+  }
+
+  SamWarner.prototype.hide = function () {
+    if (!this.$warning.is(':visible')) { return }
+
+    this.$warning.hide()
+    this.$showTrigger.show()
+
+    Cookies.set('hideWarning', true)
+  }
+
+  SamWarner.prototype.listen = function () {
+    var that = this
+
+    this.$hideTrigger.on('click', function () {
+      that.hide()
+    })
+
+    this.$showTrigger.on('click', function () {
+      that.show()
+    })
+  }
+
+  root.SamWarner = SamWarner; // gotta do this for the tests :(
+  // would prefer all the globals for this app under one global
+
+  // also this combines the start of the js evented system with
+  // the components that build the system ... which is bad form
+  $(document).ready(function () {
+    var warner = new SamWarner()
+    warner.setup()
+  })
+
+})(this)

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -417,3 +417,7 @@ a:visited {
 .usa-button-primary-alt {
   color: white;
 }
+
+.warning-hide-trigger {
+  float: right;
+}

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -418,6 +418,17 @@ a:visited {
   color: white;
 }
 
-.warning-hide-trigger {
+.warning-hide-trigger,
+.warning-show-trigger .warning-trigger {
   float: right;
+}
+
+.warning-message {
+  display: inline-block;
+  padding-left: 5rem;
+  margin: 0;
+}
+
+.usa-alert {
+  margin-bottom: 2rem;
 }

--- a/app/models/presenter/auction.rb
+++ b/app/models/presenter/auction.rb
@@ -2,7 +2,8 @@ module Presenter
   class Auction < SimpleDelegator
     include ActiveModel::SerializerSupport
     include ActionView::Helpers::DateHelper
-      include ActionView::Helpers::NumberHelper
+    include ActionView::Helpers::NumberHelper
+
 
     def current_bid?
       current_bid_record != nil
@@ -101,7 +102,6 @@ module Presenter
         'Closed'
       end
     end
-
 
     delegate :label_class, :label, :tag_data_value_status, :tag_data_label_2, :tag_data_value_2,
       to: :status_presenter

--- a/app/views/components/_data_tags.erb
+++ b/app/views/components/_data_tags.erb
@@ -1,0 +1,18 @@
+<meta name="twitter:label1" value="Status">
+<% if @auction.expiring? %>
+  <meta name="twitter:data1" value="<%= distance_of_time_in_words(Time.now, @auction.end_datetime) %> left">
+  <meta name="twitter:label2" value="Bidding">
+  <meta name="twitter:data2" value="<%= number_to_currency(@auction.current_bid_amount) %> - <%= @auction.bids.length %> bids">
+<% elsif @auction.over? %>
+  <meta name="twitter:data1" value="<%= auction.label %>">
+  <meta name="twitter:label2" value="Winning Bid">
+  <meta name="twitter:data2" value="<%= number_to_currency(@auction.current_bid_amount) %>">
+<% elsif @auction.future? %>
+  <meta name="twitter:data1" value="Starts <%= auction.human_start_time %>">
+  <meta name="twitter:label2" value="Starting bid">
+  <meta name="twitter:data2" value="<%= number_to_currency(@auction.start_price) %>">
+<% else %>
+  <meta name="twitter:data1" value="<%= distance_of_time_in_words(Time.now, @auction.end_datetime) %> left">
+  <meta name="twitter:label2" value="Bidding">
+  <meta name="twitter:data2" value="<%= number_to_currency(@auction.current_bid_amount) %> - <%= @auction.bids.length %> bids">
+<% end %>

--- a/app/views/components/_data_tags.erb
+++ b/app/views/components/_data_tags.erb
@@ -1,18 +1,4 @@
 <meta name="twitter:label1" value="Status">
-<% if @auction.expiring? %>
-  <meta name="twitter:data1" value="<%= distance_of_time_in_words(Time.now, @auction.end_datetime) %> left">
-  <meta name="twitter:label2" value="Bidding">
-  <meta name="twitter:data2" value="<%= number_to_currency(@auction.current_bid_amount) %> - <%= @auction.bids.length %> bids">
-<% elsif @auction.over? %>
-  <meta name="twitter:data1" value="<%= auction.label %>">
-  <meta name="twitter:label2" value="Winning Bid">
-  <meta name="twitter:data2" value="<%= number_to_currency(@auction.current_bid_amount) %>">
-<% elsif @auction.future? %>
-  <meta name="twitter:data1" value="Starts <%= auction.human_start_time %>">
-  <meta name="twitter:label2" value="Starting bid">
-  <meta name="twitter:data2" value="<%= number_to_currency(@auction.start_price) %>">
-<% else %>
-  <meta name="twitter:data1" value="<%= distance_of_time_in_words(Time.now, @auction.end_datetime) %> left">
-  <meta name="twitter:label2" value="Bidding">
-  <meta name="twitter:data2" value="<%= number_to_currency(@auction.current_bid_amount) %> - <%= @auction.bids.length %> bids">
-<% end %>
+<meta name="twitter:data1" value="<%= auction.tag_data_value_status %>">
+<meta name="twitter:label2" value="<%= auction.tag_data_label_2 %>">
+<meta name="twitter:data2" value="<%= auction.tag_data_value_2 %>">

--- a/app/views/components/_no_sam_verification_header.html.erb
+++ b/app/views/components/_no_sam_verification_header.html.erb
@@ -12,6 +12,7 @@
   </div>
 </div>
 
-<a class='warning-show-trigger' style="display:none" href='javascript:void(0)'>
-  Hello, where is your SAM stuff. Do you want more information?
-</a>
+<div class='usa-alert usa-alert-warning warning-show-trigger' style='display:none'>
+  <h3 class='warning-message'>DUNS not registered</h3>
+  <a class='warning-trigger' href='javascript:void(0)'>expand</a>
+</div>

--- a/app/views/components/_no_sam_verification_header.html.erb
+++ b/app/views/components/_no_sam_verification_header.html.erb
@@ -1,4 +1,5 @@
 <div class="usa-alert usa-alert-error auction-alert">
+  <a href='javascript:void(0)' class='warning-hide-trigger'>collapse</a>
   <div class="usa-alert-body"><h3>Your DUNS is not registered with SAM*</h3></div>
   <div class="usa-alert-text">
     <p>You will not be able to bid on any auctions until:</p>
@@ -10,3 +11,7 @@
     <p>*NOTE: We periodically check if all users are listed in SAM.gov. It may be possible that you registered after the most recent check. However, we will always run a check at least once per day, so you may have to wait up to 24 hours between registration and bidding.</p>
   </div>
 </div>
+
+<a class='warning-show-trigger' style="display:none" href='javascript:void(0)'>
+  Hello, where is your SAM stuff. Do you want more information?
+</a>

--- a/features/step_definitions/sam_warning_steps.rb
+++ b/features/step_definitions/sam_warning_steps.rb
@@ -1,19 +1,30 @@
-Then(/^I should not see an alert warning me about my SAM registration$/) do
+Then(/^I should not see a warning about my SAM registration$/) do
   expect(page).not_to have_selector(".auction-alert")
 end
 
-Then(/^I should see an alert warning me that my SAM registration is not complete$/) do
+Then(/^I should see a warning that my SAM registration is not complete$/) do
   expect(page).to have_selector(".auction-alert")
 end
 
-When(/^I collapse the alert warning me about my SAM registrtation$/) do
+When(/^I collapse the warning about my SAM registrtation$/) do
   click_on "collapse"
 end
 
-Then(/^I will not see the alert$/) do
+Then(/^I will not see the warning$/) do
   expect(page).not_to have_content("Your DUNS is not registered with SAM*")
+  expect(page).not_to have_content("collapse")
 end
 
-Then(/^I will see an link to expand the alert$/) do
+Then(/^I will see a link to expand the warning$/) do
   expect(page).to have_content("expand")
+  expect(page).not_to have_content("collapse")
+end
+
+
+Then(/^I will see that the warning is still collapsed$/) do
+  step "I will see a link to expand the warning"
+end
+
+When(/^I click to expand the warning$/) do
+  click_on "expand"
 end

--- a/features/step_definitions/setup_steps.rb
+++ b/features/step_definitions/setup_steps.rb
@@ -22,3 +22,11 @@ When(/^I sign in and verify my account information/) do
   step "I sign in"
   click_on "Submit"
 end
+
+Given(/^there is an open auction$/) do
+  @auction = Auction.create(start_datetime: Time.now - 3.days, end_datetime: Time.now + 3.days, title: 'an auction')
+end
+
+When(/^I visit a the open auction$/) do
+  visit "/auctions/#{@auction.id}"
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -7,6 +7,10 @@
 require 'cucumber/rails'
 require 'database_cleaner'
 
+require 'capybara/poltergeist'
+Capybara.javascript_driver = :poltergeist
+WebMock.allow_net_connect!
+
 # Capybara defaults to CSS3 selectors rather than XPath.
 # If you'd prefer to use XPath, just uncomment this line and adjust any
 # selectors in your step definitions to use the XPath syntax.

--- a/features/toggle_sam_warning.feature
+++ b/features/toggle_sam_warning.feature
@@ -13,7 +13,7 @@ Feature: Toggling visibility on the sam status warning
     When I sign in and verify my account information
     Then I should see an alert warning me that my SAM registration is not complete
 
-  @wip
+  @wip @javascript
   Scenario: Toggling the sam status warning
     Given I am a user without a verified sam account
     When I sign in and verify my account information

--- a/features/toggle_sam_warning.feature
+++ b/features/toggle_sam_warning.feature
@@ -6,17 +6,27 @@ Feature: Toggling visibility on the sam status warning
   Scenario: When sam status is verified
     Given I am a user with a verified SAM account
     When I sign in and verify my account information
-    Then I should not see an alert warning me about my SAM registration
+    Then I should not see a warning about my SAM registration
 
   Scenario: When sam status unverified
     Given I am a user without a verified sam account
     When I sign in and verify my account information
-    Then I should see an alert warning me that my SAM registration is not complete
+    Then I should see a warning that my SAM registration is not complete
 
-  @wip @javascript
+  @javascript
   Scenario: Toggling the sam status warning
     Given I am a user without a verified sam account
+    And there is an open auction
     When I sign in and verify my account information
-    When I collapse the alert warning me about my SAM registrtation
-    Then I will not see the alert
-    And I will see an link to expand the alert
+    And I collapse the warning about my SAM registrtation
+    Then I will not see the warning
+    And I will see a link to expand the warning
+
+    When I visit a the open auction
+    Then I will see that the warning is still collapsed
+
+    When I click to expand the warning
+    Then I should see a warning that my SAM registration is not complete
+
+    When I visit the home page
+    Then I should see a warning that my SAM registration is not complete

--- a/spec/features/bidder_interacts_with_auction_spec.rb
+++ b/spec/features/bidder_interacts_with_auction_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature "bidder interacts with auction", type: :feature do
       visit '/'
 
       within(:css, 'div.issue-list-item') do
-        within(:css, 'span.usa-label') do
+        within(:css, 'span.usa-label-big') do
           expect(page).to have_content('Closed')
         end
       end
@@ -45,7 +45,7 @@ RSpec.feature "bidder interacts with auction", type: :feature do
       visit '/'
 
       within(:css, 'div.issue-list-item') do
-        within(:css, 'span.usa-label') do
+        within(:css, 'span.usa-label-big') do
           expect(page).to have_content('Expiring')
         end
       end
@@ -59,7 +59,7 @@ RSpec.feature "bidder interacts with auction", type: :feature do
       visit '/'
 
       within(:css, 'div.issue-list-item') do
-        within(:css, 'span.usa-label') do
+        within(:css, 'span.usa-label-big') do
           expect(page).to have_content('Coming Soon')
         end
       end
@@ -139,7 +139,7 @@ RSpec.feature "bidder interacts with auction", type: :feature do
     # takes us to confirmation page
     expect(page).to have_content("Confirm your bid: $800")
     click_on("Confirm")
-    
+
     # returns us back to the bid page
     expect(page).to have_content("Current bid:")
     expect(page).to have_content("$800.00")
@@ -203,7 +203,7 @@ RSpec.feature "bidder interacts with auction", type: :feature do
       # takes us to confirmation page
       expect(page).to have_content("Confirm your bid: $999")
       click_on("Confirm")
-      
+
       # returns us back to the bid page
       expect(page).to have_content("Current bid:")
       expect(page).to have_content("$999.00")

--- a/spec/javascripts/sam_warner_spec.js
+++ b/spec/javascripts/sam_warner_spec.js
@@ -1,0 +1,80 @@
+describe('SamWarner', function () {
+  var warner, $fixture
+
+  beforeEach(function () {
+    $fixture = $('<div class="auction-alert"><a class="warning-hide-trigger">hide trigger</a></div> <a class="warning-show-trigger" style="display: none">show trigger</a>')
+    $('body').prepend($fixture)
+  })
+
+  afterEach(function () {
+    $fixture.remove()
+  })
+
+  describe('when the Cookie is set to hide the alert', function () {
+    beforeEach(function () {
+      Cookies.set('hideWarning', true)
+      warner = new SamWarner()
+      warner.setup()
+    })
+
+    it('hides the warning and shows the trigger', function() {
+      expect($('.auction-alert').is(':visible')).not.toBeTruthy()
+      expect($('.warning-show-trigger').is(':visible')).toBeTruthy()
+    })
+
+    it('listens for clicks to show the warning', function() {
+      $('.warning-show-trigger').trigger('click')
+      expect($('.auction-alert').is(':visible')).toBeTruthy()
+      expect($('.warning-show-trigger').is(':visible')).not.toBeTruthy()
+    })
+
+    it('toggles visibility of elements back and forth', function() {
+      $('.warning-show-trigger').trigger('click')
+      $('.warning-hide-trigger').trigger('click')
+      expect($('.auction-alert').is(':visible')).not.toBeTruthy()
+      expect($('.warning-show-trigger').is(':visible')).toBeTruthy()
+    })
+
+    it('toggles cookie values', function() {
+      expect(Cookies.get('hideWarning')).toEqual('true')
+      $('.warning-show-trigger').trigger('click')
+      expect(Cookies.get('hideWarning')).toEqual(undefined)
+      $('.warning-hide-trigger').trigger('click')
+      expect(Cookies.get('hideWarning')).toEqual('true')
+    })
+  })
+
+  describe('when the Cookie is not set', function () {
+    beforeEach(function () {
+      Cookies.remove('hideWarning')
+      warner = new SamWarner()
+      warner.setup()
+    })
+
+    it('leaves the alert visible', function() {
+      expect($('.auction-alert').is(':visible')).toBeTruthy()
+      expect($('.warning-show-trigger').is(':visible')).not.toBeTruthy()
+    })
+
+    it('listens for clicks to hide the warning', function() {
+      $('.warning-hide-trigger').trigger('click')
+      expect($('.auction-alert').is(':visible')).not.toBeTruthy()
+      expect($('.warning-show-trigger').is(':visible')).toBeTruthy()
+    })
+
+    it('toggles visibility of elements back and forth', function() {
+      $('.warning-hide-trigger').trigger('click')
+      $('.warning-show-trigger').trigger('click')
+      expect($('.auction-alert').is(':visible')).toBeTruthy()
+      expect($('.warning-show-trigger').is(':visible')).not.toBeTruthy()
+    })
+
+    it('toggles cookie values', function() {
+      expect(Cookies.get('hideWarning')).toEqual(undefined)
+      $('.warning-hide-trigger').trigger('click')
+      expect(Cookies.get('hideWarning')).toEqual('true')
+      $('.warning-show-trigger').trigger('click')
+      expect(Cookies.get('hideWarning')).toEqual(undefined)
+    })
+  })
+})

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -1,0 +1,135 @@
+# src_files
+#
+# Return an array of filepaths relative to src_dir to include before jasmine specs.
+# Default: []
+#
+# EXAMPLE:
+#
+# src_files:
+#   - lib/source1.js
+#   - lib/source2.js
+#   - dist/**/*.js
+#
+src_files:
+  - assets/application.js
+
+# stylesheets
+#
+# Return an array of stylesheet filepaths relative to src_dir to include before jasmine specs.
+# Default: []
+#
+# EXAMPLE:
+#
+# stylesheets:
+#   - css/style.css
+#   - stylesheets/*.css
+#
+stylesheets:
+  #- assets/application.css
+
+# helpers
+#
+# Return an array of filepaths relative to spec_dir to include before jasmine specs.
+# Default: ["helpers/**/*.js"]
+#
+# EXAMPLE:
+#
+# helpers:
+#   - helpers/**/*.js
+#
+helpers:
+  - 'helpers/**/*.js'
+
+# spec_files
+#
+# Return an array of filepaths relative to spec_dir to include.
+# Default: ["**/*[sS]pec.js"]
+#
+# EXAMPLE:
+#
+# spec_files:
+#   - **/*[sS]pec.js
+#
+spec_files:
+  - '**/*[sS]pec.js'
+
+# src_dir
+#
+# Source directory path. Your src_files must be returned relative to this path. Will use root if left blank.
+# Default: project root
+#
+# EXAMPLE:
+#
+# src_dir: public
+#
+src_dir:
+
+# spec_dir
+#
+# Spec directory path. Your spec_files must be returned relative to this path.
+# Default: spec/javascripts
+#
+# EXAMPLE:
+#
+# spec_dir: spec/javascripts
+#
+spec_dir:
+
+# spec_helper
+#
+# Ruby file that Jasmine server will require before starting.
+# Returned relative to your root path
+# Default spec/javascripts/support/jasmine_helper.rb
+#
+# EXAMPLE:
+#
+# spec_helper: spec/javascripts/support/jasmine_helper.rb
+#
+spec_helper: spec/javascripts/support/jasmine_helper.rb
+
+# boot_dir
+#
+# Boot directory path. Your boot_files must be returned relative to this path.
+# Default: Built in boot file
+#
+# EXAMPLE:
+#
+# boot_dir: spec/javascripts/support/boot
+#
+boot_dir:
+
+# boot_files
+#
+# Return an array of filepaths relative to boot_dir to include in order to boot Jasmine
+# Default: Built in boot file
+#
+# EXAMPLE
+#
+# boot_files:
+#   - '**/*.js'
+#
+boot_files:
+
+# rack_options
+#
+# Extra options to be passed to the rack server
+# by default, Port and AccessLog are passed.
+#
+# This is an advanced options, and left empty by default
+#
+# EXAMPLE
+#
+# rack_options:
+#   server: 'thin'
+
+# random
+#
+# Run specs in semi-random order.
+# Default: false
+#
+# EXAMPLE:
+#
+# random: true
+#
+random:
+

--- a/spec/javascripts/support/jasmine_helper.rb
+++ b/spec/javascripts/support/jasmine_helper.rb
@@ -1,0 +1,15 @@
+#Use this file to set/override Jasmine configuration options
+#You can remove it if you don't need it.
+#This file is loaded *after* jasmine.yml is interpreted.
+#
+#Example: using a different boot file.
+#Jasmine.configure do |config|
+#   config.boot_dir = '/absolute/path/to/boot_dir'
+#   config.boot_files = lambda { ['/absolute/path/to/boot_dir/file.js'] }
+#end
+#
+#Example: prevent PhantomJS auto install, uses PhantomJS already on your path.
+#Jasmine.configure do |config|
+#   config.prevent_phantom_js_auto_install = true
+#end
+#

--- a/vendor/assets/javascripts/js.cookies.js
+++ b/vendor/assets/javascripts/js.cookies.js
@@ -1,0 +1,145 @@
+/*!
+ * JavaScript Cookie v2.1.0
+ * https://github.com/js-cookie/js-cookie
+ *
+ * Copyright 2006, 2015 Klaus Hartl & Fagner Brack
+ * Released under the MIT license
+ */
+(function (factory) {
+	if (typeof define === 'function' && define.amd) {
+		define(factory);
+	} else if (typeof exports === 'object') {
+		module.exports = factory();
+	} else {
+		var _OldCookies = window.Cookies;
+		var api = window.Cookies = factory();
+		api.noConflict = function () {
+			window.Cookies = _OldCookies;
+			return api;
+		};
+	}
+}(function () {
+	function extend () {
+		var i = 0;
+		var result = {};
+		for (; i < arguments.length; i++) {
+			var attributes = arguments[ i ];
+			for (var key in attributes) {
+				result[key] = attributes[key];
+			}
+		}
+		return result;
+	}
+
+	function init (converter) {
+		function api (key, value, attributes) {
+			var result;
+
+			// Write
+
+			if (arguments.length > 1) {
+				attributes = extend({
+					path: '/'
+				}, api.defaults, attributes);
+
+				if (typeof attributes.expires === 'number') {
+					var expires = new Date();
+					expires.setMilliseconds(expires.getMilliseconds() + attributes.expires * 864e+5);
+					attributes.expires = expires;
+				}
+
+				try {
+					result = JSON.stringify(value);
+					if (/^[\{\[]/.test(result)) {
+						value = result;
+					}
+				} catch (e) {}
+
+				if (!converter.write) {
+					value = encodeURIComponent(String(value))
+						.replace(/%(23|24|26|2B|3A|3C|3E|3D|2F|3F|40|5B|5D|5E|60|7B|7D|7C)/g, decodeURIComponent);
+				} else {
+					value = converter.write(value, key);
+				}
+
+				key = encodeURIComponent(String(key));
+				key = key.replace(/%(23|24|26|2B|5E|60|7C)/g, decodeURIComponent);
+				key = key.replace(/[\(\)]/g, escape);
+
+				return (document.cookie = [
+					key, '=', value,
+					attributes.expires && '; expires=' + attributes.expires.toUTCString(), // use expires attribute, max-age is not supported by IE
+					attributes.path    && '; path=' + attributes.path,
+					attributes.domain  && '; domain=' + attributes.domain,
+					attributes.secure ? '; secure' : ''
+				].join(''));
+			}
+
+			// Read
+
+			if (!key) {
+				result = {};
+			}
+
+			// To prevent the for loop in the first place assign an empty array
+			// in case there are no cookies at all. Also prevents odd result when
+			// calling "get()"
+			var cookies = document.cookie ? document.cookie.split('; ') : [];
+			var rdecode = /(%[0-9A-Z]{2})+/g;
+			var i = 0;
+
+			for (; i < cookies.length; i++) {
+				var parts = cookies[i].split('=');
+				var name = parts[0].replace(rdecode, decodeURIComponent);
+				var cookie = parts.slice(1).join('=');
+
+				if (cookie.charAt(0) === '"') {
+					cookie = cookie.slice(1, -1);
+				}
+
+				try {
+					cookie = converter.read ?
+						converter.read(cookie, name) : converter(cookie, name) ||
+						cookie.replace(rdecode, decodeURIComponent);
+
+					if (this.json) {
+						try {
+							cookie = JSON.parse(cookie);
+						} catch (e) {}
+					}
+
+					if (key === name) {
+						result = cookie;
+						break;
+					}
+
+					if (!key) {
+						result[name] = cookie;
+					}
+				} catch (e) {}
+			}
+
+			return result;
+		}
+
+		api.get = api.set = api;
+		api.getJSON = function () {
+			return api.apply({
+				json: true
+			}, [].slice.call(arguments));
+		};
+		api.defaults = {};
+
+		api.remove = function (key, attributes) {
+			api(key, '', extend(attributes, {
+				expires: -1
+			}));
+		};
+
+		api.withConverter = init;
+
+		return api;
+	}
+
+	return init(function () {});
+}));


### PR DESCRIPTION
This is built on top of the toggle-sam-warning branch which has a different pull request and is just a bunch of refactoring.

This chuck of commits adds poltergeist in order to run acceptance specs that are driven by javascript. It adds the javascript to do the toggle. It also adds unit tests for the js.

This is not the way I would suggest building js into the app. The other js with US Web Standards is not related in any way, and we are exposing a lot of global variables. I would have not exposed anything for this work normally, but had to get it out on the global space in order to test.

Anyway, it is good enough for now.