### PR TITLE
Remove default screenshots

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,6 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'cucumber-rails', require: false
   gem 'capybara'
-  gem 'capybara-screenshot'
   gem 'poltergeist'
   gem 'byebug'
   gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,9 +84,6 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    capybara-screenshot (1.0.12)
-      capybara (>= 1.0, < 3)
-      launchy
     cf-app-utils (0.6)
     choice (0.2.0)
     chronic (0.10.2)
@@ -402,7 +399,6 @@ DEPENDENCIES
   byebug
   c2!
   capybara
-  capybara-screenshot
   cf-app-utils
   chronic
   clockwork

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -4,7 +4,6 @@ require 'database_cleaner'
 require 'cucumber/rspec/doubles'
 require 'capybara/poltergeist'
 require 'webmock/cucumber'
-require 'capybara-screenshot/cucumber'
 
 Dir[Rails.root.join("spec/support/*.rb")].each { |file| require file }
 
@@ -13,9 +12,6 @@ Capybara.register_driver :poltergeist do |app|
 end
 
 Capybara.javascript_driver = :poltergeist
-
-# Screenshots were being saved to the root directory
-Capybara.save_path = Rails.root.join('tmp')
 
 Delayed::Worker.delay_jobs = false
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,7 +6,6 @@ require 'rspec/rails'
 require 'dotenv'
 Dotenv.load
 require 'capybara/rspec'
-require 'capybara-screenshot/rspec'
 
 Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 


### PR DESCRIPTION
* Were saving to root dir for some reason
* Can throw in a screenshot as a debugging mechanism without this lib
* See https://github.com/teampoltergeist/poltergeist#taking-screenshots-with-some-extensions