### PR TITLE
Refactor logic around `winning_bid`

### DIFF
--- a/app/models/auction.rb
+++ b/app/models/auction.rb
@@ -1,11 +1,29 @@
 class Auction < ActiveRecord::Base
   has_many :bids
   has_many :bidders, through: :bids
-  enum result: {not_applicable: 0, accepted: 1, rejected: 2}
-  enum type: {single_bid: 0, multi_bid: 1}
-  enum awardee_paid_status: {not_paid: 0, paid: 1}
-  enum published: {unpublished: 0, published: 1}
+  enum result: { not_applicable: 0, accepted: 1, rejected: 2 }
+  enum type: { single_bid: 0, multi_bid: 1 }
+  enum awardee_paid_status: { not_paid: 0, paid: 1 }
+  enum published: { unpublished: 0, published: 1 }
 
   # Disable STI
   self.inheritance_column = :__disabled
+
+  def winning_bid
+    if single_bid? && AuctionStatus.new(self).available?
+      nil
+    else
+      lowest_bid
+    end
+  end
+
+  def lowest_bid
+    bids.select {|b| b.amount == lowest_amount }.sort_by(&:created_at).first
+  end
+
+  private
+
+  def lowest_amount
+    bids.sort_by(&:amount).first.try(:amount)
+  end
 end

--- a/app/models/auction_status.rb
+++ b/app/models/auction_status.rb
@@ -1,0 +1,41 @@
+class AuctionStatus
+  def initialize(auction)
+    @auction = auction
+  end
+
+  def available?
+    started_in_past? && ends_in_future?
+  end
+
+  def over?
+    auction.end_datetime.present? && ended_in_past?
+  end
+
+  def future?
+    auction.start_datetime.nil? || starts_in_future?
+  end
+
+  def expiring?
+    available? && auction.end_datetime < (Time.current + 12.hours)
+  end
+
+  private
+
+  attr_reader :auction
+
+  def ends_in_future?
+    auction.end_datetime && auction.end_datetime > Time.current
+  end
+
+  def ended_in_past?
+    auction.end_datetime < Time.current
+  end
+
+  def starts_in_future?
+    auction.start_datetime > Time.current
+  end
+
+  def started_in_past?
+    auction.start_datetime && auction.start_datetime < Time.current
+  end
+end

--- a/app/models/place_bid.rb
+++ b/app/models/place_bid.rb
@@ -47,14 +47,6 @@ class PlaceBid < Struct.new(:params, :current_user)
     Presenter::Auction.new(auction).max_allowed_bid
   end
 
-  def auction_is_single_bid?
-    auction.type == 'single_bid'
-  end
-
-  def auction_is_multi_bid?
-    auction.type == 'multi_bid'
-  end
-
   def bidder_already_bid_on_this_auction?
     return false if auction.bids.empty?
 
@@ -63,7 +55,7 @@ class PlaceBid < Struct.new(:params, :current_user)
 
   # rubocop:disable Style/IfUnlessModifier, Style/GuardClause
   def validate_bid_data
-    if auction_is_single_bid? && bidder_already_bid_on_this_auction?
+    if auction.single_bid? && bidder_already_bid_on_this_auction?
       fail UnauthorizedError, 'You can only bid once in a single-bid auction.'
     end
 
@@ -83,7 +75,7 @@ class PlaceBid < Struct.new(:params, :current_user)
       fail UnauthorizedError, 'Bid amount out of range'
     end
 
-    if auction_is_multi_bid? && amount > max_allowed_bid
+    if auction.multi_bid? && amount > max_allowed_bid
       fail UnauthorizedError, "Bids cannot be greater than the current max bid"
     end
   end

--- a/app/models/presenter/auction.rb
+++ b/app/models/presenter/auction.rb
@@ -33,6 +33,14 @@ module Presenter
     delegate :bidder_name, :bidder_duns_number,
              to: :lowest_bid, prefix: :lowest
 
+    delegate(
+      :future?,
+      :expiring?,
+      :over?,
+      :available?,
+      to: :auction_status
+    )
+
     def bids?
       bid_count > 0
     end
@@ -104,22 +112,6 @@ module Presenter
       model.winning_bid.bidder_id
     end
 
-    def available?
-      AuctionStatus.new(model).available?
-    end
-
-    def expiring?
-      AuctionStatus.new(model).expiring?
-    end
-
-    def future?
-      AuctionStatus.new(model).future?
-    end
-
-    def over?
-      AuctionStatus.new(model).over?
-    end
-
     def html_description
       return '' if description.blank?
       markdown.render(description)
@@ -158,6 +150,10 @@ module Presenter
       else
         "in #{distance}"
       end
