### PR TITLE
New auctions grid

### DIFF
--- a/app/assets/stylesheets/_uswds-grid-overrides.scss
+++ b/app/assets/stylesheets/_uswds-grid-overrides.scss
@@ -35,11 +35,16 @@ $small: new-breakpoint(min-width $small-screen 1);
   padding-top: 1.25em;
 }
 
-
 .usa-grid {
   padding: 0 1.5rem;
 
   @include media($small-screen) {
     padding: 0 3rem;
+  }
+}
+
+.usa-width-one-half {
+  &:nth-child(2n) {
+    @include omega();
   }
 }

--- a/app/assets/stylesheets/blocks/_auction-detail.scss
+++ b/app/assets/stylesheets/blocks/_auction-detail.scss
@@ -64,9 +64,12 @@
 }
 
 a[class*="auction-label-"],
-span[class*="auction-label-"] {
+span[class*="auction-label-"],
+a[class*="auction-label-"]:only-of-type,
+span[class*="auction-label-"]:only-of-type {
+  float: right;
+  margin: 0;
   margin-left: $base-padding-lite;
-
 }
 
 .auction-label,

--- a/app/assets/stylesheets/blocks/_auction.scss
+++ b/app/assets/stylesheets/blocks/_auction.scss
@@ -46,11 +46,14 @@ textarea#auction_description {
   }
 }
 
+.auction-wrapper .issue-list-item {
+  display: flex;
+}
+
 .issue-list-item {
   background-color: $color-white;
   border: 1px solid $color-gray-neutral;
   border-radius: $border-radius;
-  display: flex !important;
   -ms-flex-direction: column;
   -webkit-flex-direction: column;
   flex-direction: column;

--- a/app/assets/stylesheets/blocks/_auction.scss
+++ b/app/assets/stylesheets/blocks/_auction.scss
@@ -1,3 +1,13 @@
+.auction-wrapper {
+  display:flex;
+  -ms-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -ms-justify-content: space-between;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+}
+
 textarea#auction_summary {
   height: 150px;
   width: 500px;
@@ -7,8 +17,6 @@ textarea#auction_description {
   height: 500px;
   width: 500px;
 }
