### PR TITLE
Revert some CSS changes I made earlier

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -88,23 +88,23 @@ textarea#auction_description {
 
 .github-issue {
   h1 {
-	  line-height: 1.1rem;
-	  margin-top: 0.2rem;
-	  margin-bottom: 0.5rem;
+	  line-height: 1.1em;
+	  margin-top: 0.2em;
+	  margin-bottom: 0.5em;
   }
 
   h2, h3, h4, h5, h6 {
-	  line-height: 1.1rem;
-	  margin-top: 0.2rem;
-	  margin-bottom: 0.1rem;
+	  line-height: 1.1em;
+	  margin-top: 0.2em;
+	  margin-bottom: 0.1em;
   }
 
   p, li {
-	  line-height: 1.3rem;
+	  line-height: 1.3em;
   }
 
   ul {
-	  margin-bottom: 0.5rem;
+	  margin-bottom: 0.5em;
   }
 }
 


### PR DESCRIPTION
My eventual goal is to get rid of `em` in favor of `rem` but this is causing an issue in the short run. This reverts a change that was made in PR #216