+    end
+
+    def auction_status
+      AuctionStatus.new(model)
     end
 
     def decorated_bid(bid)

--- a/app/models/presenter/auction.rb
+++ b/app/models/presenter/auction.rb
@@ -23,8 +23,8 @@ module Presenter
     delegate :title, :created_at, :start_datetime, :end_datetime,
              :github_repo, :issue_url, :summary, :description,
              :delivery_deadline, :start_price, :published, :to_param,
-             :model_name, :to_key, :to_model, :type, :id,
-             :read_attribute_for_serialization,
+             :model_name, :to_key, :to_model, :type, :id, :single_bid?, :multi_bid?,
+             :read_attribute_for_serialization, :lowest_bid,
              to: :model
 
     delegate :amount, :time,
@@ -39,9 +39,9 @@ module Presenter
 
     def bids
       @bids ||= model.bids.to_a
-                     .map {|bid| Presenter::Bid.new(bid) }
-                     .sort_by(&:created_at)
-                     .reverse
+        .map {|bid| decorated_bid(bid) }
+        .sort_by(&:created_at)
+        .reverse
     end
 
     def veiled_bids(user)
@@ -50,7 +50,7 @@ module Presenter
       # Presenter::Bid to veil certain attributes.
 
       # redact all bids if auction is still running and type is single bid
-      if available? && single_bid?
+      if available? && model.single_bid?
         return [] if user.nil?
         return bids.select {|bid| bid.bidder_id == user.id}
       end
@@ -92,58 +92,32 @@ module Presenter
       time_in_human(model.delivery_deadline)
     end
 
-    # rubocop:disable Style/DoubleNegation
-    def available?
-      !!(
-        (model.start_datetime && !future?) &&
-          (model.end_datetime && !over?)
-      )
-    end
-    # rubocop:enable Style/DoubleNegation
-
-    def over?
-      model.end_datetime < Time.now
-    end
-
-    def future?
-      model.start_datetime > Time.now
-    end
-
-    def expiring?
-      available? && model.end_datetime < 12.hours.from_now
-    end
-
     def winning_bid
-      return Presenter::Bid::Null.new if single_bid? && available?
-      lowest_bid
-    end
-
-    def winning_bidder_id
-      winning_bid.bidder_id
-    end
-
-    def winning_bid_id
-      winning_bid.id
-    end
-
-    def single_bid?
-      model.type == 'single_bid'
-    end
-
-    def multi_bid?
-      model.type == 'multi_bid'
+      decorated_bid(model.winning_bid)
     end
 
     def lowest_bid
-      @lowest_bid ||= (lowest_bids.first || Presenter::Bid::Null.new)
-    end
-    
-    def lowest_bids
-      bids.select {|b| b.amount == lowest_amount }.sort_by(&:created_at)
+      decorated_bid(model.lowest_bid)
     end
 
-    def lowest_amount
-      bids.sort_by(&:amount).first.amount rescue nil
+    def winning_bidder_id
+      model.winning_bid.bidder_id
+    end
+
+    def available?
+      AuctionStatus.new(model).available?
+    end
+
+    def expiring?
+      AuctionStatus.new(model).expiring?
+    end
+
+    def future?
+      AuctionStatus.new(model).future?
+    end
+
+    def over?
+      AuctionStatus.new(model).over?
     end
 
     def html_description
@@ -183,6 +157,14 @@ module Presenter
         "#{distance} ago"
       else
         "in #{distance}"
+      end
+    end
+
+    def decorated_bid(bid)
+      if bid.present?
+        Presenter::Bid.new(bid)
+      else
+        Presenter::Bid::Null.new
       end
     end
 

--- a/app/models/presenter/bid.rb
+++ b/app/models/presenter/bid.rb
@@ -52,11 +52,11 @@ module Presenter
     end
 
     def is_winning?
-      model.id == presenter_auction.winning_bid_id
+      model.id == presenter_auction.winning_bid.id
     end
 
     def winning_status
-      if presenter_auction.single_bid? && presenter_auction.available?
+      if auction.single_bid? && presenter_auction.available?
         return 'n/a'
       else
         is_winning?
@@ -74,6 +74,10 @@ module Presenter
 
     class Null
       NULL = "&nbsp;".html_safe
+
+      def created_at
+        nil
+      end
 
       def time
         NULL

--- a/app/models/view_model/auction.rb
+++ b/app/models/view_model/auction.rb
@@ -30,8 +30,7 @@ module ViewModel
       user_can_bid? || current_user.nil?
     end
 
-    delegate :amount,
-             to: :highlighted_bid, prefix: true
+    delegate :amount, to: :highlighted_bid, prefix: true
 
     # This is the single bid we display under the auction as an important
     # summary of the bidding. Unlike the lowest bid, it differs based
