### PR TITLE
Add default values to `Admin::EditAuctionViewModel`

### DIFF
--- a/app/presenters/default_date_time.rb
+++ b/app/presenters/default_date_time.rb
@@ -1,6 +1,6 @@
 class DefaultDateTime
-  HOUR = "13"
-  MINUTE = "00"
+  HOUR = "13".freeze
+  MINUTE = "00".freeze
 
   attr_reader :dc_time
 
@@ -9,7 +9,7 @@ class DefaultDateTime
   end
 
   def convert
-    @_converted ||= dc_time.change({ hour: HOUR, min: MINUTE, sec: 0 })
+    @_converted ||= dc_time.change(hour: HOUR, min: MINUTE, sec: 0)
   end
 
   def hour

--- a/app/presenters/default_date_time.rb
+++ b/app/presenters/default_date_time.rb
@@ -1,0 +1,26 @@
+class DefaultDateTime
+  HOUR = "13"
+  MINUTE = "00"
+
+  attr_reader :dc_time
+
+  def initialize
+    @dc_time = DcTimePresenter.new(Time.current).convert
+  end
+
+  def convert
+    @_converted ||= dc_time.change({ hour: HOUR, min: MINUTE, sec: 0 })
+  end
+
+  def hour
+    convert.strftime('%l').strip
+  end
+
+  def minute
+    convert.strftime('%M').strip
+  end
+
+  def meridiem
+    convert.strftime('%p').strip
+  end
+end

--- a/app/view_models/admin/edit_auction_view_model.rb
+++ b/app/view_models/admin/edit_auction_view_model.rb
@@ -14,24 +14,44 @@ class Admin::EditAuctionViewModel
   end
 
   def hour_default(field)
-    dc_time(field).strftime("%l").strip
+    if field_value(field).present?
+      dc_time(field).strftime("%l").strip
+    else
+      "1"
+    end
   end
 
   def minute_default(field)
-    dc_time(field).strftime("%M").strip
+    if field_value(field).present?
+      dc_time(field).strftime("%M").strip
+    else
+      "00"
+    end
   end
 
   def meridiem_default(field)
-    dc_time(field).strftime("%p")
+    if field_value(field).present?
+      dc_time(field).strftime("%p")
+    else
+      "PM"
+    end
   end
 
   def date_default(field)
-    dc_time(field).to_date
+    if field_value(field).present?
+      dc_time(field).to_date
+    else
+      DcTimePresenter.convert(Date.today).to_date
+    end
   end
 
   private
 
   def dc_time(field)
     DcTimePresenter.convert(auction.send("#{field}_at"))
+  end
+
+  def field_value(field)
+    auction.send("#{field}_at")
   end
 end

--- a/app/view_models/admin/edit_auction_view_model.rb
+++ b/app/view_models/admin/edit_auction_view_model.rb
@@ -13,45 +13,33 @@ class Admin::EditAuctionViewModel
     false
   end
 
+  def date_default(field)
+    dc_time(field).to_date
+  end
+
   def hour_default(field)
-    if field_value(field).present?
-      dc_time(field).strftime("%l").strip
-    else
-      "1"
-    end
+    dc_time(field).strftime('%l').strip
   end
 
   def minute_default(field)
-    if field_value(field).present?
-      dc_time(field).strftime("%M").strip
-    else
-      "00"
-    end
+    dc_time(field).strftime('%M').strip
   end
 
   def meridiem_default(field)
-    if field_value(field).present?
-      dc_time(field).strftime("%p")
-    else
-      "PM"
-    end
-  end
-
-  def date_default(field)
-    if field_value(field).present?
-      dc_time(field).to_date
-    else
-      DcTimePresenter.convert(Date.today).to_date
-    end
+    dc_time(field).strftime('%p').strip
   end
 
   private
 
   def dc_time(field)
-    DcTimePresenter.convert(auction.send("#{field}_at"))
+    DcTimePresenter.convert(field_value(field))
   end
 
   def field_value(field)
-    auction.send("#{field}_at")
+    auction.send("#{field}_at") || default_date_time
+  end
+
+  def default_date_time
+    @_default_date_time ||= DefaultDateTime.new.convert
   end
 end

--- a/app/view_models/admin/new_auction_view_model.rb
+++ b/app/view_models/admin/new_auction_view_model.rb
@@ -7,19 +7,25 @@ class Admin::NewAuctionViewModel
     true
   end
 
