### PR TITLE
Bids now record the method they were posted via

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,6 +17,7 @@ class ApplicationController < ActionController::Base
     :require_admin,
     :require_authentication,
     :set_api_current_user,
+    :via,
     to: :authenticator
   )
 

--- a/app/controllers/bids_controller.rb
+++ b/app/controllers/bids_controller.rb
@@ -32,14 +32,14 @@ class BidsController < ApplicationController
 
   def confirm
     @auction = AuctionViewModel.new(current_user, Auction.find(params[:auction_id]))
-    @bid = BidPresenter.new(PlaceBid.new(params, current_user).dry_run)
+    @bid = BidPresenter.new(PlaceBid.new(params, current_user, via).dry_run)
   end
 
   def create
     unless current_user.sam_accepted?
       fail UnauthorizedError, "You must have a valid SAM.gov account to place a bid"
     end
-    @bid = BidPresenter.new(PlaceBid.new(params, current_user).perform)
+    @bid = BidPresenter.new(PlaceBid.new(params, current_user, via).perform)
 
     respond_to do |format|
       format.html do

--- a/app/controllers/bids_controller.rb
+++ b/app/controllers/bids_controller.rb
@@ -32,14 +32,14 @@ class BidsController < ApplicationController
 
   def confirm
     @auction = AuctionViewModel.new(current_user, Auction.find(params[:auction_id]))
-    @bid = BidPresenter.new(PlaceBid.new(params, current_user, via).dry_run)
+    @bid = BidPresenter.new(PlaceBid.new(params: params, user: current_user, via: via).dry_run)
   end
 
   def create
     unless current_user.sam_accepted?
       fail UnauthorizedError, "You must have a valid SAM.gov account to place a bid"
     end
-    @bid = BidPresenter.new(PlaceBid.new(params, current_user, via).perform)
+    @bid = BidPresenter.new(PlaceBid.new(params: params, user: current_user, via: via).perform)
 
     respond_to do |format|
       format.html do

--- a/app/models/api_authenticator.rb
+++ b/app/models/api_authenticator.rb
@@ -29,6 +29,10 @@ class ApiAuthenticator < Struct.new(:controller)
   end
   # rubocop:enable Style/AccessorMethodName
 
+  def via
+    'api'
+  end
+
   private
 
   def github_id_from_api_key(api_key)

--- a/app/models/place_bid.rb
+++ b/app/models/place_bid.rb
@@ -1,9 +1,15 @@
-class PlaceBid < Struct.new(:params, :current_user, :via)
+class PlaceBid
   BID_LIMIT = 3500
   BID_INCREMENT = 1
 
-  attr_reader :bid
+  attr_reader :bid, :params, :user, :via
 
+  def initialize(params:, user:, via:nil)
+    @params = params
+    @user = user
+    @via = via
+  end
+  
   def perform
     validate_bid_data
     create_bid
@@ -17,7 +23,7 @@ class PlaceBid < Struct.new(:params, :current_user, :via)
   def create_bid
     @bid ||= Bid.create(
       amount: amount,
-      bidder_id: current_user.id,
+      bidder_id: user.id,
       auction_id: auction.id,
       via: via
     )
@@ -26,7 +32,7 @@ class PlaceBid < Struct.new(:params, :current_user, :via)
   def unsaveable_bid
     @bid ||= Bid.new(
       amount: amount,
-      bidder_id: current_user.id,
+      bidder_id: user.id,
       auction_id: auction.id,
       via: via
     )
@@ -42,7 +48,7 @@ class PlaceBid < Struct.new(:params, :current_user, :via)
   end
 
   def user_can_bid?
-    presenter_auction.user_can_bid?(current_user)
+    presenter_auction.user_can_bid?(user)
   end
 
   def max_allowed_bid

--- a/app/models/place_bid.rb
+++ b/app/models/place_bid.rb
@@ -9,7 +9,7 @@ class PlaceBid
     @user = user
     @via = via
   end
-  
+
   def perform
     validate_bid_data
     create_bid
@@ -55,7 +55,6 @@ class PlaceBid
     presenter_auction.max_allowed_bid
   end
 
-  # rubocop:disable Style/IfUnlessModifier
   def validate_bid_data
     unless auction_available?
       fail UnauthorizedError, 'Auction not available'