@@ -51,7 +50,7 @@ module ViewModel
     def highlighted_bidder_name
       highlighted_bid.bidder_name
     end
-    
+
     def user_is_bidder?
       user_bids_obj.has_bid?
     end

--- a/app/serializers/admin/auction_serializer.rb
+++ b/app/serializers/admin/auction_serializer.rb
@@ -21,7 +21,7 @@ module Admin
                :billable_to
 
     def delivery_deadline
-      object.delivery_deadline.iso8601
+      object.delivery_deadline.try(:iso8601)
     end
 
     def created_at

--- a/features/step_definitions/auction_steps.rb
+++ b/features/step_definitions/auction_steps.rb
@@ -55,7 +55,7 @@ end
 Then(/^I should see the winning bid for the auction$/) do
   auction = Presenter::Auction.new(@auction)
   lowest_bid_amount = ApplicationController.helpers.number_to_currency(
-    auction.lowest_amount
+    auction.lowest_bid.amount
   )
 
   expect(page).to have_text(lowest_bid_amount)

--- a/spec/factories/auctions.rb
+++ b/spec/factories/auctions.rb
@@ -2,7 +2,6 @@ FactoryGirl.define do
   factory :auction do
     start_datetime { Time.now - 3.days }
     end_datetime { Time.now + 3.days }
-    delivery_deadline { 5.business_days.after(end_datetime) }
     delivery_url { nil }
     awardee_paid_status { :not_paid }
     result { :not_applicable }
@@ -66,6 +65,11 @@ FactoryGirl.define do
           auction.bids << FactoryGirl.create(:bid, bidder_id: bidder_id, auction: auction, amount: amount)
         end
       end
+    end
+
+    trait :available do
+      start_datetime { Time.now - 2.days }
+      end_datetime { Time.now + 2.days }
     end
 
     trait :closed do

--- a/spec/models/auction_spec.rb
+++ b/spec/models/auction_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+describe Auction do
+  describe "#lowest_bid" do
+    context "multiple bids" do
+      it "returns bid with lowest amount" do
+        auction = FactoryGirl.create(:auction)
+        low_bid = FactoryGirl.create(:bid, auction: auction, amount: 1)
+        _high = FactoryGirl.create(:bid, auction: auction, amount: 10000)
+
+        expect(auction.lowest_bid).to eq (low_bid)
+      end
+    end
+
+    context "no bids" do
+      it "returns nil" do
+        auction = FactoryGirl.create(:auction)
+
+        expect(auction.lowest_bid).to be_nil
+      end
+    end
+
+    context "multiple bids with same amount" do
+      it "returns first created bid" do
+        auction = FactoryGirl.create(:auction)
+        _second_bid = FactoryGirl.create(:bid, auction: auction, created_at: Time.current, amount: 1)
+        first_bid = FactoryGirl.create(:bid, auction: auction, created_at: 1.hour.ago, amount: 1)
+
+        expect(auction.lowest_bid).to eq (first_bid)
+      end
+    end
+  end
+
+  describe "#winning_bid" do
+    context "auction is single bid and open" do
+      it "returns nil" do
+        auction = FactoryGirl.create(:auction, :single_bid, :running)
+
+        expect(auction.winning_bid).to be_nil
+      end
+    end
+
+    context "auction is single bid and closed" do
+      it "returns lowest bid" do
+        auction = FactoryGirl.create(:auction, :single_bid, :closed)
+        low_bid = FactoryGirl.create(:bid, auction: auction, amount: 1)
+        _high = FactoryGirl.create(:bid, auction: auction, amount: 10000)
+
+        expect(auction.winning_bid).to eq low_bid
+      end
+    end
+
+    context "auction is multi bid and open" do
+      it "returns lowest bid" do
+        auction = FactoryGirl.create(:auction, :available, :multi_bid)
+        low_bid = FactoryGirl.create(:bid, auction: auction, amount: 1)
+        _high = FactoryGirl.create(:bid, auction: auction, amount: 10000)
+
+        expect(auction.winning_bid).to eq low_bid
+      end
+    end
+  end
+end