-
-
 
 .auction-description {
   h1 {
@@ -39,14 +47,21 @@ textarea#auction_description {
 }
 
 .issue-list-item {
-  border: 1px solid $color-gray-neutral;
   background-color: $color-white;
+  border: 1px solid $color-gray-neutral;
   border-radius: $border-radius;
+  display: flex !important;
+  flex-direction: column;
+  -ms-flex-direction: column;
+  -webkit-flex-direction: column;
   font-weight: $font-light;
   margin-bottom: $site-margins;
 
   &:last-of-type {
     margin-bottom: $base-padding-large;
+
+  .issue-content-wrapper {
+    flex: 1 0 auto;
   }
 
   .issue-label {
@@ -71,6 +86,7 @@ textarea#auction_description {
     color: $color-white;
     padding: $base-padding 3rem;
     padding-bottom: 0;
+    width: 100%;
 
     .current-bid-box {
       position: relative;
@@ -129,6 +145,10 @@ textarea#auction_description {
 
   &:last-of-type {
     margin-right: 0;
+  }
+
+  span {
+    font-weight: $font-normal;
   }
 }
 

--- a/app/assets/stylesheets/blocks/_auction.scss
+++ b/app/assets/stylesheets/blocks/_auction.scss
@@ -1,5 +1,5 @@
 .auction-wrapper {
-  display:flex;
+  display: flex;
   -ms-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   flex-wrap: wrap;
@@ -51,9 +51,9 @@ textarea#auction_description {
   border: 1px solid $color-gray-neutral;
   border-radius: $border-radius;
   display: flex !important;
-  flex-direction: column;
   -ms-flex-direction: column;
   -webkit-flex-direction: column;
+  flex-direction: column;
   font-weight: $font-light;
   margin-bottom: $site-margins;
 

--- a/app/assets/stylesheets/blocks/_auction.scss
+++ b/app/assets/stylesheets/blocks/_auction.scss
@@ -62,6 +62,7 @@ textarea#auction_description {
 
   &:last-of-type {
     margin-bottom: $base-padding-large;
+  }
 
   .issue-content-wrapper {
     flex: 1 0 auto;

--- a/app/views/auctions/_list_item.html.erb
+++ b/app/views/auctions/_list_item.html.erb
@@ -2,7 +2,7 @@
   <div class="usa-grid issue-content-wrapper">
     <div class='usa-width-one-whole issue-label'>
       <h3 class='issue-title'>
-        <a href="<%= auction_path(auction) %>"><%= auction.title %></a> <span class="usa-label-big <%= auction.label_class %>"><%= auction.label %></span>
+        <span class="usa-label-big <%= auction.label_class %>"><%= auction.label %></span> <a href="<%= auction_path(auction) %>"><%= auction.title %></a>
       </h3>
       <p class='issue-description'>
         <%=h raw auction.html_summary %><a class="issue-list-item-details" href="<%= auction_path(auction) %>">View details <icon class="fa fa-angle-double-right"></icon></a>

--- a/app/views/auctions/_list_item.html.erb
+++ b/app/views/auctions/_list_item.html.erb
@@ -1,5 +1,5 @@
-<div class='usa-width-one-whole issue-list-item'>
-  <div class="usa-grid">
+<div class='usa-width-one-half issue-list-item'>
+  <div class="usa-grid issue-content-wrapper">
     <div class='usa-width-one-whole issue-label'>
       <h3 class='issue-title'>
         <a href="<%= auction_path(auction) %>"><%= auction.title %></a> <span class="usa-label-big <%= auction.label_class %>"><%= auction.label %></span>

--- a/app/views/auctions/_winning_bid.html.erb
+++ b/app/views/auctions/_winning_bid.html.erb
@@ -6,7 +6,7 @@
 
 <% if auction.bids? %>
   <div class="issue-bids-info-item"><% if defined? for_winners_page %><% else %>
-    <div class="issue-bids-info-item">Winning bid: </div>
+    <span>Winning bid: </span>
   <% end %><%= auction.highlighted_bid_amount_as_currency %></div>
 
 <% else %>

--- a/app/views/auctions/index.html.erb
+++ b/app/views/auctions/index.html.erb
@@ -18,7 +18,7 @@
 <section class="usa-grid">
   <h2>Issues open for bid</h2>
 
-  <div class="usa-grid-full">
+  <div class="usa-grid-full auction-wrapper">
     <%= render partial: @view_model.auctions_list_partial %>
   </div>
 </section>

--- a/features/auctions.feature
+++ b/features/auctions.feature
@@ -22,10 +22,6 @@ Feature: Basic Auction Views
     And I should see a "Bid" button
     And there should be meta tags for the index page for 1 open and 0 future auctions
 
-  Scenario: Default ordering for the micropurchase homepage
-    When I visit the home page
-    Then the auction previews should be in descending order by end date timestamp
-
   Scenario: Many auctions
     Given there are many different auctions
     When I visit the home page

--- a/features/auctions.feature
+++ b/features/auctions.feature
@@ -22,6 +22,10 @@ Feature: Basic Auction Views
     And I should see a "Bid" button
     And there should be meta tags for the index page for 1 open and 0 future auctions
 
+  Scenario: Default ordering for the micropurchase homepage
+    When I visit the home page
+    Then the auction previews should be in descending order by end date timestamp
+
   Scenario: Many auctions
     Given there are many different auctions
     When I visit the home page

--- a/spec/controllers/auctions_controller_spec.rb
+++ b/spec/controllers/auctions_controller_spec.rb
@@ -43,9 +43,9 @@ describe AuctionsController do
         auction_3 = auctions[2]
 
         expect(auction_1).to be_a(AuctionViewModel)
-        expect(auction_1.end_datetime).to eq(date_latest)
-        expect(auction_2.end_datetime).to eq(date_middle)
-        expect(auction_3.end_datetime).to eq(date_first)
+        expect(auction_1.end_datetime).to be_within(0.1).of(date_latest)
+        expect(auction_2.end_datetime).to be_within(0.1).of(date_middle)
+        expect(auction_3.end_datetime).to be_within(0.1).of(date_first)
       end
     end
   end

--- a/spec/controllers/auctions_controller_spec.rb
+++ b/spec/controllers/auctions_controller_spec.rb
@@ -15,10 +15,10 @@ describe AuctionsController do
 
         Timecop.freeze
 
-        date_start = Time.now - 3.days
-        date_latest = Time.now + 3.days
-        date_middle = Time.now + 2.days
-        date_first = Time.now + 1.days
+        date_start = Time.current - 3.days
+        date_latest = Time.current + 3.days
+        date_middle = Time.current + 2.days
+        date_first = Time.current + 1.days
 
         auction_record_1 = create(
           :auction,

--- a/spec/controllers/auctions_controller_spec.rb
+++ b/spec/controllers/auctions_controller_spec.rb
@@ -9,6 +9,45 @@ describe AuctionsController do
       expect(auction).to be_a(AuctionViewModel)
       expect(auction.id).to eq(auction_record.id)
     end
+
+    context 'the list of auctions is sorted' do
+      it 'renders them descending by datetime' do
+
+        Timecop.freeze
+
+        date_start = Time.now - 3.days
+        date_latest = Time.now + 3.days
+        date_middle = Time.now + 2.days
+        date_first = Time.now + 1.days
+
+        auction_record_1 = create(
+          :auction,
+          start_datetime: date_start,
+          end_datetime: date_middle)
+
+        auction_record_2 = create(
+          :auction,
+          start_datetime: date_start,
+          end_datetime: date_latest)
+
+        auction_record_3 = create(
+          :auction,
+          start_datetime: date_start,
+          end_datetime: date_first)
+
+        get :index
+        auctions = assigns(:view_model).auctions
+
+        auction_1 = auctions[0]
+        auction_2 = auctions[1]
+        auction_3 = auctions[2]
+
+        expect(auction_1).to be_a(AuctionViewModel)
+        expect(auction_1.end_datetime).to eq(date_latest)
+        expect(auction_2.end_datetime).to eq(date_middle)
+        expect(auction_3.end_datetime).to eq(date_first)
+      end
+    end
   end
 
   describe '#show' do


### PR DESCRIPTION
For #538 

I made the grid 2 wide to emulate the [micropurchase prototype](https://pages.18f.gov/micropurchase/).

* used flexbox to create same-heighted cards
* did not change style of auction cards
* wrote rspec tests to make sure that they are ordered by `date_endtime`