### PR TITLE
Add a small_business flag to users table

### DIFF
--- a/app/presenters/user_presenter.rb
+++ b/app/presenters/user_presenter.rb
@@ -23,6 +23,14 @@ class UserPresenter < SimpleDelegator
     "components/user_nav_drawer"
   end
 
+  def small_business_label
+    if model.sam_accepted?
+      small_business? ? 'Yes' : 'No'
+    else
+      'N/A'
+    end
+  end
+
   def model
     __getobj__
   end

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -8,6 +8,7 @@
       <th scope="col">DUNS Number</th>
       <th scope="col">Sam.gov status</th>
       <th scope="col">Contracting Officer?</th>
+      <th scope="col">Small Business?</th>
       <th scope="col">GitHub ID</th>
       <th scope="col"></th>
     </tr>
@@ -20,6 +21,7 @@
         <td><%= user.duns_number %></td>
         <td><%= user.sam_status %></td>
         <td><%= user.contracting_officer? %></td>
+        <td><%= user.small_business? %></td>
         <td><%= link_to(user.github_id, user.github_json_url) %></td>
         <td><%= link_to('Edit', edit_admin_user_path(user)) %></td>
       </tr>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -8,7 +8,6 @@
       <th scope="col">DUNS Number</th>
       <th scope="col">Sam.gov status</th>
       <th scope="col">Contracting Officer?</th>
-      <th scope="col">Small Business?</th>
       <th scope="col">GitHub ID</th>
       <th scope="col"></th>
     </tr>
@@ -21,7 +20,6 @@
         <td><%= user.duns_number %></td>
         <td><%= user.sam_status %></td>
         <td><%= user.contracting_officer? %></td>
-        <td><%= user.small_business? %></td>
         <td><%= link_to(user.github_id, user.github_json_url) %></td>
         <td><%= link_to('Edit', edit_admin_user_path(user)) %></td>
       </tr>
@@ -33,14 +31,14 @@
   Users (<%= @users.length %>); w/ DUNS (<%= @admin_report.non_admin_users_with_duns.length %>); In SAM (<%= @admin_report.non_admin_users_in_sam.length %>)
 </h2>
 
-<table class="usa-table-borderless">
+<table id="table-users" class="usa-table-borderless">
   <thead>
     <tr>
       <th scope="col">Name</th>
       <th scope="col">Email</th>
       <th scope="col">DUNS Number</th>
       <th scope="col">SAM.gov status</th>
-      <th scope="col">Contracting Officer?</th>
+      <th scope="col">Small Business?</th>
       <th scope="col">GitHub ID</th>
       <th scope="col"></th>
     </tr>
@@ -52,7 +50,7 @@
         <td><%= user.email %></td>
         <td><%= user.duns_number %></td>
         <td><%= user.in_sam? %></td>
-        <td><%= user.contracting_officer? %></td>
+        <td><%= user.small_business_label %></td>
         <td><%= link_to(user.github_id, user.github_json_url) %></td>
         <td><%= link_to('Edit', edit_admin_user_path(user)) %></td>
       </tr>

--- a/db/migrate/20160510180328_add_small_biz_flag_to_users.rb
+++ b/db/migrate/20160510180328_add_small_biz_flag_to_users.rb
@@ -1,0 +1,5 @@
+class AddSmallBizFlagToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :small_business, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160503143402) do
+ActiveRecord::Schema.define(version: 20160510180328) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -72,10 +72,11 @@ ActiveRecord::Schema.define(version: 20160503143402) do
     t.datetime "created_at",                           null: false
     t.datetime "updated_at",                           null: false
     t.string   "email"
-    t.string   "credit_card_form_url"
     t.string   "github_login"
+    t.string   "credit_card_form_url"
     t.integer  "sam_status",           default: 0,     null: false
     t.boolean  "contracting_officer",  default: false, null: false
+    t.boolean  "small_business",       default: false, null: false
   end
 
   add_index "users", ["contracting_officer"], name: "index_users_on_contracting_officer", where: "(contracting_officer = true)", using: :btree

--- a/features/admin_users.feature
+++ b/features/admin_users.feature
@@ -23,7 +23,7 @@ Feature: Admin Users
     And there are users in the system
     And I visit the admin users page
     When I sign in