--- a/spec/models/auction_status_spec.rb
+++ b/spec/models/auction_status_spec.rb
@@ -1,0 +1,176 @@
+require "rails_helper"
+
+describe AuctionStatus do
+  describe "#available?" do
+    context "start datetime in past, end datetime in future" do
+      it "is true" do
+        auction = FactoryGirl.build(:auction, start_datetime: yesterday, end_datetime: tomorrow)
+
+        status = AuctionStatus.new(auction)
+
+        expect(status).to be_available
+      end
+
+      context "start datetime in past, end datetime in past" do
+        it "is false" do
+          auction = FactoryGirl.build(:auction, start_datetime: yesterday, end_datetime: yesterday)
+
+          status = AuctionStatus.new(auction)
+
+          expect(status).not_to be_available
+        end
+      end
+
+
+      context "start datetime in future, end datetime in future" do
+        it "is false" do
+          auction = FactoryGirl.build(:auction, start_datetime: tomorrow, end_datetime: tomorrow)
+
+          status = AuctionStatus.new(auction)
+
+          expect(status).not_to be_available
+        end
+      end
+
+      context "auction does not have a start date time" do
+        it "is false" do
+          auction = FactoryGirl.build(:auction, start_datetime: nil, end_datetime: tomorrow)
+
+          status = AuctionStatus.new(auction)
+
+          expect(status).not_to be_available
+        end
+      end
+
+      context "auction does not have an end datetime" do
+        it "is false" do
+          auction = FactoryGirl.build(:auction, start_datetime: tomorrow, end_datetime: nil)
+
+          status = AuctionStatus.new(auction)
+
+          expect(status).not_to be_available
+        end
+      end
+    end
+
+    describe "#over?" do
+      context "end datetime is in past" do
+        it "is true" do
+          auction = FactoryGirl.build(:auction, end_datetime: yesterday)
+
+          status = AuctionStatus.new(auction)
+
+          expect(status).to be_over
+        end
+      end
+
+      context "end datetime is in future" do
+        it "is false" do
+          auction = FactoryGirl.build(:auction, end_datetime: tomorrow)
+
+          status = AuctionStatus.new(auction)
+
+          expect(status).not_to be_over
+        end
+      end
+
+      context "end datetime is nil" do
+        it "is false" do
+          auction = FactoryGirl.build(:auction, end_datetime: nil)
+
+          status = AuctionStatus.new(auction)
+
+          expect(status).not_to be_over
+        end
+      end
+    end
+
+    describe "#future?" do
+      context "start datetime is in future" do
+        it "is true" do
+          auction = FactoryGirl.build(:auction, start_datetime: tomorrow)
+
+          status = AuctionStatus.new(auction)
+
+          expect(status).to be_future
+        end
+      end
+
+      context "start datetime is in past" do
+        it "is false" do
+          auction = FactoryGirl.build(:auction, start_datetime: yesterday)
+
+          status = AuctionStatus.new(auction)
+
+          expect(status).not_to be_future
+        end
+      end
+
+      context "start datetime is nil" do
+        it "is true" do
+          auction = FactoryGirl.build(:auction, start_datetime: nil)
+
+          status = AuctionStatus.new(auction)
+
+          expect(status).to be_future
+        end
+      end
+    end
+
+    describe "expiring?" do
+      context "auction in progress and expiring in less than 12 hours" do
+        it "is true" do
+          auction = FactoryGirl.build(
+            :auction,
+            start_datetime: yesterday,
+            end_datetime: one_hour_from_now
+          )
+
+          status = AuctionStatus.new(auction)
+
+          expect(status).to be_expiring
+        end
+      end
+
+      context "auction not started and expiring in less than 12 hours" do
+        it "is false" do
+          auction = FactoryGirl.build(
+            :auction,
+            start_datetime: tomorrow,
+            end_datetime: one_hour_from_now
+          )
+
+          status = AuctionStatus.new(auction)
+
+          expect(status).not_to be_expiring
+        end
+      end
+
+      context "auction in progress and expiring in more than 12 hours" do
+        it "is false" do
+          auction = FactoryGirl.build(
+            :auction,
+            start_datetime: yesterday,
+            end_datetime: tomorrow
+          )
+
+          status = AuctionStatus.new(auction)
+
+          expect(status).not_to be_expiring
+        end
+      end
+    end
+
+    def yesterday
+      @_yesterday ||= Time.current - 1.day
+    end
+
+    def tomorrow
+      @_tomorrow ||= Time.current + 1.day
+    end
+
+    def one_hour_from_now
+      @_one_hour_from_now ||= Time.current + 1.hour
+    end
+  end
+end

--- a/spec/models/presenter/auction_spec.rb
+++ b/spec/models/presenter/auction_spec.rb
@@ -5,126 +5,18 @@ RSpec.describe Presenter::Auction do
   let(:ar_bids_by_amount) { ar_auction.bids.order('amount ASC, created_at ASC') }
   let(:auction) { Presenter::Auction.new(ar_auction) }
   let(:user) { FactoryGirl.create(:user) }
-  
-  describe 'internal bid methods' do
-    context 'when there are no bids' do
-      let(:ar_auction) { FactoryGirl.create(:auction) }
 
