### PR TITLE
Rebased: Setting up ActiveJob (with DJ backend) to check DUNS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,9 @@ gem 'active_model_serializers'
 gem 'business_time'
 gem 'holidays'
 gem 'factory_girl_rails'
+gem 'delayed_job_active_record'
+gem 'daemons'
+gem 'foreman'
 
 group :test do
   gem "codeclimate-test-reporter", require: nil

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,9 +107,15 @@ GEM
       nokogiri (~> 1.5)
       railties (>= 3, < 5)
     cucumber-wire (0.0.1)
-    database_cleaner (1.5.2)
+    daemons (1.2.3)
+    database_cleaner (1.5.3)
     db-query-matchers (0.4.2)
     debug_inspector (0.0.2)
+    delayed_job (4.1.1)
+      activesupport (>= 3.0, < 5.0)
+    delayed_job_active_record (4.1.0)
+      activerecord (>= 3.0, < 5)
+      delayed_job (>= 3.0, < 5)
     diff-lcs (1.2.5)
     docile (1.1.5)
     domain_name (0.5.20160310)
@@ -131,6 +137,8 @@ GEM
       i18n (~> 0.5)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
+    foreman (0.78.0)
+      thor (~> 0.19.1)
     gherkin (3.2.0)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
@@ -171,6 +179,7 @@ GEM
       mime-types (>= 1.16, < 4)
     method_source (0.8.2)
     mime-types (2.99.1)
+    mime-types-data (3.2016.0221)
     mini_portile2 (2.0.0)
     minitest (5.8.4)
     multi_json (1.11.2)
@@ -365,12 +374,15 @@ DEPENDENCIES
   codeclimate-test-reporter
   codeclimate_batch
   cucumber-rails
+  daemons
   database_cleaner
   db-query-matchers
+  delayed_job_active_record
   dotenv-rails
   email_validator
   factory_girl_rails
   faker
+  foreman
   hakiri
   holidays
   jasmine

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,7 +179,6 @@ GEM
       mime-types (>= 1.16, < 4)
     method_source (0.8.2)
     mime-types (2.99.1)
-    mime-types-data (3.2016.0221)
     mini_portile2 (2.0.0)
     minitest (5.8.4)
     multi_json (1.11.2)

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: bundle exec puma
+worker: bin/delayed_job run

--- a/app/models/update_user.rb
+++ b/app/models/update_user.rb
@@ -31,7 +31,7 @@ class UpdateUser < Struct.new(:params, :current_user)
     reckoner = SamAccountReckoner.new(user)
 
     reckoner.clear
-    reckoner.set! unless user.duns_number.blank?
+    reckoner.delay.set! unless user.duns_number.blank?
   rescue
     # do nothing
   end

--- a/bin/delayed_job
+++ b/bin/delayed_job
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
+require 'delayed/command'
+Delayed::Command.new(ARGV).daemonize

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,6 +32,8 @@ module Micropurchase
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
 
+    config.active_job.queue_adapter = :delayed_job
+
     # Don't automatically generate factories for now
     config.generators do |g|
       g.factory_girl false

--- a/db/migrate/20160420151607_create_delayed_jobs.rb
+++ b/db/migrate/20160420151607_create_delayed_jobs.rb
@@ -1,0 +1,22 @@
+class CreateDelayedJobs < ActiveRecord::Migration
+  def self.up
+    create_table :delayed_jobs, force: true do |table|
+      table.integer :priority, default: 0, null: false # Allows some jobs to jump to the front of the queue
+      table.integer :attempts, default: 0, null: false # Provides for retries, but still fail eventually.
+      table.text :handler,                 null: false # YAML-encoded string of the object that will do work
+      table.text :last_error                           # reason for last failure (See Note below)
+      table.datetime :run_at                           # When to run. Could be Time.zone.now for immediately, or sometime in the future.
+      table.datetime :locked_at                        # Set when a client is working on this object
+      table.datetime :failed_at                        # Set when all retries have failed (actually, by default, the record is deleted instead)
+      table.string :locked_by                          # Who is working on this object (if locked)
+      table.string :queue                              # The name of the queue this job is in
+      table.timestamps null: true
+    end
+
+    add_index :delayed_jobs, [:priority, :run_at], name: "delayed_jobs_priority"
+  end
+
+  def self.down
+    drop_table :delayed_jobs
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160216174015) do
+ActiveRecord::Schema.define(version: 20160420151607) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,6 +46,22 @@ ActiveRecord::Schema.define(version: 20160216174015) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "delayed_jobs", force: :cascade do |t|
+    t.integer  "priority",   default: 0, null: false
+    t.integer  "attempts",   default: 0, null: false
+    t.text     "handler",                null: false
+    t.text     "last_error"
+    t.datetime "run_at"
+    t.datetime "locked_at"
+    t.datetime "failed_at"
+    t.string   "locked_by"
+    t.string   "queue"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "delayed_jobs", ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
+
   create_table "users", force: :cascade do |t|
     t.string   "github_id"
     t.string   "duns_number"
@@ -54,8 +70,8 @@ ActiveRecord::Schema.define(version: 20160216174015) do
     t.datetime "updated_at",                           null: false
     t.string   "email"
     t.boolean  "sam_account",          default: false, null: false
-    t.string   "github_login"
     t.string   "credit_card_form_url"
