### PR TITLE
Reorganize Presenter::Auction spec

### DIFF
--- a/app/models/presenter/auction.rb
+++ b/app/models/presenter/auction.rb
@@ -162,11 +162,11 @@ module Presenter
     end
 
     def lowest_bids
-      bids.select {|b| b.amount == lowest_amount }
+      bids.select {|b| b.amount == lowest_amount }.sort_by(&:created_at)
     end
 
     def lowest_amount
-      bids.sort_by(&:amount).first.amount
+      bids.sort_by(&:amount).first.amount rescue nil
     end
 
     def html_description

--- a/app/models/presenter/bid.rb
+++ b/app/models/presenter/bid.rb
@@ -59,6 +59,11 @@ module Presenter
       end
     end
 
+    def ==(other)
+      return false unless other.is_a?(Presenter::Bid)
+      self.id == other.id
+    end
+    
     def model
       __getobj__
     end

--- a/spec/models/presenter/auction_spec.rb
+++ b/spec/models/presenter/auction_spec.rb
@@ -2,122 +2,238 @@ require 'rails_helper'
 
 RSpec.describe Presenter::Auction do
   let(:ar_auction) { FactoryGirl.create(:auction) }
+  let(:ar_bids_by_amount) { ar_auction.bids.order('amount ASC, created_at ASC') }
   let(:auction) { Presenter::Auction.new(ar_auction) }
   let(:user) { FactoryGirl.create(:user) }
+  
+  describe 'internal bid methods' do
+    context 'when there are no bids' do
+      let(:ar_auction) { FactoryGirl.create(:auction) }
 
-  describe '#veiled_bids' do
-    context 'when a single bid auction is still running' do
-      let(:ar_auction) { FactoryGirl.create(:auction, :single_bid_with_tie, :running) }
+      specify { expect(auction.bids?).to be_falsey }
+      specify { expect(auction.bid_count).to eq(0) }
+      specify { expect(auction.bids).to eq([]) }
+      specify { expect(auction.current_bid?).to be_falsey }
+      specify { expect(auction.current_bid).to be_a(Presenter::Bid::Null) }
 
-      it 'should return no bids' do
-        expect(auction.veiled_bids(user)).to match_array([])
+      it 'current_max_bid should return the starting bid for the auction' do
+        expect(auction.current_max_bid).to eq(auction.start_price - PlaceBid::BID_INCREMENT)
+      end
+      
+      specify { expect(auction.lowest_bids).to eq([]) }
+      specify { expect(auction.lowest_amount).to be_nil }
+    end
+
+    context 'when there are multiple bids' do
+      let(:ar_auction) { FactoryGirl.create(:auction, :with_bidders) }
+
+      specify { expect(auction.bids?).to be_truthy }
+      specify { expect(auction.bid_count).to eq(ar_auction.bids.count) }
+
+      it 'bids should return Presenter::Bid objects sorted by descending creation time' do
+        bids = auction.bids
+        last_create = 100.years.from_now
+
+        expect(bids).to be_an(Array)
+        bids.each do |bid|
+          expect(bid).to be_a(Presenter::Bid)
+          expect(bid.created_at).to be <= last_create
+          last_create = bid.created_at
+        end
+      end
+
+      specify { expect(auction.current_bid?).to be_truthy }
+
+      it 'current_bid should return the bid with the lowest amount' do
+        current_bid = auction.current_bid
+
+        expect(current_bid).to be_a(Presenter::Bid)
+        expect(current_bid.amount).to eq(ar_bids_by_amount.first.amount)
+        expect(current_bid.bidder_id).to eq(ar_bids_by_amount.first.bidder_id)
+      end
+
+      specify { expect(auction.current_max_bid).to eq(auction.current_bid.amount - PlaceBid::BID_INCREMENT) }
+      
+      it 'lowest_bids should return an array of the lowest amount' do
+        bids = auction.lowest_bids
+
+        expect(auction.lowest_bids).to be_an(Array)
+        expect(auction.lowest_bids.count).to eq(1)
+        expect(auction.lowest_bids.first.bidder_id).to eq(ar_bids_by_amount.first.bidder_id)
+        expect(auction.lowest_bids.first.amount).to eq(ar_bids_by_amount.first.amount)
+      end
+
+      it 'lowest_amount should return the lowest bid' do
+        expect(auction.lowest_amount).to eq(ar_bids_by_amount.first.amount)
       end
     end
 