-      specify { expect(auction.bids?).to be_falsey }
-      specify { expect(auction.bid_count).to eq(0) }
-      specify { expect(auction.bids).to eq([]) }
-      specify { expect(auction.lowest_bid).to be_a(Presenter::Bid::Null) }
-
-      it 'max_allowed_bid should return the starting bid for the auction' do
-        expect(auction.max_allowed_bid).to eq(auction.start_price - PlaceBid::BID_INCREMENT)
-      end
-      
-      specify { expect(auction.lowest_bids).to eq([]) }
-      specify { expect(auction.lowest_amount).to be_nil }
-    end
-
-    context 'when there are multiple bids' do
-      let(:ar_auction) { FactoryGirl.create(:auction, :with_bidders) }
-
-      specify { expect(auction.bids?).to be_truthy }
-      specify { expect(auction.bid_count).to eq(ar_auction.bids.count) }
-
-      it 'bids should return Presenter::Bid objects sorted by descending creation time' do
-        bids = auction.bids
-        last_create = 100.years.from_now
-
-        expect(bids).to be_an(Array)
-        bids.each do |bid|
-          expect(bid).to be_a(Presenter::Bid)
-          expect(bid.created_at).to be <= last_create
-          last_create = bid.created_at
-        end
-      end
-
-      it 'lowest_bid should return the bid with the lowest amount' do
-        lowest_bid = auction.lowest_bid
-
-        expect(lowest_bid).to be_a(Presenter::Bid)
-        expect(lowest_bid.amount).to eq(ar_bids_by_amount.first.amount)
-        expect(lowest_bid.bidder_id).to eq(ar_bids_by_amount.first.bidder_id)
-      end
-
-      specify { expect(auction.max_allowed_bid).to eq(auction.lowest_bid.amount - PlaceBid::BID_INCREMENT) }
-      
-      it 'lowest_bids should return an array of the lowest amount' do
-        bids = auction.lowest_bids
-
-        expect(auction.lowest_bids).to be_an(Array)
-        expect(auction.lowest_bids.count).to eq(1)
-        expect(auction.lowest_bids.first.bidder_id).to eq(ar_bids_by_amount.first.bidder_id)
-        expect(auction.lowest_bids.first.amount).to eq(ar_bids_by_amount.first.amount)
-      end
-
-      it 'lowest_amount should return the lowest bid' do
-        expect(auction.lowest_amount).to eq(ar_bids_by_amount.first.amount)
-      end
-    end
-
-    context 'when there are multiple low bids of the same amount' do
-      let(:ar_auction) { FactoryGirl.create(:auction, :single_bid_with_tie) }
-
-      specify { expect(auction.bids?).to be_truthy }
-      specify { expect(auction.bid_count).to eq(ar_auction.bids.count) }
-
-      it 'bids should return Presenter::Bid objects sorted by descending creation time' do
-        bids = auction.bids
-        last_create = 100.years.from_now
-
-        expect(bids).to be_an(Array)
-        bids.each do |bid|
-          expect(bid).to be_a(Presenter::Bid)
-          expect(bid.created_at).to be <= last_create
-          last_create = bid.created_at
-        end
-      end
-
-      it 'lowest_bid should return the bid with the lowest amount and the earliest creation time' do
-        lowest_bid = auction.lowest_bid
-
-        expect(lowest_bid).to be_a(Presenter::Bid)
-        expect(lowest_bid.amount).to eq(ar_bids_by_amount.first.amount)
-        expect(lowest_bid.bidder_id).to eq(ar_bids_by_amount.first.bidder_id)
-      end
-
-      specify { expect(auction.max_allowed_bid).to eq(auction.lowest_bid.amount - PlaceBid::BID_INCREMENT) }
-
-      it 'lowest_bids should return an array of all bids with the lowest amount sorted by ascending creation time' do
-        lowest_bids = auction.lowest_bids
-        ar_lowest_bids = ar_bids_by_amount.select {|b| b.amount == ar_bids_by_amount.first.amount }
-        
-        expect(lowest_bids).to be_an(Array)
-        expect(lowest_bids.first).to be_a(Presenter::Bid)
-        expect(lowest_bids.count).to eq(ar_lowest_bids.count)
-        expect(lowest_bids.map(&:id)).to eq(ar_lowest_bids.map(&:id))
-        expect(lowest_bids.map(&:bidder_id)).to eq(ar_lowest_bids.map(&:bidder_id))
-      end
-
-      it 'lowest_amount should return the lowest bid' do
-        expect(auction.lowest_amount).to eq(ar_bids_by_amount.first.amount)
-      end
-    end
-  end
-  
   describe 'type-specific bid methods' do
     context 'for a single-bid auction' do
       context 'when the auction is still running' do
         let(:ar_auction) { FactoryGirl.create(:auction, :single_bid_with_tie, :running) }
