### PR TITLE
Ensure header is legible on mobile devices

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -274,10 +274,20 @@ nav.usa-site-navbar a {
   margin-left: 14px;
   font-size: 30px;
   color: #fff;
+
+  @media all and (max-width: 345px) {
+    display: inline-block;
+    margin-left: 0;
+    font-size: 25px;
+  }
 }
 
 #logo {
   line-height: 0;
+
+  @media all and (max-width: 345px) {
+    line-height: normal;
+  }
 }
 
 
@@ -352,6 +362,12 @@ footer {
   position: relative;
   top: 15px;
   color: #fff;
+
+  @media all and (max-width: 450px) {
+    float: none;
+    margin-top: .4em;
+    margin-bottom: .4em;
+  }
 }
 
 .header-account span {


### PR DESCRIPTION
The site's header is hard to read on mobile devices because the logo, page title, and login button are on top of each other.

The small CSS changes here are to ensure that the header is legible on all devices

*Before*
<img width="342" alt="screen shot 2016-03-09 at 7 47 55 pm" src="https://cloud.githubusercontent.com/assets/780941/13655868/981f1b7a-e630-11e5-9db4-3a071c0b9793.png">

*After*
<img width="344" alt="screen shot 2016-03-09 at 7 49 10 pm" src="https://cloud.githubusercontent.com/assets/780941/13655881/a66033d6-e630-11e5-8fdb-2f5e019f4b2c.png">