@@ -81,7 +80,6 @@ class PlaceBid
       fail UnauthorizedError, "Bids cannot be greater than the current max bid"
     end
   end
-  # rubocop:enable Style/IfUnlessModifier
 
   def auction_available?
     AuctionStatus.new(auction).available?

--- a/app/models/place_bid.rb
+++ b/app/models/place_bid.rb
@@ -1,4 +1,4 @@
-class PlaceBid < Struct.new(:params, :current_user)
+class PlaceBid < Struct.new(:params, :current_user, :via)
   BID_LIMIT = 3500
   BID_INCREMENT = 1
 
@@ -18,7 +18,8 @@ class PlaceBid < Struct.new(:params, :current_user)
     @bid ||= Bid.create(
       amount: amount,
       bidder_id: current_user.id,
-      auction_id: auction.id
+      auction_id: auction.id,
+      via: via
     )
   end
 
@@ -26,7 +27,8 @@ class PlaceBid < Struct.new(:params, :current_user)
     @bid ||= Bid.new(
       amount: amount,
       bidder_id: current_user.id,
-      auction_id: auction.id
+      auction_id: auction.id,
+      via: via
     )
 
     @bid.readonly!

--- a/app/models/web_authenticator.rb
+++ b/app/models/web_authenticator.rb
@@ -20,4 +20,8 @@ class WebAuthenticator < Struct.new(:controller)
   def github_id
     current_user.github_id
   end
+
+  def via
+    'web'
+  end
 end

--- a/db/migrate/20160514014929_add_submit_method_to_bids.rb
+++ b/db/migrate/20160514014929_add_submit_method_to_bids.rb
@@ -1,0 +1,5 @@
+class AddSubmitMethodToBids < ActiveRecord::Migration
+  def change
+    add_column :bids, :via, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160510180328) do
+ActiveRecord::Schema.define(version: 20160514014929) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,6 +47,7 @@ ActiveRecord::Schema.define(version: 20160510180328) do
     t.integer  "amount"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string   "via"
   end
 
   create_table "delayed_jobs", force: :cascade do |t|

--- a/spec/controllers/bids_controller_spec.rb
+++ b/spec/controllers/bids_controller_spec.rb
@@ -127,12 +127,7 @@ RSpec.describe BidsController, controller: true do
     end
 
     context 'when there are no other bids' do
-      # before do
-      #   allow(PlaceBid).to receive(:new).and_return(place_bid)
-      # end
-
       let(:bid) { auction.bids.first }
-      # let(:place_bid) { double('place bid object', perform: true) }
       let(:request_params) do
         {
           auction_id: auction.id,
@@ -142,11 +137,10 @@ RSpec.describe BidsController, controller: true do
 
       context 'when the bid is good' do
         it "creates a bid and redirects to the new bid page" do
-          #expect(PlaceBid).to receive(:new).with(anything, current_bidder).and_return(place_bid)
           post :create, request_params, user_id: current_bidder.id
           expect(flash[:bid]).to eq("success")
           expect(response).to redirect_to("/auctions/#{auction.id}")
-          
+
           bid = auction.bids.order('created_at DESC').first
           expect(bid.bidder).to eq(current_bidder)
           expect(bid.amount).to eq(1000)
@@ -161,7 +155,6 @@ RSpec.describe BidsController, controller: true do
             bid: { amount: -192 }
           }
         end
-        
 
         it "adds a flash error when the bid is bad" do
           post :create, request_params, user_id: current_bidder.id

--- a/spec/controllers/bids_controller_spec.rb
+++ b/spec/controllers/bids_controller_spec.rb
@@ -127,32 +127,47 @@ RSpec.describe BidsController, controller: true do
     end
 
     context 'when there are no other bids' do
-      before do
-        allow(PlaceBid).to receive(:new).and_return(place_bid)
-      end
+      # before do
+      #   allow(PlaceBid).to receive(:new).and_return(place_bid)
+      # end
 
       let(:bid) { auction.bids.first }
-      let(:place_bid) { double('place bid object', perform: true) }
+      # let(:place_bid) { double('place bid object', perform: true) }
       let(:request_params) do
         {
           auction_id: auction.id,
-          bid: { amount: 3000.50 }
+          bid: { amount: 1000 }
         }
       end
 
