### PR TITLE
Use absolute path to call auction/win_header partial

### DIFF
--- a/app/models/view_model/auction_show.rb
+++ b/app/models/view_model/auction_show.rb
@@ -13,7 +13,7 @@ module ViewModel
     end
 
     def current_user_header_partial
-      current_user_has_no_sam_verification? ? "/components/no_sam_verification_header" : "win_header"
+      current_user_has_no_sam_verification? ? "/components/no_sam_verification_header" : "auctions/win_header"
     end
 
     def auction_link_text


### PR DESCRIPTION
This pull request fixes a production-only error, triggered by visiting Admin::AuctionsController#preview by using an absolute path to call a partial.