### PR TITLE
Run Application using Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM ruby:2.2.3
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs
+RUN mkdir /app
+WORKDIR /app
+ADD Gemfile /app/Gemfile
+ADD Gemfile.lock /app/Gemfile.lock
+RUN bundle install
+RUN gem install foreman
+RUN curl https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh > /usr/local/bin/wait-for-it
+RUN chmod +x /usr/local/bin/wait-for-it
+CMD wait-for-it db:5432 && bundle exec rake db:create:all || true && \
+  bundle exec rake db:migrate db:test:prepare && \
+  bundle exec rake db:seed && \
+  foreman start -p 3000
+

--- a/README.md
+++ b/README.md
@@ -60,6 +60,21 @@ MPT_3500_GITHUB_SECRET="your-client-secret"
 
 Make sure to restart the server to register those environmental variables.
 
+### Using Docker
+
+A development instance of the Micropurchase application can be spun up quickly
+using [Docker Compose](https://docs.docker.com/compose/).  After setting your
+Github application credentials in your `.env` file as described above, start up
+the database and application server using `docker-compose`.
+
+```
+docker-compose up
+```
+
+Visit http://localhost:3000/
+
+The sample data will be populated in the database automatically.
+
 #### For deployment
 
 See the GitHub API keys section of our deployment instructions below.
@@ -72,6 +87,13 @@ bundle exec rspec
 or
 ```
 rake spec
+```
+
+#### Using Docker
+
+```
+docker-compose up -d
+docker-compose run web bundle exec rake spec
 ```
 
 ## Deployment

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ the database and application server using `docker-compose`.
 docker-compose up
 ```
 
-Visit http://localhost:3000/
+Visit http://localhost:3000/  (If running Docker within a VM using [boot2docker](https://github.com/boot2docker/boot2docker) or [Docker Machine](https://docs.docker.com/machine/overview/), use the IP address of the VM rather than localhost, e.g. `boot2docker ip` or `docker-machine ip default`.)
 
 The sample data will be populated in the database automatically.
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -21,23 +21,23 @@ default: &default
   # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: 5
 
-development:
+development: &development
   <<: *default
-  database: micropurchase_development
+  database: <%= ENV['DATABASE_NAME'] or 'micropurchase_development' %>
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.
   # When left blank, postgres will use the default role. This is
   # the same name as the operating system user that initialized the database.
-  #username: micropurchase
+  username: <%= ENV['DATABASE_USER'] or '' %>
 
   # The password associated with the postgres role (username).
-  #password:
+  password: <%= ENV['DATABASE_PASSWORD'] or '' %>
 
   # Connect on a TCP socket. Omitted by default since the client uses a
   # domain socket that doesn't need configuration. Windows does not have
   # domain sockets, so uncomment these lines.
-  #host: localhost
+  host: <%= ENV['DATABASE_HOST'] or '' %>
 
   # The TCP port the server listens on. Defaults to 5432.
   # If your server runs on a different port number, change accordingly.
@@ -56,7 +56,7 @@ development:
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test: &test
-  <<: *default
+  <<: *development
   database: micropurchase_test
 
 # As with config/secrets.yml, you never want to store sensitive information,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+db:
+   image: postgres:9
+web:
+    build: .
+    env_file: .env
+    environment:
+       DATABASE_USER: postgres
+       DATABASE_NAME: postgres
+       DATABASE_HOST: db
+    volumes:
+      - .:/app
+    ports:
+      - "3000:3000"
+    links:
+      - db


### PR DESCRIPTION
Add a Docker Compose configuration file to spin up Postgres and the
Rails application in Docker containers.

Update database configuration so it works when the database is on a
separate host, as in the docker compose configuration, or on localhost,
as when Travis CI runs the tests.

The database name, username, password, and host can be set in
environment variables.  The docker compose configuration sets the
environment variables to use a separate postgres container.