+    t.string   "github_login"
   end
 
   add_index "users", ["sam_account"], name: "index_users_on_sam_account", using: :btree

--- a/features/sam_check.feature
+++ b/features/sam_check.feature
@@ -17,6 +17,7 @@ Feature: Automatically checking a user's SAM status
     When I enter a new DUNS in my profile
     And I click on the "Submit" button
     Then I should become a valid SAM user
+    When I refresh the page
     And I should not see a warning about my SAM registration
     When I visit my profile page
     Then I should see a success message that "Your DUNS number has been verified in Sam.gov"
@@ -43,8 +44,6 @@ Feature: Automatically checking a user's SAM status
     And I click on the "Submit" button
     Then I should not become a valid SAM user
     And I should see a warning that my SAM registration is not complete
-    When I visit my profile page
-    Then I should see an alert that my DUNS number was not found in Sam.gov
 
   Scenario: Negative SAM check on DUNS change
     Given I am a user without a verified SAM account

--- a/features/step_definitions/page_steps.rb
+++ b/features/step_definitions/page_steps.rb
@@ -1,3 +1,7 @@
+When(/^I refresh the page$/) do
+  visit page.current_path
+end
+
 When(/^I click on the "?([^"]+)"? button$/) do |button|
   # will click the first if there are two with same text!
   first(:link_or_button, button).click

--- a/features/step_definitions/sam_warning_steps.rb
+++ b/features/step_definitions/sam_warning_steps.rb
@@ -51,11 +51,13 @@ Given(/^a SAM check for my DUNS will (.+)$/) do |action|
 end
 
 Then(/^I should become a valid SAM user$/) do
+  Delayed::Worker.new.work_off
   @user.reload
   expect(@user).to be_sam_account
 end
 
 Then(/^I should not become a valid SAM user$/) do
+  Delayed::Worker.new.work_off
   @user.reload
   expect(@user).to_not be_sam_account
 end

--- a/lib/cloud_foundry.rb
+++ b/lib/cloud_foundry.rb
@@ -1,0 +1,26 @@
+module CloudFoundry
+  def self.raw_vcap_data
+    ENV['VCAP_APPLICATION']
+  end
+
+  def self.vcap_data
+    if is_environment?
+      JSON.parse(raw_vcap_data)
+    else
+      nil
+    end
+  end
+
+  # returns `true` if this app is running in Cloud Foundry
+  def self.is_environment?
+    !!raw_vcap_data
+  end
+
+  def self.instance_index
+    if is_environment?
+      vcap_data['instance_index']
+    else
+      nil
+    end
+  end
+end

--- a/lib/server_env.rb
+++ b/lib/server_env.rb
@@ -1,0 +1,7 @@
+require_relative 'cloud_foundry'
+
+module ServerEnv
+  def self.instance_index
+    CloudFoundry.instance_index || 0
+  end
+end

--- a/lib/tasks/cf.rake
+++ b/lib/tasks/cf.rake
@@ -1,0 +1,11 @@
+require File.expand_path('../../server_env', __FILE__)
+
+# From http://docs.cloudfoundry.org/buildpacks/ruby/ruby-tips.html#rake
+namespace :cf do
+  desc "Only run on the first application instance"
+  task :on_first_instance do
+    unless ServerEnv.instance_index == 0
+      exit(0)
+    end
+  end
+end

--- a/manifest-staging.yml
+++ b/manifest-staging.yml
@@ -10,4 +10,4 @@ applications:
     - micropurchase-staging-psql
     - micropurchase-github
     - data-dot-gov
-  command: null
+  command: script/start

--- a/manifest.yml
+++ b/manifest.yml
@@ -10,7 +10,4 @@ applications:
     - micropurchase-psql
     - micropurchase-github
     - data-dot-gov
-  command: null
-  env:
-    RAILS_ENV: production
-    RACK_ENV: production
+  command: script/start

--- a/script/start
+++ b/script/start
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+set -x
+
+# default the port, for development
+# http://stackoverflow.com/a/6859838/358804
+PORT=${PORT-3000}
+
+bin/rake cf:on_first_instance db:migrate db:seed
+foreman start -p $PORT

--- a/script/start
+++ b/script/start
@@ -7,5 +7,5 @@ set -x
 # http://stackoverflow.com/a/6859838/358804
 PORT=${PORT-3000}
 
-bin/rake cf:on_first_instance db:migrate db:seed
+bin/rake cf:on_first_instance db:migrate
 foreman start -p $PORT

--- a/spec/models/update_user_spec.rb
+++ b/spec/models/update_user_spec.rb
@@ -116,5 +116,17 @@ RSpec.describe UpdateUser do
       user.reload
       expect(user.sam_account).to eq(false)
     end
+
+    it 'calls the SamAccountReckoner through a delayed job' do
+      reckoner = double('reckoner', clear: true)
+      allow(SamAccountReckoner).to receive(:new).with(user).and_return(reckoner)
+      delayed_job = double(set!: true)
+      allow(reckoner).to receive(:delay).and_return(delayed_job)
+      
+      updater.save
+
+      expect(reckoner).to have_received(:delay)
+      expect(delayed_job).to have_received(:set!)
+    end
   end
 end


### PR DESCRIPTION
This would negate: https://github.com/18F/micropurchase/pull/440

- Sets up ActiveJob/Delayed job
- Delays a call to the `SamReckoner`

Fixes https://github.com/18F/micropurchase/issues/381