### PR TITLE
Ensure vendors that are not small businesses cannot bid on auctions > $3500 via API

### DIFF
--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -10,6 +10,16 @@ FactoryGirl.define do
     sam_status :duns_blank
     credit_card_form_url 'https://some-website.com/pay'
 
+    trait :small_business do
+      sam_status { :sam_accepted }
+      small_business { true }
+    end
+
+    trait :not_small_business do
+      sam_status { :sam_accepted }
+      small_business { false }
+    end
+
     factory :admin_user do
       github_id { Admins.github_ids.first }
 

--- a/spec/requests/bids_spec.rb
+++ b/spec/requests/bids_spec.rb
@@ -126,6 +126,23 @@ describe AuctionsController do
         end
       end
 
+      context 'when the auction start price is between the micropurchase and SAT threshold' do
+        let(:auction) { create(:auction, :between_micropurchase_and_sat_threshold, :running) }
+        let(:bid_amount) { current_auction_price - 10 }
+
+        context 'and the vendor is not small business' do
+          let(:user) { create(:user, :not_small_business) }
+
+          it 'returns a json error' do
+            expect(json_response['error']).to eq('You are not allowed to bid on this auction')
+          end
+
+          it 'returns a 403 status code' do
+            expect(status).to eq(403)
+          end
+        end
+      end
+
       context 'when the auction is multi-bid' do
         let(:auction) { FactoryGirl.create(:auction, :running, :multi_bid) }
 


### PR DESCRIPTION
fixes https://github.com/18F/micropurchase/issues/571

I'm not sure we should have cucumber features for an API story. If I'm wrong, let me know and I'll try to add some.

You'll notice this PR doesn't contain any new application code, just a new request spec (tests the API) and specs on `PlaceBid` (controls all bid placement) to ensure that vendors who aren't small businesses cannot bid on small-business-only auctions.