-    context 'when a single bid auction is still running and the user has placed a bid' do
-      let(:ar_auction) { FactoryGirl.create(:auction, :single_bid_with_tie, :running) }
-      let(:last_bid) { auction.bids.last }
-      let(:last_bidder) { last_bid.bidder }
+    context 'when there are multiple low bids of the same amount' do
+      let(:ar_auction) { FactoryGirl.create(:auction, :single_bid_with_tie) }
 
-      it 'should return only the bid placed by the user' do
-        expect(auction.veiled_bids(last_bidder).map(&:id)).to match_array([last_bid].map(&:id))
+      specify { expect(auction.bids?).to be_truthy }
+      specify { expect(auction.bid_count).to eq(ar_auction.bids.count) }
+
+      it 'bids should return Presenter::Bid objects sorted by descending creation time' do
+        bids = auction.bids
+        last_create = 100.years.from_now
+
+        expect(bids).to be_an(Array)
+        bids.each do |bid|
+          expect(bid).to be_a(Presenter::Bid)
+          expect(bid.created_at).to be <= last_create
+          last_create = bid.created_at
+        end
+      end
+
+      specify { expect(auction.current_bid?).to be_truthy }
+
+      it 'current_bid should return the bid with the lowest amount and the earliest creation time' do
+        current_bid = auction.current_bid
+
+        expect(current_bid).to be_a(Presenter::Bid)
+        expect(current_bid.amount).to eq(ar_bids_by_amount.first.amount)
+        expect(current_bid.bidder_id).to eq(ar_bids_by_amount.first.bidder_id)
+      end
+
+      specify { expect(auction.current_max_bid).to eq(auction.current_bid.amount - PlaceBid::BID_INCREMENT) }
+
+      it 'lowest_bids should return an array of all bids with the lowest amount sorted by ascending creation time' do
+        lowest_bids = auction.lowest_bids
+        ar_lowest_bids = ar_bids_by_amount.select {|b| b.amount == ar_bids_by_amount.first.amount }
+        
+        expect(lowest_bids).to be_an(Array)
+        expect(lowest_bids.first).to be_a(Presenter::Bid)
+        expect(lowest_bids.count).to eq(ar_lowest_bids.count)
+        expect(lowest_bids.map(&:id)).to eq(ar_lowest_bids.map(&:id))
+        expect(lowest_bids.map(&:bidder_id)).to eq(ar_lowest_bids.map(&:bidder_id))
+      end
+
+      it 'lowest_amount should return the lowest bid' do
+        expect(auction.lowest_amount).to eq(ar_bids_by_amount.first.amount)
+      end
+    end
+  end
+  
+  describe 'type-specific bid methods' do
+    context 'for a single-bid auction' do
+      context 'when the auction is still running' do
+        let(:ar_auction) { FactoryGirl.create(:auction, :single_bid_with_tie, :running) }
+        
+        context 'when the user has not placed a bid' do
+          it 'veiled_bids should return an empty array' do
+            expect(auction.veiled_bids(user)).to match_array([])
+          end
+
+          specify { expect(auction.winning_bid).to be_nil }
+          specify { expect(auction.winning_bid_id).to be_nil }
+          specify { expect(auction.winning_bidder).to be_nil }
+          specify { expect(auction.winning_bidder_id).to be_nil }
+        end
+        
+        context 'the user has placed a bid' do
+          let(:last_bid) { auction.bids.last }
+          let(:last_bidder) { last_bid.bidder }
+
+          it 'veiled_bids should return only the bid placed by the user' do
+            expect(auction.veiled_bids(last_bidder).map(&:id)).to match_array([last_bid].map(&:id))
+          end
+
+          specify { expect(auction.winning_bid).to be_nil }
+          specify { expect(auction.winning_bidder).to be_nil }
+          specify { expect(auction.winning_bidder_id).to be_nil }
+        end
+
+        context 'when the auction has no bids' do
+          it 'veiled_bids should return an empty array' do
+            expect(auction.veiled_bids(user)).to match_array([])
+          end
+
+          specify { expect(auction.winning_bid).to be_nil }
+          specify { expect(auction.winning_bid_id).to be_nil }
+          specify { expect(auction.winning_bidder).to be_nil }
+          specify { expect(auction.winning_bidder_id).to be_nil }
+        end
+      end
+
+      context 'when the auction is closed' do
+        let(:ar_auction) { FactoryGirl.create(:auction, :single_bid_with_tie, :closed) }
+
+        it 'veiled_bids should return all bids associated with the auction' do
+          expect(auction.veiled_bids(user).map(&:id)).to match_array(auction.bids.map(&:id))
+        end
+
+        it 'winning_bid should be the bid with the lowest amount that is first' do
+          expect(auction.winning_bid).to_not be_nil
+          expect(auction.winning_bid).to be_a(Presenter::Bid)
+          expect(auction.winning_bid.bidder_id).to eq(ar_bids_by_amount.first.bidder_id)
+          expect(auction.winning_bid.amount).to eq(ar_bids_by_amount.first.amount)
+        end
+
+        specify { expect(auction.winning_bidder).to eq(auction.winning_bid.bidder) }
+        specify { expect(auction.winning_bidder_id).to eq(auction.winning_bid.bidder_id) }
+        specify { expect(auction.winning_bid_id).to eq(auction.winning_bid.id) }
       end
     end
 