-      it "creates creates a bid and redirects to the new bid page" do
-        expect(PlaceBid).to receive(:new).with(anything, current_bidder).and_return(place_bid)
-        post :create, request_params, user_id: current_bidder.id
-        expect(flash[:bid]).to eq("success")
-        expect(response).to redirect_to("/auctions/#{auction.id}")
+      context 'when the bid is good' do
+        it "creates a bid and redirects to the new bid page" do
+          #expect(PlaceBid).to receive(:new).with(anything, current_bidder).and_return(place_bid)
+          post :create, request_params, user_id: current_bidder.id
+          expect(flash[:bid]).to eq("success")
+          expect(response).to redirect_to("/auctions/#{auction.id}")
+          
+          bid = auction.bids.order('created_at DESC').first
+          expect(bid.bidder).to eq(current_bidder)
+          expect(bid.amount).to eq(1000)
+          expect(bid.via).to eq('web')
+        end
       end
 
-      it "adds a flash error when the bid is bad" do
-        expect(PlaceBid).to receive(:new).with(anything, current_bidder)
-          .and_raise(UnauthorizedError.new("Bad bid, sucker!"))
-        post :create, request_params, user_id: current_bidder.id
-        expect(flash[:error]).to eq("Bad bid, sucker!")
-        expect(response).to redirect_to("/auctions/#{auction.id}/bids/new")
+      context 'when the bid is bad' do
+        let(:request_params) do
+          {
+            auction_id: auction.id,
+            bid: { amount: -192 }
+          }
+        end
+        
+
+        it "adds a flash error when the bid is bad" do
+          post :create, request_params, user_id: current_bidder.id
+          expect(flash[:error]).to eq("Bid amount out of range")
+          expect(response).to redirect_to("/auctions/#{auction.id}/bids/new")
+        end
       end
     end
   end

--- a/spec/models/place_bid_spec.rb
+++ b/spec/models/place_bid_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe PlaceBid do
-  let(:place_bid) { PlaceBid.new(params, current_user) }
-  let(:place_second_bid) { PlaceBid.new(second_params, current_user) }
+  let(:place_bid) { PlaceBid.new(params: params, user: current_user) }
+  let(:place_second_bid) { PlaceBid.new(params: second_params, user: current_user) }
   let(:current_user) { FactoryGirl.create(:user, sam_status: :sam_accepted) }
   let(:second_user) { FactoryGirl.create(:user, sam_status: :sam_accepted) }
   let(:amount) { 1005 }
@@ -86,8 +86,8 @@ RSpec.describe PlaceBid do
         }
       }
       expect do
-        PlaceBid.new(params, current_user).perform
-        PlaceBid.new(params, second_user).perform
+        PlaceBid.new(params: params, user: current_user).perform
+        PlaceBid.new(params: params, user: second_user).perform
       end.to_not raise_error
     end
   end

--- a/spec/requests/bids_spec.rb
+++ b/spec/requests/bids_spec.rb
@@ -177,11 +177,19 @@ describe AuctionsController do
           let(:user) { create(:user, :not_small_business) }
 
           it 'returns a json error' do
+            post auction_bids_path(auction), params, headers
             expect(json_response['error']).to eq('You are not allowed to bid on this auction')
           end
 
           it 'returns a 403 status code' do
+            post auction_bids_path(auction), params, headers
             expect(status).to eq(403)
+          end
+
+          it 'does not create a bid' do
+            expect do
+              post auction_bids_path(auction), params, headers
+            end.to_not change { auction.bids.count }
           end
         end
       end

--- a/spec/requests/bids_spec.rb
+++ b/spec/requests/bids_spec.rb
@@ -34,6 +34,7 @@ describe AuctionsController do
 
   describe 'POST /auctions/:auction_id/bids' do
     before do
+      @bid_count = auction.bids.count
       post auction_bids_path(auction), params, headers
     end
     let(:json_bid) { json_response['bid'] }
@@ -53,6 +54,10 @@ describe AuctionsController do
       it 'returns a 404 status code' do
         expect(status).to eq(404)
       end
+
+      it 'should not create a bid' do
+        expect(auction.bids.count).to eq(@bid_count)
+      end
     end
 
     context 'when the API key is invalid' do
@@ -69,6 +74,10 @@ describe AuctionsController do
 
       it 'returns a 404 status code' do
         expect(status).to eq(404)
+      end
+
+      it 'should not create a bid' do
+        expect(auction.bids.count).to eq(@bid_count)
       end
     end
 
