### PR TITLE
Tested and fixed auction preview bug

### DIFF
--- a/app/controllers/admin/auctions_controller.rb
+++ b/app/controllers/admin/auctions_controller.rb
@@ -25,7 +25,8 @@ module Admin
     end
 
     def preview
-      @auction = Presenter::Auction.new(Auction.find(params[:id]))
+      auction = Auction.find(params[:id])
+      @view_model = ViewModel::AuctionShow.new(current_user, auction)
 
       render 'auctions/show'
     end

--- a/spec/features/admin_dashboard_spec.rb
+++ b/spec/features/admin_dashboard_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature "AdminDashboards", type: :feature do
     @complete_and_successful = 5.times.map do
       FactoryGirl.create(:auction, :complete_and_successful)
     end
+    @unpublished = FactoryGirl.create(:auction, :unpublished)
     sign_in_admin
   end
 
@@ -14,6 +15,12 @@ RSpec.feature "AdminDashboards", type: :feature do
     @complete_and_successful.each do |auction|
       expect(page).to have_text(auction.title)
     end
+  end
+
+  scenario "Viewing a preview of an unpublished auction" do
+    visit "/admin/auctions/#{@unpublished.id}/preview"
+
+    expect(page).to have_text(@unpublished.description)
   end
 
 end


### PR DESCRIPTION
This PR adds a test for a feature that I failed to test previously. That feature was found to be broken on staging. This PR also fixes the broken feature. (the feature in question is the auction preview).

To try this out locally, visit `/admin/drafts` (as an admin) and click "preview" on any auction. You will see a preview of the unpublished auction.