-    context 'when a single bid auction has closed' do
-      let(:ar_auction) { FactoryGirl.create(:auction, :single_bid_with_tie, :closed) }
+    context 'for a regular auction' do
+      context 'when the auction is still running' do
+        context 'when the auction has no bids' do
+          let(:ar_auction) { FactoryGirl.create(:auction) }
 
-      it 'should return all bids associated with the auction' do
-        expect(auction.veiled_bids(user).map(&:id)).to match_array(auction.bids.map(&:id))
+          it 'veiled_bids should return an empty array' do
+            expect(auction.veiled_bids(user)).to eq([])
+          end
+
+          specify { expect(auction.winning_bid).to be_a(Presenter::Bid::Null) }
+          specify { expect(auction.winning_bid_id).to be_nil }
+          specify { expect(auction.winning_bidder).to be_nil }
+          specify { expect(auction.winning_bidder_id).to be_nil }          
+        end
+      
+        context 'when the auction has bids' do
+          let(:ar_auction) { FactoryGirl.create(:auction, :multi_bid, :with_bidders, :running) }
+          let(:ar_lowest_bid) { ar_bids_by_amount.first }
+          let(:user) { auction.bids.first.bidder }
+
+          it 'veiled_bids should return all bids' do
+            expect(auction.veiled_bids(user)).to eq(auction.bids)
+          end
+
+          it 'winning_bid should return the lowest bid' do
+            expect(auction.winning_bid).to be_a(Presenter::Bid)
+            expect(auction.winning_bid.amount).to eq(ar_lowest_bid.amount)
+            expect(auction.winning_bid.bidder_id).to eq(ar_lowest_bid.bidder_id)
+          end
+          
+          specify { expect(auction.winning_bid_id).to eq(ar_lowest_bid.id) }
+          specify { expect(auction.winning_bidder).to eq(ar_lowest_bid.bidder) }
+          specify { expect(auction.winning_bidder_id).to eq(ar_lowest_bid.bidder_id) }
+        end
       end
-    end
 
-    context 'when a multi-bid auction is still running' do
-      let(:ar_auction) { FactoryGirl.create(:auction, :multi_bid, :with_bidders, :running) }
+      context 'when the auction is over' do
+        let(:ar_auction) { FactoryGirl.create(:auction, :multi_bid, :with_bidders, :running) }
+        let(:ar_lowest_bid) { ar_bids_by_amount.first }
 
-      it 'should return all bids associated with the auction' do
-        expect(auction.veiled_bids(user).map(&:id)).to match_array(auction.bids.map(&:id))
-      end
-    end
+        context 'when the auction has bids' do
+          it 'veiled_bids should return fill information for all bids'
 