-        
+
         context 'when the user has not placed a bid' do
           it 'veiled_bids should return an empty array' do
             expect(auction.veiled_bids(user)).to match_array([])
           end
-
-          specify { expect(auction.winning_bid).to be_a(Presenter::Bid::Null) }
-          specify { expect(auction.winning_bid_id).to be_nil }
-          specify { expect(auction.winning_bidder_id).to be_nil }
         end
-        
+
         context 'the user has placed a bid' do
           let(:last_bid) { auction.bids.last }
           let(:last_bidder) { last_bid.bidder }
@@ -132,233 +24,140 @@ RSpec.describe Presenter::Auction do
           it 'veiled_bids should return only the bid placed by the user' do
             expect(auction.veiled_bids(last_bidder).map(&:id)).to match_array([last_bid].map(&:id))
           end
-
-          specify { expect(auction.winning_bid).to be_a(Presenter::Bid::Null) }
-          specify { expect(auction.winning_bid_id).to be_nil }
-          specify { expect(auction.winning_bidder_id).to be_nil }
         end
 
         context 'when the auction has no bids' do
           it 'veiled_bids should return an empty array' do
             expect(auction.veiled_bids(user)).to match_array([])
           end
-
-          specify { expect(auction.winning_bid).to be_a(Presenter::Bid::Null) }
-          specify { expect(auction.winning_bid_id).to be_nil }
-          specify { expect(auction.winning_bidder_id).to be_nil }
-        end
-      end
-
-      context 'when the auction is closed' do
-        let(:ar_auction) { FactoryGirl.create(:auction, :single_bid_with_tie, :closed) }
-
-        it 'veiled_bids should return all bids associated with the auction' do
-          expect(auction.veiled_bids(user).map(&:id)).to match_array(auction.bids.map(&:id))
         end
 
-        it 'winning_bid should be the bid with the lowest amount that is first' do
-          expect(auction.winning_bid).to_not be_nil
-          expect(auction.winning_bid).to be_a(Presenter::Bid)
-          expect(auction.winning_bid.bidder_id).to eq(ar_bids_by_amount.first.bidder_id)
-          expect(auction.winning_bid.amount).to eq(ar_bids_by_amount.first.amount)
-        end
+        context 'when the auction is closed' do
+          let(:ar_auction) { FactoryGirl.create(:auction, :single_bid_with_tie, :closed) }
 
-        specify { expect(auction.winning_bidder_id).to eq(auction.winning_bid.bidder_id) }
-        specify { expect(auction.winning_bid_id).to eq(auction.winning_bid.id) }
-      end
-    end
-
-    context 'for a regular auction' do
-      context 'when the auction is still running' do
-        context 'when the auction has no bids' do
-          let(:ar_auction) { FactoryGirl.create(:auction) }
-
-          it 'veiled_bids should return an empty array' do
-            expect(auction.veiled_bids(user)).to eq([])
+          it 'veiled_bids should return all bids associated with the auction' do
+            expect(auction.veiled_bids(user).map(&:id)).to match_array(auction.bids.map(&:id))
           end
-
-          specify { expect(auction.winning_bid).to be_a(Presenter::Bid::Null) }
-          specify { expect(auction.winning_bid_id).to be_nil }
-          specify { expect(auction.winning_bidder_id).to be_nil }          
         end
-      
-        context 'when the auction has bids' do
-          let(:ar_auction) { FactoryGirl.create(:auction, :multi_bid, :with_bidders, :running) }
-          let(:ar_lowest_bid) { ar_bids_by_amount.first }
-          let(:user) { auction.bids.first.bidder }
 
-          it 'veiled_bids should return all bids' do
-            expect(auction.veiled_bids(user)).to eq(auction.bids)
-          end
+        context 'for a regular auction' do
+          context 'when the auction is still running' do
+            context 'when the auction has no bids' do
+              let(:ar_auction) { FactoryGirl.create(:auction) }
 
-          it 'winning_bid should return the lowest bid' do
-            expect(auction.winning_bid).to be_a(Presenter::Bid)
-            expect(auction.winning_bid.amount).to eq(ar_lowest_bid.amount)
-            expect(auction.winning_bid.bidder_id).to eq(ar_lowest_bid.bidder_id)
+              it 'veiled_bids should return an empty array' do
+                expect(auction.veiled_bids(user)).to eq([])
+              end
+            end
+            context 'when the auction has bids' do
+              let(:ar_auction) { FactoryGirl.create(:auction, :multi_bid, :with_bidders, :running) }
+              let(:ar_lowest_bid) { ar_bids_by_amount.first }
+              let(:user) { auction.bids.first.bidder }
+
+              it 'veiled_bids should return all bids' do
+                expect(auction.veiled_bids(user)).to eq(auction.bids)
+              end
+            end
           end
