### PR TITLE
How I sped up my test suite by 20% with this one weird trick

### DIFF
--- a/spec/factories/auctions.rb
+++ b/spec/factories/auctions.rb
@@ -22,36 +22,22 @@ FactoryGirl.define do
       after(:create) do |auction|
         Timecop.freeze(auction.start_datetime) do
           Timecop.scale(3600)
-          3.times do
+          2.times do
             FactoryGirl.create(:bid, auction: auction, amount: 3000)
           end
         end
       end
     end
 
-    trait :single_bid_with_tie_and_other_bids do
-      single_bid
-
-      after(:create) do |auction|
-        Timecop.freeze(auction.start_datetime) do
-          Timecop.scale(3600)
-          3.times do |i|
-            FactoryGirl.create(:bid, auction: auction, amount: 3000 - i)
-            FactoryGirl.create(:bid, auction: auction, amount: 100)
-          end
-        end
-      end
-    end
-
     trait :with_bidders do
-      ignore do
+      transient do
         bidder_ids []
       end
 
       after(:build) do |instance|
         Timecop.freeze(instance.start_datetime) do
           Timecop.scale(3600)
-          (1..4).each do |i|
+          (1..2).each do |i|
             amount = 3499 - (20 * i) - rand(10)
             instance.bids << FactoryGirl.create(:bid, auction: instance, amount: amount)
           end


### PR DESCRIPTION
* And also got rid of annoying FG warning about `transient` being
  deprecated
* See https://robots.thoughtbot.com/factory-girl-2-2-your-new-best-friend#transient-attributes-have-a-cleaner-syntax

Before:

![screen shot 2016-04-22 at 4 59 15 pm](https://cloud.githubusercontent.com/assets/601515/14757762/111242c6-08ac-11e6-9dc8-bd0a7ac9bfa2.png)

After:

![screen shot 2016-04-22 at 5 03 14 pm](https://cloud.githubusercontent.com/assets/601515/14757768/1b63a5e4-08ac-11e6-92a3-8f4536ab229b.png)
