### PR TITLE
Using codeclimate_batch for reporting coverage

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,10 @@
+SimpleCov.add_filter '/.bundle'
+SimpleCov.add_filter '/spec'
+SimpleCov.add_filter '/features'
+
+if ENV['CODECLIMATE_REPO_TOKEN']
+  require 'codeclimate_batch'
+  CodeclimateBatch.start
+else
+  SimpleCov.start
+end

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,12 @@ cache: bundler
 before_script:
 - bundle exec rake db:create
 - bundle exec rake db:migrate
-script: bundle exec rake
+script: bundle exec rake $TASK
+env:
+  - TASK: rspec
+  - TASK: cucumber
+after_script:
+  - codeclimate-batch --groups 4
 addons:
   postgresql: '9.3'
   code_climate:

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ gem 'business_time'
 
 group :test do
   gem "codeclimate-test-reporter", require: nil
+  gem 'codeclimate_batch'
   gem 'webmock'
   gem 'json-schema'
   gem 'db-query-matchers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,8 @@ GEM
     cliver (0.3.2)
     codeclimate-test-reporter (0.4.8)
       simplecov (>= 0.7.1, < 1.0.0)
+    codeclimate_batch (0.4.0)
+      json
     coderay (1.1.0)
     commander (4.3.8)
       highline (~> 1.7.2)
@@ -360,6 +362,7 @@ DEPENDENCIES
   cf-app-utils
   chronic
   codeclimate-test-reporter
+  codeclimate_batch
   cucumber-rails
   database_cleaner
   db-query-matchers

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -4,6 +4,7 @@
 # instead of editing this one. Cucumber will automatically load all features/**/*.rb
 # files.
 
+require 'simplecov'
 require 'cucumber/rails'
 require 'database_cleaner'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,8 +17,8 @@
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 
-require "codeclimate-test-reporter"
-CodeClimate::TestReporter.start
+require 'simplecov'
+SimpleCov.start
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate


### PR DESCRIPTION
I think this will fix the issue with CodeClimate not reporting the coverage for the cucumber projects. I copied some of the relevant files from [another project using this gem](https://github.com/mhutter/wikimd) and it should hopefully work better at generating/merging coverage for both rake tasks on Travis