### PR TITLE
Move auction.notes field into auction create form

### DIFF
--- a/app/views/admin/auctions/_edit_attributes.html.erb
+++ b/app/views/admin/auctions/_edit_attributes.html.erb
@@ -7,8 +7,5 @@
 <label for='auction_cap_proposal_url'>CAP Proposal URL</label>
 <%= f.text_field :cap_proposal_url %>
 
-<label for='auction_notes'>Notes</label>
-<%= f.text_area :notes %>
-
 <label for='auction_awardee_paid_status'>Paid?</label>
 <%= f.select :awardee_paid_status, Auction.awardee_paid_statuses.keys.to_a %>

--- a/app/views/admin/auctions/_general_attributes.html.erb
+++ b/app/views/admin/auctions/_general_attributes.html.erb
@@ -33,3 +33,6 @@
 
 <label for='auction_published'>Published?</label>
 <%= f.select :published, Auction.publisheds.keys.to_a %>
+
+<label for='auction_notes'>Notes</label>
+<%= f.text_area :notes %>


### PR DESCRIPTION
This PR allows site admins to edit auction notes when they create them. cc @lauraGgit 