### PR TITLE
Temporarily suspend meta tags

### DIFF
--- a/app/views/auctions/_data_tags.html.erb
+++ b/app/views/auctions/_data_tags.html.erb
@@ -1,4 +1,1 @@
-<meta name="twitter:label1" value="Status">
-<meta name="twitter:data1" value="<%= auction.tag_data_value_status %>">
-<meta name="twitter:label2" value="<%= auction.tag_data_label_2 %>">
-<meta name="twitter:data2" value="<%= auction.tag_data_value_2 %>">
+

--- a/app/views/auctions/show.html.erb
+++ b/app/views/auctions/show.html.erb
@@ -1,8 +1,4 @@
 <% content_for :title do %>18F Micro-purchase - <%= @view_model.auction_title %><% end %>
-<% content_for :description do %><%= @view_model.auction_summary %><% end %>
-<% content_for :data_tags do %>
-  <%= render partial: '/auctions/data_tags', locals: {auction: @view_model.auction} %>
-<% end %>
 
 <%= render partial: @view_model.current_user_header_partial, locals: {auction: @view_model.auction} %>
 

--- a/app/views/bids/index.html
+++ b/app/views/bids/index.html
@@ -1,8 +1,4 @@
 <% content_for :title do %>18F Micro-purchase - Bids on <%= @auction.title %><% end %>
-<% content_for :description do %>Auction <%= @auction.id %> has <%= @auction.bids.length %> bids.<% end %>
-<% content_for :data_tags do %>
-<%= render partial: '/auctions/data_tags', locals: {auction: @auction} %>
-<% end %>
 
 <h1>Bids for "<%= @auction.title %>"</h1>
 

--- a/app/views/components/_data_tags.erb
+++ b/app/views/components/_data_tags.erb
@@ -1,4 +1,0 @@
-<meta name="twitter:label1" value="Status">
-<meta name="twitter:data1" value="<%= auction.tag_data_value_status %>">
-<meta name="twitter:label2" value="<%= auction.tag_data_label_2 %>">
-<meta name="twitter:data2" value="<%= auction.tag_data_value_2 %>">

--- a/spec/features/meta_tags_spec.rb
+++ b/spec/features/meta_tags_spec.rb
@@ -23,6 +23,7 @@ RSpec.feature "Pages have meta tags", type: :feature do
   end
 
   scenario "Open auction meta tags" do
+    skip 'removing meta tags for now'
     current_auction, _bids = create_current_auction
     visit auction_path(current_auction)
 
@@ -35,6 +36,8 @@ RSpec.feature "Pages have meta tags", type: :feature do
   end
 
   scenario "Closed auction meta tags" do
+    skip 'removing meta tags for now'
+
     closed_auction, _bids = create_closed_auction
     visit auction_path(closed_auction)
 


### PR DESCRIPTION
They were leaking bid data for single bid auctions. Re-implement this later.