### PR TITLE
Removed a few named scopes

### DIFF
--- a/app/models/auction.rb
+++ b/app/models/auction.rb
@@ -8,7 +8,4 @@ class Auction < ActiveRecord::Base
 
   # Disable STI
   self.inheritance_column = :__disabled
-
-  scope :in_reverse_chron_order, -> { order('end_datetime DESC') }
-  scope :with_bids, -> { includes(:bids) }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,4 @@
 class User < ActiveRecord::Base
   has_many :bids
   validates :email, email: true, allow_blank: true
-  scope :blank_name, -> { where(name: [nil, '']) }
 end

--- a/spec/models/presenter/auction_spec.rb
+++ b/spec/models/presenter/auction_spec.rb
@@ -200,16 +200,6 @@ RSpec.describe Presenter::Auction do
     end
   end
 
-  describe "#in_reverse_chron_order" do
-    it 'should arrange auctions in order of descending end times' do
-      auction1 = FactoryGirl.create(:auction, end_datetime: Time.now)
-      auction2 = FactoryGirl.create(:auction, end_datetime: 2.days.from_now)
-      auction3 = FactoryGirl.create(:auction, end_datetime: 3.days.ago)
-
-      expect(Auction.in_reverse_chron_order).to eq([auction2, auction1, auction3])
-    end
-  end
-
   describe "#html_summary" do
     let(:summary) { nil }
     let(:auction) { Presenter::Auction.new(FactoryGirl.build(:auction, summary: summary)) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,25 +1,4 @@
 require 'rails_helper'
 
 RSpec.describe User do
-  describe 'named scopes' do
-    describe '.blank_name' do
-      it 'should return NULL names' do
-        u = FactoryGirl.create(:user)
-        u.update_attribute(:name, nil)
-
-        expect(User.blank_name).to include(u)
-      end
-
-      it 'should return blank string names' do
-        u = FactoryGirl.create(:user, name: '')
-        expect(User.blank_name).to include(u)
-      end
-
-      it 'should not return set names' do
-        u = FactoryGirl.create(:user)
-        expect(u.name).to_not be_blank
-        expect(User.blank_name).to_not include(u)
-      end
-    end
-  end
 end


### PR DESCRIPTION
I was about to do another bigger refactor, but I discovered these named scopes lurking around and they don't seem to be used anywhere except in their own tests. So I suggest we remove them and this is a small pull request for a change.