-    context 'when a single-bid auction has closed' do
-      let(:ar_auction) { FactoryGirl.create(:auction, :multi_bid, :with_bidders, :closed) }
-
-      it 'should return all bids associated with the auction' do
-        expect(auction.veiled_bids(user).map(&:id)).to match_array(auction.bids.map(&:id))
+          it 'winning_bid should return the lowest bid' do
+            expect(auction.winning_bid).to be_a(Presenter::Bid)
+            expect(auction.winning_bid.amount).to eq(ar_lowest_bid.amount)
+            expect(auction.winning_bid.bidder_id).to eq(ar_lowest_bid.bidder_id)
+          end
+          
+          specify { expect(auction.winning_bid_id).to eq(ar_lowest_bid.id) }
+          specify { expect(auction.winning_bidder).to eq(ar_lowest_bid.bidder) }
+          specify { expect(auction.winning_bidder_id).to eq(ar_lowest_bid.bidder_id) }
+        end
       end
     end
   end
 
-  describe '#winning_bid' do
-    let(:lowest_bid_amount) { auction.bids.sort_by {|a| a.amount}.first.amount }
-
-    context 'when the auction is a single bid auction' do
-      let(:ar_auction) { FactoryGirl.create(:auction, :single_bid_with_tie, :closed) }
-      let(:earliest_bidder) { auction.bids.sort_by {|a| a.created_at}.first }
-
-      it 'should select the earliest bid in the event of a tie' do
-        expect(auction.winning_bid.id).to eq(earliest_bidder.id)
-      end
-
-      it 'should select the lowest bid' do
-        expect(auction.winning_bid.amount).to eq(lowest_bid_amount)
-      end
-    end
-
-    context 'when the auction is a multi bid auction' do
-      let(:ar_auction) { FactoryGirl.create(:auction, :multi_bid, :with_bidders) }
-
-      it 'should select the lowest bid' do
-        expect(auction.winning_bid.amount).to eq(lowest_bid_amount)
-      end
-    end
-  end
-
-  describe '#current_bid when there are no bids' do
-    it 'return a null bid' do
-      expect(auction.current_bid).to be_a(Presenter::Bid::Null)
-    end
-  end
-
-  describe '#current_bid when there is only one bid in the timeframe' do
-    let!(:bid) { FactoryGirl.create(:bid, auction_id: ar_auction.id) }
-
-    it 'return that bid' do
-      expect(auction.current_bid).to eq(bid)
-    end
-  end
-
-  describe '#current_bid when there are multiple bids of different amounts' do
-    let!(:bids) do
-      [
-        FactoryGirl.create(:bid, auction_id: ar_auction.id, amount: 20),
-        FactoryGirl.create(:bid, auction_id: ar_auction.id, amount: 10)
-      ]
-    end
-
-    it 'return the bid with the lowest amount' do
-      expect(auction.current_bid).to eq(bids.last)
-    end
-  end
-
-  describe '#current_bid when there are multiple bids with the same amount' do
-    let!(:bids) do
-      collection = [
-        FactoryGirl.create(:bid, auction_id: ar_auction.id, amount: 10.00),
-        FactoryGirl.create(:bid, auction_id: ar_auction.id, amount: 10.00),
-        FactoryGirl.create(:bid, auction_id: ar_auction.id, amount: 10.00)
-      ]
-      collection[1].update_attribute(:created_at, (Time.now - 3.hours).utc)
-      collection
-    end
-
-    it 'return the bid with the lowest amount' do
-      expect(auction.current_bid).to eq(bids[1])
-    end
-  end
-
-  describe 'boolean methods' do
+  describe 'status methods' do
     context 'when the auction has expired' do
       let(:ar_auction) { FactoryGirl.create(:auction, :closed) }
 

--- a/spec/models/presenter/bid_spec.rb
+++ b/spec/models/presenter/bid_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe Presenter::Bid, type: :model do
+  describe 'equality' do
+    let(:bid) { FactoryGirl.create(:bid) }
+    let(:bid2) { FactoryGirl.create(:bid) }
+
+    specify { expect(Presenter::Bid.new(bid)).to eq(Presenter::Bid.new(bid)) }
+    specify { expect(Presenter::Bid.new(bid)).to_not eq(Presenter::Bid.new(bid2)) }
+    specify { expect(Presenter::Bid.new(bid)).to_not eq(bid) }
+  end
+end


### PR DESCRIPTION
I want to do a little more cleanup on the Presenter::Auction (getting rid of those `rescue nil` statements would be a good start), but I thought I would fix the tests first since they're a bit disorganized. I decided to instead group tests for related attributes by auction type and status rather than organize by a top method. This will allow me to group behavior for other auction types in the future.