### PR TITLE
Use `flash.now` instead of `flash`

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -24,7 +24,7 @@ class UsersController < ApplicationController
       redirect_to root_path
     else
       @user = updater.user
-      flash[:error] = updater.errors
+      flash.now[:error] = updater.errors
       render :edit
     end
   end


### PR DESCRIPTION
* So that flash message does not persist to next page view
* By default, adding values to the flash will make them available to the
  next request, but sometimes you may want to access those values in the
  same request. For example, if the create action fails to save a
  resource and you render the new template directly, that's not going to
  result in a new request, but you may still want to display a message
  using the flash. To do this, you can use flash.now in the same way you
  use the normal flash:
* See http://guides.rubyonrails.org/action_controller_overview.html#the-response-object#flash-now