### PR TITLE
Fix mailer test

### DIFF
--- a/app/credentials/smtp_credentials.rb
+++ b/app/credentials/smtp_credentials.rb
@@ -27,11 +27,7 @@ class SMTPCredentials
     end
   end
 
-  def self.default_from(force_vcap: false)
-    if use_env_var?(force_vcap)
-      ENV['DEFAULT_EMAIL_FROM']
-    else
-      credentials('micropurchase-smtp')['default_from']
-    end
+  def self.default_from
+    credentials('micropurchase-smtp')['default_from']
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -8,6 +8,7 @@ Rails.application.configure do
     authentication: 'login',
     enable_starttls_auto: true
   }
+
   config.cache_classes = true
   config.eager_load = true
   config.consider_all_requests_local = false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,9 +1,9 @@
 Rails.application.configure do
   config.cache_classes = true
   config.eager_load = false
-  config.serve_static_files   = true
+  config.serve_static_files = true
   config.static_cache_control = 'public, max-age=3600'
-  config.consider_all_requests_local       = true
+  config.consider_all_requests_local = true
   config.action_controller.perform_caching = false
   config.action_dispatch.show_exceptions = false
   config.action_controller.allow_forgery_protection = false

--- a/spec/credentials/smtp_credentials_spec.rb
+++ b/spec/credentials/smtp_credentials_spec.rb
@@ -6,21 +6,17 @@ describe SMTPCredentials do
       env_var_smtp_password = 'fake smtp password'
       env_var_smtp_username = 'fake smtp username'
       env_var_default_url_host = 'fake url host'
-      env_var_defalt_from = 'fake default from'
-      ENV['SMTP_PASSWORD'] =  env_var_smtp_password
-      ENV['SMTP_USERNAME'] = env_var_smtp_username
-      ENV['DEFAULT_URL_HOST'] = env_var_default_url_host
-      ENV['DEFAULT_EMAIL_FROM'] = env_var_defalt_from
+      allow(ENV).to receive(:[]).with('SMTP_PASSWORD').and_return(env_var_smtp_password)
+      allow(ENV).to receive(:[]).with('SMTP_USERNAME').and_return(env_var_smtp_username)
+      allow(ENV).to receive(:[]).with('DEFAULT_URL_HOST').and_return(env_var_default_url_host)
 
-      password = SMTPCredentials.smtp_password(force_vcap: false)
-      username = SMTPCredentials.smtp_username(force_vcap: false)
-      url_host = SMTPCredentials.default_url_host(force_vcap: false)
-      from = SMTPCredentials.default_from(force_vcap: false)
+      password = SMTPCredentials.smtp_password
+      username = SMTPCredentials.smtp_username
+      url_host = SMTPCredentials.default_url_host
 
       expect(password).to eq env_var_smtp_password
       expect(username).to eq env_var_smtp_username
       expect(url_host).to eq env_var_default_url_host
-      expect(from).to eq env_var_defalt_from
     end
   end
 
@@ -34,7 +30,7 @@ describe SMTPCredentials do
       password = SMTPCredentials.smtp_password(force_vcap: true)
       username = SMTPCredentials.smtp_username(force_vcap: true)
       url_host = SMTPCredentials.default_url_host(force_vcap: true)
-      from = SMTPCredentials.default_from(force_vcap: true)
+      from = SMTPCredentials.default_from
 
       expect(password).to eq smtp_password_from_fixture
       expect(username).to eq smtp_username_from_fixture

--- a/spec/mailers/auction_mailer_spec.rb
+++ b/spec/mailers/auction_mailer_spec.rb
@@ -12,7 +12,7 @@ describe AuctionMailer do
         I18n.t('mailers.auction_mailer.losing_bidder_notification.subject')
       )
       expect(email.subject).to eq I18n.t('mailers.auction_mailer.losing_bidder_notification.subject')
-      expect(email.from).to eq [SMTPCredentials.default_from]
+      expect(email.from).to eq SMTPCredentials.default_from
       expect(email.body.encoded).to include(
         I18n.t(
           'mailers.auction_mailer.losing_bidder_notification.para_1',


### PR DESCRIPTION
* SMTPCredentials returns parsed JSON or ENV var depending on ENV
* Failing on CI bc weirdly, parsed JSON returns a string for `from`
  whereas env var string returns a one item array
* This makes no sense but whatevs