### PR TITLE
Moved eligibility labels into the eligibility classes

### DIFF
--- a/app/models/in_sam_eligibility.rb
+++ b/app/models/in_sam_eligibility.rb
@@ -2,4 +2,8 @@ class InSamEligibility
   def eligible?(user)
     user.sam_accepted?
   end
+
+  def label
+    'SAM.gov only'
+  end
 end

--- a/app/models/rules/base_rules.rb
+++ b/app/models/rules/base_rules.rb
@@ -7,6 +7,10 @@ class Rules::BaseRules
     @eligibility = eligibility
   end
 
+  def eligibility_label
+    eligibility.label
+  end
+
   def partial_path(name, base_dir = 'auctions')
     "#{base_dir}/#{partial_prefix}/#{name}.html.erb"
   end

--- a/app/models/small_business_eligibility.rb
+++ b/app/models/small_business_eligibility.rb
@@ -3,4 +3,8 @@ class SmallBusinessEligibility
     InSamEligibility.new.eligible?(user) &&
       user.small_business?
   end
+
+  def label
+    'Small-business only'
+  end
 end

--- a/app/presenters/auction_presenter.rb
+++ b/app/presenters/auction_presenter.rb
@@ -137,12 +137,8 @@ class AuctionPresenter
     "#{root_url}/auctions/#{id}"
   end
 
-  def eligibility
-    if small_business?
-      'Small-business only'
-    else
-      'SAM.gov only'
-    end
+  def eligibility_label
+    auction_rules.eligibility.label
   end
 
   private

--- a/app/view_models/auction_view_model.rb
+++ b/app/view_models/auction_view_model.rb
@@ -8,7 +8,7 @@ class AuctionViewModel < Struct.new(:current_user, :auction_record)
     :bids?,
     :created_at,
     :delivery_deadline,
-    :eligibility,
+    :eligibility_label,
     :end_datetime,
     :formatted_delivery_deadline,
     :formatted_end_time,

--- a/app/views/auctions/_list_item.html.erb
+++ b/app/views/auctions/_list_item.html.erb
@@ -8,7 +8,7 @@
         <%=h raw auction.html_summary %><a class="issue-list-item-details" href="<%= auction_path(auction) %>">View details <icon class="fa fa-angle-double-right"></icon></a>
       </p>
       <p><%= auction.formatted_type.capitalize %></p>
-      <p><%= auction.eligibility %></p>
+      <p><%= auction.eligibility_label %></p>
     </div>
   </div>
   <div class="usa-grid issue-bid-details">

--- a/app/views/auctions/show.html.erb
+++ b/app/views/auctions/show.html.erb
@@ -25,7 +25,7 @@
       </div>
       <div>
         <p class="auction-label">Eligible vendors:</p>
-        <p class="auction-label-info"><%= @view_model.auction.eligibility %></p>
+        <p class="auction-label-info"><%= @view_model.auction.eligibility_label %></p>
       </div>
       <div>
         <p class="auction-label">Status:</p>


### PR DESCRIPTION
My attempt at implementing some of the feedback from https://github.com/18F/micropurchase/pull/558.

In this PR, `AuctionPresenter` is made to know nothing about strings/labels related to eligibilities. It's delegated out to the eligibility classes via the `Rules::BaseRules` class.