@@ -87,6 +96,10 @@ describe AuctionsController do
       it 'returns a 403 status code' do
         expect(status).to eq(403)
       end
+
+      it 'should not create a bid' do
+        expect(auction.bids.count).to eq(@bid_count)
+      end
     end
 
     context 'when the auction has not yet started' do
@@ -103,6 +116,10 @@ describe AuctionsController do
 
       it 'returns a 403 status code' do
         expect(status).to eq(403)
+      end
+
+      it 'should not create a bid' do
+        expect(auction.bids.count).to eq(@bid_count)
       end
     end
 
@@ -123,6 +140,15 @@ describe AuctionsController do
 
         it 'returns a 200 status code' do
           expect(status).to eq(200)
+        end
+
+        it 'should create a bid from the API source' do
+          expect(auction.bids.count).to eq(@bid_count + 1)
+          new_bid = auction.bids.order('created_at DESC').first
+
+          expect(new_bid.amount).to eq(bid_amount)
+          expect(new_bid.bidder).to eq(user)
+          expect(new_bid.via).to eq('api')
         end
       end
 
@@ -156,6 +182,10 @@ describe AuctionsController do
           it 'returns a 403 status code' do
             expect(status).to eq(403)
           end
+
+          it 'should not create a bid' do
+            expect(auction.bids.count).to eq(@bid_count)
+          end
         end
       end
 
@@ -186,6 +216,15 @@ describe AuctionsController do
           it 'returns a 200 status code' do
             expect(status).to eq(200)
           end
+
+          it 'should create a bid from the API source' do
+            expect(auction.bids.count).to eq(@bid_count + 1)
+
+            new_bid = auction.bids.order('created_at DESC').first
+            expect(new_bid.amount).to eq(bid_amount)
+            expect(new_bid.bidder).to eq(user)
+            expect(new_bid.via).to eq('api')
+          end
         end
 
         context 'and the bidder has already bid on this auction' do
@@ -193,11 +232,13 @@ describe AuctionsController do
           let(:second_bid_amount) { bid_amount - 10 }
 
           it 'returns a 403 status code' do
+            bid_count = auction.bids.count
             post auction_bids_path(auction), second_params, headers
 
             expect(status).to eq(403)
             expect(json_response).to have_key('error')
             expect(json_response['error']).to eq('You are not allowed to bid on this auction')
+            expect(auction.bids.count).to eq(bid_count)
           end
         end
       end
@@ -213,6 +254,10 @@ describe AuctionsController do
         it 'returns a 403 status code' do
           expect(status).to eq(403)
         end
+
+        it 'should not create a bid' do
+          expect(auction.bids.count).to eq(@bid_count)
+        end
       end
 
       context 'and the user has a pending #sam_status' do
@@ -225,6 +270,10 @@ describe AuctionsController do
 
         it 'returns a 403 status code' do
           expect(status).to eq(403)
+        end
+
+        it 'should not create a bid' do
+          expect(auction.bids.count).to eq(@bid_count)
         end
       end
 
@@ -258,6 +307,8 @@ describe AuctionsController do
         it 'returns a 403 status code' do
           expect(status).to eq(403)
         end
+
+        it 'should not create a bid'
       end
 
       context 'and the bid amount contains cents' do
@@ -269,6 +320,9 @@ describe AuctionsController do
 
         it 'returns a 403 status code' do
           expect(status).to eq(403)
+        end
+
+        it 'should not create a bid' do
         end
       end
     end

--- a/spec/requests/bids_spec.rb
+++ b/spec/requests/bids_spec.rb
@@ -33,10 +33,6 @@ describe AuctionsController do
   let(:status) { response.status }
 
   describe 'POST /auctions/:auction_id/bids' do
-    before do
-      @bid_count = auction.bids.count
-      post auction_bids_path(auction), params, headers
-    end
     let(:json_bid) { json_response['bid'] }
 
     context 'when the API key is missing' do
@@ -48,15 +44,19 @@ describe AuctionsController do
       let(:bid_amount) { current_auction_price - 10 }
 
       it 'returns a json error' do
+        post auction_bids_path(auction), params, headers
         expect(json_response['error']).to eq('User not found')
       end
 
       it 'returns a 404 status code' do
-        expect(status).to eq(404)
+        post auction_bids_path(auction), params, headers
+        expect(response.status).to eq(404)
       end
 
       it 'should not create a bid' do