-          
-          specify { expect(auction.winning_bid_id).to eq(ar_lowest_bid.id) }
-          specify { expect(auction.winning_bidder_id).to eq(ar_lowest_bid.bidder_id) }
         end
       end
 
-      context 'when the auction is over' do
-        let(:ar_auction) { FactoryGirl.create(:auction, :multi_bid, :with_bidders, :running) }
-        let(:ar_lowest_bid) { ar_bids_by_amount.first }
+      describe "#html_summary" do
+        let(:summary) { nil }
+        let(:auction) { Presenter::Auction.new(FactoryGirl.build(:auction, summary: summary)) }
 
-        context 'when the auction has bids' do
-          it 'veiled_bids should return fill information for all bids'
+        it 'should return an empty string if the summary is blank' do
+          expect(auction.html_summary).to be_blank
+        end
 
-          it 'winning_bid should return the lowest bid' do
-            expect(auction.winning_bid).to be_a(Presenter::Bid)
-            expect(auction.winning_bid.amount).to eq(ar_lowest_bid.amount)
-            expect(auction.winning_bid.bidder_id).to eq(ar_lowest_bid.bidder_id)
+        context 'bold text' do
+          let(:summary) { 'This is **bold** text' }
+
+          it 'should render correctly' do
+            expect(auction.html_summary).to match("<strong>bold</strong>")
           end
-          
-          specify { expect(auction.winning_bid_id).to eq(ar_lowest_bid.id) }
-          specify { expect(auction.winning_bidder_id).to eq(ar_lowest_bid.bidder_id) }
+        end
+
+        context 'italicized text' do
+          let(:summary) { 'This is _italic_ text' }
+
+          it 'should render correctly' do
+            expect(auction.html_summary).to match('<em>italic</em>')
+          end
+        end
+
+        context 'autolinks' do
+          let(:summary) { 'Please visit http://18f.gov anytime' }
+
+          it 'should render correctly' do
+            expect(auction.html_summary).to match('<a href="http://18f.gov">http://18f.gov</a>')
+          end
+        end
+
+        context 'ignoring underscores in words' do
+          let(:summary) { 'This_is_a_test' }
+
+          it 'should not render as italicized' do
+            expect(auction.html_summary).to_not match('<em>')
+          end
+        end
+
+        context 'table rendering' do
+          let(:summary) { "First Header|Second Header\n------------- | -------------\nContent Cell  | Content Cell\n" }
+
+          it 'should render a table element' do
+            expect(auction.html_summary).to match('<table>')
+          end
         end
       end
-    end
-  end
 
-  describe 'status methods' do
-    context 'when the auction has expired' do
-      let(:ar_auction) { FactoryGirl.create(:auction, :closed) }
+      describe '#html_description' do
+        let(:description) { nil }
+        let(:auction) { Presenter::Auction.new(FactoryGirl.build(:auction, description: description)) }
 
-      specify { expect(auction).to_not be_available }
-      specify { expect(auction).to_not be_expiring }
-      specify { expect(auction).to_not be_future }
-      specify { expect(auction).to be_over }
-    end
+        it 'should return an empty string if the description is blank' do
+          expect(auction.html_description).to be_blank
+        end
 
-    context 'when the auction has not started yet' do
-      let(:ar_auction) do
-        FactoryGirl.create(:auction,
-                           :future,
-                           start_datetime: 1.hour.from_now,
-                           end_datetime: 3.hours.from_now)
-      end
+        context 'bold text' do
+          let(:description) { 'This is **bold** text' }
 
-      specify { expect(auction).to_not be_available }
-      specify { expect(auction).to_not be_expiring }
-      specify { expect(auction).to be_future }
-      specify { expect(auction).to_not be_over }
-    end
+          it 'should render correctly' do
+            expect(auction.html_description).to match("<strong>bold</strong>")
+          end
+        end
 
-    context 'when the auction is happening' do
-      let(:ar_auction) { FactoryGirl.create(:auction) }
+        context 'italicized text' do
+          let(:description) { 'This is _italic_ text' }
 
-      specify { expect(auction).to be_available }
-      specify { expect(auction).to_not be_expiring }
-      specify { expect(auction).to_not be_future }
-      specify { expect(auction).to_not be_over }
-    end
+          it 'should render correctly' do
+            expect(auction.html_description).to match('<em>italic</em>')
+          end
+        end
 
