### PR TITLE
Keep logs out of CF deployments

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,1 +1,15 @@
 vendor
+
+# Ignore bundler config.
+/.bundle
+
+# Ignore all logfiles and tempfiles.
+/log/*
+!/log/.keep
+/tmp
+
+**/*.DS_Store
+
+/coverage
+/public/capybara.html
+.env


### PR DESCRIPTION
Logs were 500mb and were slowing deploys (especially local deploys).

This PR adds logs to the cfignore (straight copy of gitignore). We should look into symlinking.