-    And I click the edit user link next to the first non-admin user
+    And I click the edit user link next to the first admin user
     And I check the 'Contracting officer' checkbox
     And I submit the changes to the user
-    Then I expect there to be a contracting officer in the list of users
+    Then I expect there to be a contracting officer in the list of admin users

--- a/features/small_business.feature
+++ b/features/small_business.feature
@@ -3,13 +3,26 @@ Feature: Small Business Vendors
   I want to be able to identify small-business users
   So they can bid on restricted auctions
 
-  Scenario: I see whether a user (with a DUNS number, in Sam.gov) is a small business
+  Scenario: A user that is not a small business
     Given I am an administrator
-    And there are various types of users in the system
+    And there is a user in SAM.gov who is not a small business
     When I sign in
     And I visit the admin users page
     Then I should see a column labeled "Small Business?"
-    # Figuring out to best make this in a Gherkin environment
-    # And for each user who has a DUNS nSam.gov that is a small business, I should see "Yes"
-    # And for each user who has a DUNS number and is in Sam.gov that is not a small business, I should see "No"
-    # And for each user who does not both have a DUNS number and is in Sam.gov, I should see "N/A"
+    And I should see "No" for the user in the "Small Business?" column
+
+  Scenario: A user who is a small business
+    Given I am an administrator
+    And there is a user in SAM.gov who is a small business
+    When I sign in
+    And I visit the admin users page
+    Then I should see a column labeled "Small Business?"
+    And I should see "Yes" for the user in the "Small Business?" column
+
+  Scenario: A user who is not in SAM.gov
+    Given I am an administrator
+    And there is a user who is not in SAM.gov
+    When I sign in
+    And I visit the admin users page
+    Then I should see a column labeled "Small Business?"
+    And I should see "N/A" for the user in the "Small Business?" column

--- a/features/small_business.feature
+++ b/features/small_business.feature
@@ -1,0 +1,15 @@
+Feature: Small Business Vendors
+  As an adminstrator
+  I want to be able to identify small-business users
+  So they can bid on restricted auctions
+
+  Scenario: I see whether a user (with a DUNS number, in Sam.gov) is a small business
+    Given I am an administrator
+    And there are various types of users in the system
+    When I sign in
+    And I visit the admin users page
+    Then I should see a column labeled "Small Business?"
+    # Figuring out to best make this in a Gherkin environment
+    # And for each user who has a DUNS nSam.gov that is a small business, I should see "Yes"
+    # And for each user who has a DUNS number and is in Sam.gov that is not a small business, I should see "No"
+    # And for each user who does not both have a DUNS number and is in Sam.gov, I should see "N/A"

--- a/features/step_definitions/admin_users_steps.rb
+++ b/features/step_definitions/admin_users_steps.rb
@@ -44,3 +44,24 @@ end
 Then(/^I expect the page to show me the number of admin users$/) do
   expect(page).to have_text("Admins (1)")
 end
+
+Then(/^I should see a column labeled "([^"]+)"$/) do |text|
+  find('th', text: text)
+end
+
+Given(/^there are various types of users in the system$/) do
+  @users = []
+
+  30.times do
+    has_duns = rand(4)
+    in_sam = has_duns && rand(4)
+    small_biz = in_sam && rand(4)
+
+    opts = { }
+    opts[:duns_number] = nil unless has_duns
+    opts[:sam_status] = :sam_accepted if in_sam
+    opts[:small_business] = true if small_biz
+
+    @users << FactoryGirl.create(:user, opts)
+  end
+end

--- a/features/step_definitions/admin_users_steps.rb
+++ b/features/step_definitions/admin_users_steps.rb
@@ -23,6 +23,12 @@ When(/^I click the edit user link next to the first non-admin user$/) do
   end
 end
 
+When(/^I click the edit user link next to the first admin user$/) do
+  within(:xpath, '/html/body/div/div/table[1]') do
+    click_on "Edit"
+  end
+end
+
 When(/^I check the 'Contracting officer' checkbox$/) do
   check('user_contracting_officer')
 end
