### PR TITLE
Update error msg for auction start price error

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,6 +3,8 @@ en:
     attributes:
       user:
         duns_number: "DUNS number"
+      auction:
+        start_price: ""
 
     errors:
       models:


### PR DESCRIPTION
* Had key "start price" so read "Start price You do not have permission to publish
  auctions with a start price over $3500"
* Now just "You do not have permission to publish auctions with a start
* price over $3500"

Updated:

![screen shot 2016-05-12 at 4 06 10 pm](https://cloud.githubusercontent.com/assets/601515/15233170/77c254de-185b-11e6-8a49-852a3cbc5a3d.png)