-    context 'when the auction is closing soon' do
-      let(:ar_auction) { FactoryGirl.create(:auction, :expiring) }
+        context 'autolinks' do
+          let(:description) { 'Please visit http://18f.gov anytime' }
 
-      specify { expect(auction).to be_available }
-      specify { expect(auction).to be_expiring }
-      specify { expect(auction).to_not be_future }
-      specify { expect(auction).to_not be_over }
-    end
-  end
+          it 'should render correctly' do
+            expect(auction.html_description).to match('<a href="http://18f.gov">http://18f.gov</a>')
+          end
+        end
 
-  describe "#html_summary" do
-    let(:summary) { nil }
-    let(:auction) { Presenter::Auction.new(FactoryGirl.build(:auction, summary: summary)) }
+        context 'ignoring underscores in words' do
+          let(:description) { 'This_is_a_test' }
 
-    it 'should return an empty string if the summary is blank' do
-      expect(auction.html_summary).to be_blank
-    end
+          it 'should not render as italicized' do
+            expect(auction.html_description).to_not match('<em>')
+          end
+        end
 
-    context 'bold text' do
-      let(:summary) { 'This is **bold** text' }
+        context 'table rendering' do
+          let(:description) { "First Header|Second Header\n------------- | -------------\nContent Cell  | Content Cell\n" }
 
-      it 'should render correctly' do
-        expect(auction.html_summary).to match("<strong>bold</strong>")
-      end
-    end
-
-    context 'italicized text' do
-      let(:summary) { 'This is _italic_ text' }
-
-      it 'should render correctly' do
-        expect(auction.html_summary).to match('<em>italic</em>')
-      end
-    end
-
-    context 'autolinks' do
-      let(:summary) { 'Please visit http://18f.gov anytime' }
-
-      it 'should render correctly' do
-        expect(auction.html_summary).to match('<a href="http://18f.gov">http://18f.gov</a>')
-      end
-    end
-
-    context 'ignoring underscores in words' do
-      let(:summary) { 'This_is_a_test' }
-
-      it 'should not render as italicized' do
-        expect(auction.html_summary).to_not match('<em>')
-      end
-    end
-
-    context 'table rendering' do
-      let(:summary) { "First Header|Second Header\n------------- | -------------\nContent Cell  | Content Cell\n" }
-
-      it 'should render a table element' do
-        expect(auction.html_summary).to match('<table>')
-      end
-    end
-  end
-
-  describe '#html_description' do
-    let(:description) { nil }
-    let(:auction) { Presenter::Auction.new(FactoryGirl.build(:auction, description: description)) }
-
-    it 'should return an empty string if the description is blank' do
-      expect(auction.html_description).to be_blank
-    end
-
-    context 'bold text' do
-      let(:description) { 'This is **bold** text' }
-
-      it 'should render correctly' do
-        expect(auction.html_description).to match("<strong>bold</strong>")
-      end
-    end
-
-    context 'italicized text' do
-      let(:description) { 'This is _italic_ text' }
-
-      it 'should render correctly' do
-        expect(auction.html_description).to match('<em>italic</em>')
-      end
-    end
-
-    context 'autolinks' do
-      let(:description) { 'Please visit http://18f.gov anytime' }
-
-      it 'should render correctly' do
-        expect(auction.html_description).to match('<a href="http://18f.gov">http://18f.gov</a>')
-      end
-    end
-
-    context 'ignoring underscores in words' do
-      let(:description) { 'This_is_a_test' }
-
-      it 'should not render as italicized' do
-        expect(auction.html_description).to_not match('<em>')
-      end
-    end
-
-    context 'table rendering' do
-      let(:description) { "First Header|Second Header\n------------- | -------------\nContent Cell  | Content Cell\n" }
-
-      it 'should render a table element' do
-        expect(auction.html_description).to match('<table>')
+          it 'should render a table element' do
+            expect(auction.html_description).to match('<table>')
+          end
+        end
       end
     end
   end

--- a/spec/models/presenter/auction_status_spec.rb
+++ b/spec/models/presenter/auction_status_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ViewModel::Auction do
 
   context "when the auction is expiring soon" do
     let(:auction) do
-      a = Auction.new(start_datetime: Time.now - 3.day, end_datetime: Time.now + 3.hours, start_price: 3500, type: 1)
+      a = Auction.new(start_datetime: Time.current - 3.days, end_datetime: Time.current + 3.hours, start_price: 3500, type: 1)
       a.bids.build(amount: 3000)
       a
     end


### PR DESCRIPTION
* This represents business logic and therefore makes sense to include in
  `auction`
* Related `status` logic was hard to parse, moved that into service
  class