-        expect(auction.bids.count).to eq(@bid_count)
+        expect do
+          post auction_bids_path(auction), params, headers
+        end.to_not change { auction.bids.count }
       end
     end
 
@@ -69,15 +69,19 @@ describe AuctionsController do
       let(:bid_amount) { current_auction_price - 10 }
 
       it 'returns a json error' do
+        post auction_bids_path(auction), params, headers
         expect(json_response['error']).to eq('User not found')
       end
 
       it 'returns a 404 status code' do
+        post auction_bids_path(auction), params, headers
         expect(status).to eq(404)
       end
 
       it 'should not create a bid' do
-        expect(auction.bids.count).to eq(@bid_count)
+        expect do
+          post auction_bids_path(auction), params, headers
+        end.to_not change { auction.bids.count }
       end
     end
 
@@ -90,15 +94,19 @@ describe AuctionsController do
       let(:bid_amount) { current_auction_price - 10 }
 
       it 'returns a json error' do
+        post auction_bids_path(auction), params, headers
         expect(json_response['error']).to eq('Auction not available')
       end
 
       it 'returns a 403 status code' do
+        post auction_bids_path(auction), params, headers
         expect(status).to eq(403)
       end
 
       it 'should not create a bid' do
-        expect(auction.bids.count).to eq(@bid_count)
+        expect do
+          post auction_bids_path(auction), params, headers
+        end.to_not change { auction.bids.count }
       end
     end
 
@@ -111,15 +119,19 @@ describe AuctionsController do
       let(:bid_amount) { current_auction_price - 10 }
 
       it 'returns a json error' do
+        post auction_bids_path(auction), params, headers
         expect(json_response['error']).to eq('Auction not available')
       end
 
       it 'returns a 403 status code' do
+        post auction_bids_path(auction), params, headers
         expect(status).to eq(403)
       end
 
       it 'should not create a bid' do
-        expect(auction.bids.count).to eq(@bid_count)
+        expect do
+          post auction_bids_path(auction), params, headers
+        end.to_not change { auction.bids.count }
       end
     end
 
@@ -134,16 +146,21 @@ describe AuctionsController do
         let(:bid_amount) { current_auction_price - 10 }
 
         it 'creates a new bid' do
+          post auction_bids_path(auction), params, headers
           expect(json_bid['amount']).to eq(bid_amount)
           expect(json_bid['bidder_id']).to eq(user.id)
         end
 
         it 'returns a 200 status code' do
+          post auction_bids_path(auction), params, headers
           expect(status).to eq(200)
         end
 
         it 'should create a bid from the API source' do
-          expect(auction.bids.count).to eq(@bid_count + 1)
+          expect do
+            post auction_bids_path(auction), params, headers
+          end.to change { auction.bids.count }.by(1)
+
           new_bid = auction.bids.order('created_at DESC').first
 
           expect(new_bid.amount).to eq(bid_amount)
@@ -176,15 +193,19 @@ describe AuctionsController do
           let(:bid_amount) { current_auction_price + 10 }
 
           it 'returns a json error' do
+            post auction_bids_path(auction), params, headers
             expect(json_response['error']).to eq('Bids cannot be greater than the current max bid')
           end
 
           it 'returns a 403 status code' do
+            post auction_bids_path(auction), params, headers
             expect(status).to eq(403)
           end
 
           it 'should not create a bid' do
-            expect(auction.bids.count).to eq(@bid_count)
+            expect do
+              post auction_bids_path(auction), params, headers
+            end.to_not change { auction.bids.count }
           end
         end
       end
@@ -197,10 +218,12 @@ describe AuctionsController do
           let(:bid_amount) { amount }
 
           it 'returns a 200 status code' do
+            post auction_bids_path(auction), params, headers
             expect(status).to eq(200)
           end
 
           it 'returns the right amount' do
+            post auction_bids_path(auction), params, headers
             expect(json_response['bid']['amount']).to eq(amount)
           end
         end
@@ -209,16 +232,20 @@ describe AuctionsController do
           let(:bid_amount) { current_auction_price - 10 }
 
           it 'creates a new bid' do
+            post auction_bids_path(auction), params, headers
             expect(json_bid['amount']).to eq(bid_amount)
             expect(json_bid['bidder_id']).to eq(user.id)
           end
 
           it 'returns a 200 status code' do
