### PR TITLE
Refactor GitHubCredentials into UserProvidedService

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'rack-cors', require: 'rack/cors'
 gem 'active_model_serializers'
 gem 'business_time'
 gem 'holidays'
+gem 'factory_girl_rails'
 
 group :test do
   gem "codeclimate-test-reporter", require: nil
@@ -48,10 +49,6 @@ group :development do
   gem 'web-console', '~> 2.0'
   gem 'rails-erd'
   gem 'rubocop'
-end
-
-group :staging, :development, :test do
-  gem 'factory_girl_rails'
 end
 
 group :production, :staging do

--- a/app/concerns/user_provided_service.rb
+++ b/app/concerns/user_provided_service.rb
@@ -1,0 +1,22 @@
+module UserProvidedService
+  def credentials(service_name)
+    user_provided_service(service_name)['credentials']
+  end
+
+  def use_env_var?(force_vcap)
+    !force_vcap && (Rails.env.development? or Rails.env.test?)
+  end
+
+
+  def vcap_services
+    JSON.parse(ENV['VCAP_SERVICES'])
+  end
+
+  def user_provided_services
+    vcap_services['user-provided']
+  end
+
+  def user_provided_service(name)
+    user_provided_services.find {|service| service['name'] == name }
+  end
+end

--- a/app/models/data_dot_gov_credentials.rb
+++ b/app/models/data_dot_gov_credentials.rb
@@ -1,0 +1,11 @@
+class DataDotGovCredentials
+  extend UserProvidedService
+
+  def self.api_key(force_vcap: false)
+    if use_env_var?(force_vcap)
+      ENV['DATA_DOT_GOV_API_KEY']
+    else
+      credentials('data-dot-gov')['api_key']
+    end
+  end
+end

--- a/app/models/github_credentials.rb
+++ b/app/models/github_credentials.rb
@@ -1,31 +1,19 @@
 class GithubCredentials
+  extend UserProvidedService
+
   def self.client_id(force_vcap: false)
-    return ENV['MPT_3500_GITHUB_KEY'] if use_env_var?(force_vcap)
-    credentials['client_id']
+    if use_env_var?(force_vcap)
+      ENV['MPT_3500_GITHUB_KEY']
+    else
+      credentials('micropurchase-github')['client_id']
+    end
   end
 
   def self.secret(force_vcap: false)
-    return ENV['MPT_3500_GITHUB_SECRET'] if use_env_var?(force_vcap)
-    credentials['secret']
-  end
-
-  def self.use_env_var?(force_vcap)
-    !force_vcap && (Rails.env.development? or Rails.env.test?)
-  end
-
-  def self.credentials
-    user_provided_service('micropurchase-github')['credentials']
-  end
-
-  def self.vcap_services
-    JSON.parse(ENV['VCAP_SERVICES'])
-  end
-
-  def self.user_provided_services
-    vcap_services['user-provided']
-  end
-
-  def self.user_provided_service(name)
-    user_provided_services.find {|service| service['name'] == name }
+    if use_env_var?(force_vcap)
+      ENV['MPT_3500_GITHUB_SECRET']
+    else
+      credentials('micropurchase-github')['secret']
+    end
   end
 end

--- a/app/models/sam_account_reckoner.rb
+++ b/app/models/sam_account_reckoner.rb
@@ -29,6 +29,6 @@ class SamAccountReckoner < Struct.new(:user)
   end
 
   def client
-    @client ||= Samwise::Client.new
+    @client ||= Samwise::Client.new(api_key: DataDotGovCredentials.api_key)
   end
 end

--- a/manifest-staging.yml
+++ b/manifest-staging.yml
@@ -9,7 +9,5 @@ applications:
   services:
     - micropurchase-staging-psql
     - micropurchase-github
+    - data-dot-gov
   command: null
-  env:
-    RAILS_ENV: staging
-    RACK_ENV: staging

--- a/manifest.yml
+++ b/manifest.yml
@@ -9,6 +9,7 @@ applications:
   services:
     - micropurchase-psql
     - micropurchase-github
+    - data-dot-gov
   command: null
   env:
     RAILS_ENV: production

--- a/spec/models/data_dot_gov_credentials_spec.rb
+++ b/spec/models/data_dot_gov_credentials_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe DataDotGovCredentials do
+  let(:vcap_json) do
+    JSON.parse(File.read('spec/support/vcap_services.json'))
+  end
+  let(:data_dot_gov_api_key) do
+    data_dot_gov = vcap_json['user-provided']
+      .find {|service| service['name'] == 'data-dot-gov'}
+
+    data_dot_gov['credentials']['api_key']
+  end
+
+  describe '::api_key' do
+    let(:api_key) { DataDotGovCredentials.api_key(force_vcap: true) }
+    it 'returns a string' do
+      expect(api_key).to eq(data_dot_gov_api_key)
+    end
+  end
+end

--- a/spec/models/github_credentials_spec.rb
+++ b/spec/models/github_credentials_spec.rb
@@ -1,17 +1,27 @@
 require 'rails_helper'
 
 RSpec.describe GithubCredentials do
+  let(:vcap_json) do
+    JSON.parse(File.read('spec/support/vcap_services.json'))
+  end
+  let(:github) do
+    vcap_json['user-provided']
+      .find {|service| service['name'] == 'micropurchase-github'}
+  end
+  let(:github_secret) { github['credentials']['secret'] }
+  let(:github_client_id) { github['credentials']['client_id'] }
+
   describe '::secret' do
     let(:secret) { GithubCredentials.secret(force_vcap: true) }
     it 'returns a string' do
-      expect(secret).to be_a(String)
+      expect(secret).to eq(github_secret)
     end
   end
 
   describe '::client_id' do
     let(:client_id) { GithubCredentials.client_id(force_vcap: true) }
     it 'returns a string' do
-      expect(client_id).to be_a(String)
+      expect(client_id).to eq(github_client_id)
     end
   end
 end

--- a/spec/support/vcap_services.json
+++ b/spec/support/vcap_services.json
@@ -30,6 +30,15 @@
     "name": "micropurchase-github",
     "syslog_drain_url": "",
     "tags": []
-   }
+  },
+  {
+   "credentials": {
+    "api_key": "fakeapikey"
+   },
+   "label": "user-provided",
+   "name": "data-dot-gov",
+   "syslog_drain_url": "",
+   "tags": []
+  }
   ]
 }


### PR DESCRIPTION
This PR refactors some common VCAP parsing code into its own class. It also creates a small PORO for loading getting the data.gov api key from the `data-dot-gov` user-provided-service

TODO: 

- ~~load the data.gov api key into `ENV['DATA_DOT_DOV_API_KEY']` in an initializer~~
- ~~test `UserProvidedService` and/or `DataDotGovCredentials`~~