### PR TITLE
Enforce space between `{` and `|`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -150,7 +150,7 @@ Style/SpaceInsideBlockBraces:
   # Valid values are: space, no_space
   EnforcedStyleForEmptyBraces: no_space
   # Space between { and |. Overrides EnforcedStyle if there is a conflict.
-  SpaceBeforeBlockParameters: false
+  SpaceBeforeBlockParameters: true
 
 Style/SpaceInsideHashLiteralBraces:
   EnforcedStyle: space

--- a/app/serializers/auction_serializer.rb
+++ b/app/serializers/auction_serializer.rb
@@ -14,7 +14,7 @@ class AuctionSerializer < ActiveModel::Serializer
 
   def bids
     bids = object.veiled_bids(scope)
-    bids.map { |bid| BidSerializer.new(bid, {scope: scope, root: false}) }
+    bids.map { |bid| BidSerializer.new(bid, { scope: scope, root: false }) }
   end
 
   def created_at


### PR DESCRIPTION
* Was set to enforce NO space, which is crazytown