### PR TITLE
Specify micro-purchase delivery deadline as a number of business days

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'octokit', '~> 4.0'
 gem 'active_model_serializers'
 
 gem 'business_time'
+gem 'holidays'
 
 group :test do
   gem "codeclimate-test-reporter", require: nil

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,6 +148,7 @@ GEM
     hashdiff (0.3.0)
     hashie (3.4.3)
     highline (1.7.8)
+    holidays (3.2.0)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     httpclient (2.7.1)
@@ -359,6 +360,7 @@ DEPENDENCIES
   factory_girl_rails
   faker
   hakiri
+  holidays
   jasmine
   json-schema
   octokit (~> 4.0)
@@ -382,4 +384,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/app/models/auction_parser.rb
+++ b/app/models/auction_parser.rb
@@ -48,7 +48,12 @@ class AuctionParser < Struct.new(:params)
   end
 
   def delivery_deadline
-    parse_time(params[:auction][:delivery_deadline])
+    due_in_days = params[:auction][:due_in_days]
+    if defined? due_in_days and due_in_days.to_i > 0
+      due_in_days.to_i.business_days.after(end_datetime.to_date).end_of_day
+    else
+      parse_time(params[:auction][:delivery_deadline])
+    end
   end
 
   def start_datetime

--- a/app/models/auction_parser.rb
+++ b/app/models/auction_parser.rb
@@ -49,7 +49,7 @@ class AuctionParser < Struct.new(:params)
 
   def delivery_deadline
     if params.has_key?(:due_in_days)
-      params[:due_in_days].to_i.business_days.after(end_datetime.to_date).end_of_day
+      params[:due_in_days].to_i.business_days.after(end_datetime.to_date).end_of_workday
     else
       parse_time(params[:auction][:delivery_deadline])
     end

--- a/app/models/auction_parser.rb
+++ b/app/models/auction_parser.rb
@@ -48,9 +48,8 @@ class AuctionParser < Struct.new(:params)
   end
 
   def delivery_deadline
-    due_in_days = params[:auction][:due_in_days]
-    if defined? due_in_days and due_in_days.to_i > 0
-      due_in_days.to_i.business_days.after(end_datetime.to_date).end_of_day
+    if params.has_key?(:due_in_days)
+      params[:due_in_days].to_i.business_days.after(end_datetime.to_date).end_of_day
     else
       parse_time(params[:auction][:delivery_deadline])
     end

--- a/app/models/presenter/auction.rb
+++ b/app/models/presenter/auction.rb
@@ -205,8 +205,8 @@ module Presenter
       bid = lowest_user_bid(user)
       bid.nil? ? nil : bid.amount
     end
-    
-    
+
+
     def html_description
       return '' if description.blank?
       markdown.render(description)

--- a/app/views/admin/auctions/_general_attributes.html.erb
+++ b/app/views/admin/auctions/_general_attributes.html.erb
@@ -22,8 +22,13 @@
 <label for='auction_end_datetime'>End date</label>
 <%= f.text_field :end_datetime %>
 
-<label for='auction_delivery_deadline'>Delivery deadline</label>
-<%= f.text_field :delivery_deadline %>
+<% if @auction.new_record? %>
+  <label for='auction_due_in_days'>Due in days</label>
+  <%= text_field_tag :auction_due_in_days %>
+<% else %>
+  <label for='delivery_deadline'>Delivery deadline</label>
+  <%= f.text_field :delivery_deadline %>
+<% end %>
 
 <label for='auction_billable_to'>Billable to</label>
 <%= f.text_field :billable_to %>

--- a/app/views/admin/auctions/_general_attributes.html.erb
+++ b/app/views/admin/auctions/_general_attributes.html.erb
@@ -23,8 +23,8 @@
 <%= f.text_field :end_datetime %>
 
 <% if @auction.new_record? %>
-  <label for='auction_due_in_days'>Due in days</label>
-  <%= text_field_tag :auction_due_in_days %>
+  <label for='due_in_days'>Due in days</label>
+  <%= text_field_tag :due_in_days %>
 <% else %>
   <label for='delivery_deadline'>Delivery deadline</label>
   <%= f.text_field :delivery_deadline %>

--- a/config/initializers/business_time.rb
+++ b/config/initializers/business_time.rb
@@ -1,0 +1,3 @@
+Holidays.between(Date.today, 5.years.from_now, :us, :observed).map{
+  |holiday| BusinessTime::Config.holidays << holiday[:date]
+}

--- a/config/initializers/extensions.rb
+++ b/config/initializers/extensions.rb
@@ -1,0 +1,3 @@
+# Be sure to restart your server when you modify this file.
+
+require File.join(Rails.root, 'lib/extensions/date.rb')

--- a/lib/extensions/date.rb
+++ b/lib/extensions/date.rb
@@ -1,0 +1,8 @@
+# Blindly calculates end of workday using BusinessTime settings.
+# Does not consider weekends or holidays.
+class Date
+  def end_of_workday
+    cob = Time.parse(BusinessTime::Config.end_of_workday)
+    Time.mktime(self.year, self.month, self.day, cob.hour, cob.min, cob.sec)
+  end
+end

--- a/spec/features/admin_auctions_spec.rb
+++ b/spec/features/admin_auctions_spec.rb
@@ -47,7 +47,7 @@ RSpec.feature "AdminAuctions", type: :feature do
     fill_in("auction_issue_url", with: "https://github.com/18F/calc/issues/255")
     fill_in("auction_start_datetime", with: Presenter::DcTime.convert(Time.now + 3.days).strftime("%m/%d/%Y"))
     fill_in("auction_end_datetime", with: Presenter::DcTime.convert(Time.now - 3.days).strftime("%m/%d/%Y"))
-    fill_in("auction_due_in_days", with: 5)
+    fill_in("due_in_days", with: 5)
     fill_in("auction_billable_to", with: "the tock line item for CALC")
     select("published", from: "auction_published")
 

--- a/spec/features/admin_auctions_spec.rb
+++ b/spec/features/admin_auctions_spec.rb
@@ -47,7 +47,7 @@ RSpec.feature "AdminAuctions", type: :feature do
     fill_in("auction_issue_url", with: "https://github.com/18F/calc/issues/255")
     fill_in("auction_start_datetime", with: Presenter::DcTime.convert(Time.now + 3.days).strftime("%m/%d/%Y"))
     fill_in("auction_end_datetime", with: Presenter::DcTime.convert(Time.now - 3.days).strftime("%m/%d/%Y"))
-    fill_in("auction_delivery_deadline", with: Presenter::DcTime.convert(Time.now + 5.days).strftime("%m/%d/%Y"))
+    fill_in("auction_due_in_days", with: 5)
     fill_in("auction_billable_to", with: "the tock line item for CALC")
     select("published", from: "auction_published")
 


### PR DESCRIPTION
We have used the following gems to complete this requirement:

https://github.com/bokmann/business_time
https://github.com/holidays/holidays

The code uses the business_time gem to calculate the delivery deadline date. The holidays configuration for the business_time gem is configured through the holidays gem. The delivery deadline day closes at 5:00 pm which the default time for the business_time gem.