### PR TITLE
Current bid amount not showing if not logged in

### DIFF
--- a/app/models/view_model/auction.rb
+++ b/app/models/view_model/auction.rb
@@ -44,7 +44,6 @@ module ViewModel
 
     # This could be in the Presenter::Auction modelm but I don't want to make that change now
     def current_bid
-      return nil if current_user.nil?
       if auction.available? && auction.single_bid?
         auction.bids.detect {|bid| bid.bidder_id == current_user.id }
       else

--- a/features/bidding.feature
+++ b/features/bidding.feature
@@ -42,6 +42,10 @@ Feature: Bidding
 
   Scenario: Logging in before bidding
     Given there is an open auction
+
+    When I visit the home page
+    Then I should see a current bid amount
+
     And I am a user with a verified SAM account
     And I sign in and verify my account information
     When I click on the "Bid" button

--- a/features/closed_auctions.feature
+++ b/features/closed_auctions.feature
@@ -8,7 +8,7 @@ Feature: Closed Auctions
     And I am allowed to bid
     And I have placed the lowest bid
     When I visit the auction page
-    Then I should see the auction had a winning bid
+    Then I should see the auction had a winning bid with name
     And I should see I am the winner
     And I should see when the auction ended
     And there should be meta tags for the closed auction
@@ -18,7 +18,7 @@ Feature: Closed Auctions
     And I am allowed to bid
     And I have placed a bid that is not the lowest
     When I visit the auction page
-    Then I should see the auction had a winning bid
+    Then I should see the auction had a winning bid with name
     Then I should see I am not the winner
     And I should see when the auction ended
     And there should be meta tags for the closed auction
@@ -28,7 +28,7 @@ Feature: Closed Auctions
     And I am allowed to bid
     And I have not placed a bid
     When I visit the auction page
-    Then I should see the auction had a winning bid
+    Then I should see the auction had a winning bid with name
     And I should not see a winner alert box
     And I should see when the auction ended
     And there should be meta tags for the closed auction
@@ -40,3 +40,11 @@ Feature: Closed Auctions
     Then I should see when the auction ended
     And I should see the auction ended with no bids
     And there should be meta tags for the closed auction
+
+  Scenario: I am not logged in
+    Given there is a closed auction
+    When I visit the home page
+    Then I should see the auction had a winning bid
+
+    When I visit the auction page
+    Then I should see the auction had a winning bid with name

--- a/features/step_definitions/auction_steps.rb
+++ b/features/step_definitions/auction_steps.rb
@@ -119,7 +119,7 @@ When(/^I submit a bid for \$(.+)$/) do |amount|
 end
 
 Then(/^I should see a current bid amount( of \$([\d\.]+))?$/) do |_, amount|
-  expect(page).to have_content("Current bid:")
+  expect(page).to have_content(/Current bid: \$[\d,\.]+/)
   expect(page).to have_content(amount) unless amount.nil?
 end
 

--- a/features/step_definitions/closed_auctions_steps.rb
+++ b/features/step_definitions/closed_auctions_steps.rb
@@ -22,7 +22,14 @@ end
 
 Then(/^I should see the auction had a winning bid$/) do
   auction = Presenter::Auction.new(@auction)
-  expect(page).to have_content("Winning bid (#{auction.current_bidder_name}):")
+  expect(page).to have_content("Winning bid: #{auction.current_bid_amount_as_currency}")
+  expect(page).not_to have_content("Current bid:")
+end
+
+
+Then(/^I should see the auction had a winning bid with name$/) do
+  auction = Presenter::Auction.new(@auction)
+  expect(page).to have_content("Winning bid (#{auction.current_bidder_name}): #{auction.current_bid_amount_as_currency}")
   expect(page).not_to have_content("Current bid:")
 end
 


### PR DESCRIPTION
Refactoring some code exposed a latent bug that would prevent non-logged-in users from seeing current and winning bid amounts. Fixed the bug and added some tests as well.

Fixes #407 cc @stvnrlly 