### PR TITLE
Use absolute (and not relative) partial paths

### DIFF
--- a/app/models/view_model/auction_show.rb
+++ b/app/models/view_model/auction_show.rb
@@ -13,7 +13,7 @@ module ViewModel
     end
 
     def current_user_header_partial
-      current_user_has_no_sam_verification? ? "/components/no_sam_verification_header" : "win_header"
+      current_user_has_no_sam_verification? ? "components/no_sam_verification_header" : "auctions/win_header"
     end
 
     def auction_link_text

--- a/app/models/view_model/auctions_index.rb
+++ b/app/models/view_model/auctions_index.rb
@@ -14,11 +14,11 @@ module ViewModel
 
     def header_partial
       if current_user && current_user.sam_account?
-        '/components/sam_verified_header'
+        'components/sam_verified_header'
       elsif current_user
-         '/components/no_sam_verification_header'
+         'components/no_sam_verification_header'
       else
-        '/components/no_current_user_header'
+        'components/no_current_user_header'
       end
     end
 

--- a/app/views/auctions/show.html.erb
+++ b/app/views/auctions/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title do %>18F Micro-purchase - <%= @view_model.auction_title %><% end %>
 <% content_for :description do %><%= @view_model.auction_summary %><% end %>
 <% content_for :data_tags do %>
-  <%= render partial: '/auctions/data_tags', locals: {auction: @view_model.auction} %>
+  <%= render partial: 'auctions/data_tags', locals: {auction: @view_model.auction} %>
 <% end %>
 
 <%= render partial: @view_model.current_user_header_partial, locals: {auction: @view_model.auction} %>


### PR DESCRIPTION
Testing this out on staging to fix:

```
2016-02-18T11:42:42.97-0600 [App/0]      OUT   Rendered auctions/_data_tags.html.erb (2.3ms)
2016-02-18T11:42:42.97-0600 [App/0]      OUT   Rendered auctions/show.html.erb within layouts/application (3.5ms)
2016-02-18T11:42:42.97-0600 [App/0]      OUT Completed 500 Internal Server Error in 7ms (ActiveRecord: 1.6ms)
2016-02-18T11:42:42.97-0600 [App/0]      OUT ActionView::Template::Error (Missing partial admin/auctions/_win_header, application/_win_header with {:locale=>[:en], :formats=>[:html], :variants=>[], :handlers=>[:erb, :builder, :raw, :ruby]}. Searched in:
2016-02-18T11:42:42.97-0600 [App/0]      OUT   * "/home/vcap/app/app/views"
2016-02-18T11:42:42.97-0600 [App/0]      OUT ):
2016-02-18T11:42:42.97-0600 [App/0]      OUT     4:   <%= render partial: '/auctions/data_tags', locals: {auction: @view_model.auction} %>
2016-02-18T11:42:42.97-0600 [App/0]      OUT     5: <% end %>
2016-02-18T11:42:42.97-0600 [App/0]      OUT     6: 
2016-02-18T11:42:42.97-0600 [App/0]      OUT     7: <%= render partial: @view_model.current_user_header_partial, locals: {auction: @view_model.auction} %>
2016-02-18T11:42:42.97-0600 [App/0]      OUT     8: 
2016-02-18T11:42:42.97-0600 [App/0]      OUT     9: <div class="usa-grid-full">
2016-02-18T11:42:42.97-0600 [App/0]      OUT    10:   <p><a href="<%= root_path %>">« Back to open projects</a></p>
2016-02-18T11:42:42.97-0600 [App/0]      OUT   app/views/auctions/show.html.erb:7:in `_app_views_auctions_show_html_erb__2326395956528755307_70171850545140'
```