### PR TITLE
Disable analysis of Rake tasks

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -19,3 +19,4 @@ exclude_paths:
 - spec/**/*
 - features/**/*
 - "**/vendor/**/*"
+- "lib/tasks/**"


### PR DESCRIPTION
I don't think we want to worry about test coverage for our Rake tasks for now so disabling coverage in CodeClimate