+  def date_default(_field)
+    default_date_time.convert.to_date
+  end
+
   def hour_default(_field)
-    "1"
+    default_date_time.hour
   end
 
   def minute_default(_field)
-    "00"
+    default_date_time.minute
   end
 
   def meridiem_default(_field)
-    "PM"
+    default_date_time.meridiem
   end
 
-  def date_default(_field)
-    DcTimePresenter.convert(Date.today).to_date
+  private
+
+  def default_date_time
+    DefaultDateTime.new
   end
 end

--- a/app/view_models/admin/new_auction_view_model.rb
+++ b/app/view_models/admin/new_auction_view_model.rb
@@ -8,7 +8,7 @@ class Admin::NewAuctionViewModel
   end
 
   def hour_default(_field)
-    "7"
+    "1"
   end
 
   def minute_default(_field)
@@ -20,6 +20,6 @@ class Admin::NewAuctionViewModel
   end
 
   def date_default(_field)
-    Date.today
+    DcTimePresenter.convert(Date.today).to_date
   end
 end

--- a/spec/view_models/admin/edit_auction_view_model_spec.rb
+++ b/spec/view_models/admin/edit_auction_view_model_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+
+describe Admin::EditAuctionViewModel do
+  describe '#hour_default' do
+    context 'time present' do
+      it 'returns hour in DC time' do
+        Timecop.freeze(Time.parse("10:00:00 UTC")) do
+          auction = build(:auction, delivery_due_at: Time.current)
+          view_model = Admin::EditAuctionViewModel.new(auction)
+
+          expect(view_model.hour_default('delivery_due')).to eq '6'
+         end
+      end
+    end
+
+    context 'time not present' do
+      it 'returns default' do
+        auction = build(:auction, delivery_due_at: nil)
+        view_model = Admin::EditAuctionViewModel.new(auction)
+
+        expect(view_model.hour_default('delivery_due')).to eq '1'
+      end
+    end
+  end
+
+  describe '#minute_default' do
+    context 'time present' do
+      it 'returns minutes for time entered' do
+        Timecop.freeze(Time.parse("10:30:00 UTC")) do
+          auction = build(:auction, delivery_due_at: Time.current)
+          view_model = Admin::EditAuctionViewModel.new(auction)
+
+          expect(view_model.minute_default('delivery_due')).to eq '30'
+         end
+      end
+    end
+
+    context 'time not present' do
+      it 'returns default' do
+        auction = build(:auction, delivery_due_at: nil)
+        view_model = Admin::EditAuctionViewModel.new(auction)
+
+        expect(view_model.minute_default('delivery_due')).to eq '00'
+      end
+    end
+  end
+
+  describe '#meridiam' do
+    context 'time present' do
+      it 'returns meridiam for time value' do
+        Timecop.freeze(Time.parse("10:00:00 UTC")) do
+          auction = build(:auction, delivery_due_at: Time.current)
+          view_model = Admin::EditAuctionViewModel.new(auction)
+
+          expect(view_model.meridiem_default('delivery_due')).to eq "AM"
+         end
+      end
+    end
+
+    context 'time not present' do
+      it 'returns default' do
+        auction = build(:auction, delivery_due_at: nil)
+        view_model = Admin::EditAuctionViewModel.new(auction)
+
+        expect(view_model.meridiem_default('delivery_due')).to eq "PM"
+      end
+    end
+  end
+
+  describe '#date_default' do
+    context 'date present' do
+      it 'returns the date value of the field' do
+        auction = build(:auction, delivery_due_at: 1.day.ago)
+        view_model = Admin::EditAuctionViewModel.new(auction)
+
+        expect(view_model.date_default('delivery_due')).to eq(
+          DcTimePresenter.convert(1.day.ago).to_date
+        )
+      end
+    end
+
+    context 'date not present' do
+      it 'returns todays date' do
+        auction = build(:auction, delivery_due_at: nil)
+        view_model = Admin::EditAuctionViewModel.new(auction)
+
+        expect(view_model.date_default('delivery_due')).to eq(
+          DcTimePresenter.convert(Date.today).to_date
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Started_at and ended_at are required, but `delivery_deadline` input
  (which is on create only) is not, leaving us with a blank
  `delivery_due_at` field on edit
* Was receiving errors on staging (`undefined method strftime for nil`)
* Also update `auctions#new` defaults to be ET defaults suggested in #560