+            post auction_bids_path(auction), params, headers
             expect(status).to eq(200)
           end
 
           it 'should create a bid from the API source' do
-            expect(auction.bids.count).to eq(@bid_count + 1)
+            expect do
+              post auction_bids_path(auction), params, headers
+            end.to change { auction.bids.count }.by(1)
 
             new_bid = auction.bids.order('created_at DESC').first
             expect(new_bid.amount).to eq(bid_amount)
@@ -232,13 +259,15 @@ describe AuctionsController do
           let(:second_bid_amount) { bid_amount - 10 }
 
           it 'returns a 403 status code' do
-            bid_count = auction.bids.count
-            post auction_bids_path(auction), second_params, headers
+            post auction_bids_path(auction), params, headers
+
+            expect do
+              post auction_bids_path(auction), second_params, headers
+            end.to_not change { auction.bids.count }
 
             expect(status).to eq(403)
             expect(json_response).to have_key('error')
             expect(json_response['error']).to eq('You are not allowed to bid on this auction')
-            expect(auction.bids.count).to eq(bid_count)
           end
         end
       end
@@ -248,15 +277,19 @@ describe AuctionsController do
         let(:bid_amount) { current_auction_price - 10 }
 
         it 'returns a json error' do
+          post auction_bids_path(auction), params, headers
           expect(json_response['error']).to eq('You must have a valid SAM.gov account to place a bid')
         end
 
         it 'returns a 403 status code' do
+          post auction_bids_path(auction), params, headers
           expect(status).to eq(403)
         end
 
         it 'should not create a bid' do
-          expect(auction.bids.count).to eq(@bid_count)
+          expect do
+            post auction_bids_path(auction), params, headers
+          end.to_not change { auction.bids.count }
         end
       end
 
@@ -265,15 +298,19 @@ describe AuctionsController do
         let(:bid_amount) { current_auction_price - 10 }
 
         it 'returns a json error' do
+          post auction_bids_path(auction), params, headers
           expect(json_response['error']).to eq('You must have a valid SAM.gov account to place a bid')
         end
 
         it 'returns a 403 status code' do
+          post auction_bids_path(auction), params, headers
           expect(status).to eq(403)
         end
 
         it 'should not create a bid' do
-          expect(auction.bids.count).to eq(@bid_count)
+          expect do
+            post auction_bids_path(auction), params, headers
+          end.to_not change { auction.bids.count }
         end
       end
 
@@ -281,6 +318,7 @@ describe AuctionsController do
         let(:bid_amount) { (current_auction_price - 10).to_f }
 
         it 'ignores the floatiness' do
+          post auction_bids_path(auction), params, headers
           expect(json_bid['amount']).to eq(bid_amount)
         end
       end
@@ -289,10 +327,12 @@ describe AuctionsController do
         let(:bid_amount) { 'clearly not a valid bid' }
 
         it 'returns a json error' do
+          post auction_bids_path(auction), params, headers
           expect(json_response['error']).to eq('Bid amount out of range')
         end
 
         it 'returns a 403 status code' do
+          post auction_bids_path(auction), params, headers
           expect(status).to eq(403)
         end
       end
@@ -301,24 +341,32 @@ describe AuctionsController do
         let(:bid_amount) { -1000 }
 
         it 'returns a json error' do
+          post auction_bids_path(auction), params, headers
           expect(json_response['error']).to eq('Bid amount out of range')
         end
 
         it 'returns a 403 status code' do
+          post auction_bids_path(auction), params, headers
           expect(status).to eq(403)
         end
 
-        it 'should not create a bid'
+        it 'should not create a bid' do
+          expect do
+            post auction_bids_path(auction), params, headers
+          end.to_not change { auction.bids.count }
+        end
       end
 
       context 'and the bid amount contains cents' do
         let(:bid_amount) { 1.99 }
 
         it 'returns a json error' do
+          post auction_bids_path(auction), params, headers
           expect(json_response['error']).to eq('Bids must be in increments of one dollar')
         end
 
         it 'returns a 403 status code' do
+          post auction_bids_path(auction), params, headers
           expect(status).to eq(403)
         end
 


### PR DESCRIPTION
It uses 'web' for HTTP access and 'api' for bids posted via the API. I figured this would be helpful for assessing how bids were being submitted.

Fixes #526