@@ -31,8 +37,8 @@ When(/^I submit the changes to the user$/) do
   click_on "Update User"
 end
 
-Then(/^I expect there to be a contracting officer in the list of users$/) do
-  within(:xpath, "html/body/div/div/div/table[2]/tbody/tr[1]/td[5]") do
+Then(/^I expect there to be a contracting officer in the list of admin users$/) do
+  within(:css, "table#table-admins tbody tr td:nth-child(5)") do
     expect(page).to have_content("true")
   end
 end

--- a/features/step_definitions/admin_users_steps.rb
+++ b/features/step_definitions/admin_users_steps.rb
@@ -49,19 +49,27 @@ Then(/^I should see a column labeled "([^"]+)"$/) do |text|
   find('th', text: text)
 end
 
-Given(/^there are various types of users in the system$/) do
-  @users = []
+Given(/^there is a user in SAM.gov who is not a small business$/) do
+  @user = FactoryGirl.create(:user, sam_status: :sam_accepted, small_business: false)
+end
 
-  30.times do
-    has_duns = rand(4)
-    in_sam = has_duns && rand(4)
-    small_biz = in_sam && rand(4)
+Given(/^there is a user in SAM.gov who is a small business$/) do
+  @user = FactoryGirl.create(:user, sam_status: :sam_accepted, small_business: true)
+end
 
-    opts = { }
-    opts[:duns_number] = nil unless has_duns
-    opts[:sam_status] = :sam_accepted if in_sam
-    opts[:small_business] = true if small_biz
+Given(/^there is a user who is not in SAM.gov$/) do
+  @user = FactoryGirl.create(:user, sam_status: :sam_pending)
+end
 
-    @users << FactoryGirl.create(:user, opts)
+Then(/^I should see "([^"]+)" for the user in the "([^"]+)" column$/) do |value, column|
+  user_admin_columns = ['Name', 'Email', 'DUNS Number', 'SAM.gov status',
+                        'Small Business?', 'Github ID']
+
+  index = user_admin_columns.index(column)
+  fail 'Unrecognized column: #{column}' if index.nil?
+  css = "table#table-users tbody tr td:nth-child(#{index+1})"
+
+  within(css) do
+    expect(page).to have_content(value)
   end
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -4,6 +4,8 @@ require 'database_cleaner'
 require 'cucumber/rspec/doubles'
 require 'capybara/poltergeist'
 require 'webmock/cucumber'
+require 'capybara-screenshot/cucumber'
+
 Dir[Rails.root.join("spec/support/*.rb")].each { |file| require file }
 
 Capybara.register_driver :poltergeist do |app|
@@ -11,6 +13,9 @@ Capybara.register_driver :poltergeist do |app|
 end
 
 Capybara.javascript_driver = :poltergeist
+
+# Screenshots were being saved to the root directory
+Capybara.save_path = Rails.root.join('tmp')
 
 Delayed::Worker.delay_jobs = false
 

--- a/spec/support/api/schemas/admin/users.json
+++ b/spec/support/api/schemas/admin/users.json
@@ -45,8 +45,9 @@
               "email",
               "sam_status",
               "credit_card_form_url",
-              "github_login",
-              "contracting_officer"
+              "github_login",  
+              "contracting_officer",
+              "small_business"
             ],
             "properties": {
               "id": {
@@ -57,6 +58,9 @@
                 "minLength": 1
               },
               "contracting_officer": {
+                "type": "boolean"
+              },
+              "small_business": {
                 "type": "boolean"
               },
               "duns_number": {
@@ -108,7 +112,8 @@
               "sam_status",
               "credit_card_form_url",
               "github_login",
-              "contracting_officer"
+              "contracting_officer",
+              "small_business"  
             ],
             "properties": {
               "id": {
@@ -119,6 +124,9 @@
                 "minLength": 1
               },
               "contracting_officer": {
+                "type": "boolean"
+              },
+              "small_business": {
                 "type": "boolean"
               },
               "duns_number": {


### PR DESCRIPTION
**This is not ready to be merged**. This is an implementation of #499 only and adds a column to the table and displays in the admin. I still need to fix the cucumber feature to be complete. Note that this does not cover setting the `small_business` flag from samwise, just displaying in the admin.