### PR TITLE
Include quartile minute helpers in `seed` task

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,10 +1,4 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
-#
-# Examples:
-#
-#   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
-#   Mayor.create(name: 'Emanuel', city: cities.first)
+require Rails.root.join('spec', 'support', 'time_helpers.rb')
 
 FactoryGirl.create(:auction, :multi_bid, :with_bidders)
 FactoryGirl.create(:auction, :multi_bid, :expiring, :with_bidders)

--- a/spec/factories/auctions.rb
+++ b/spec/factories/auctions.rb
@@ -1,15 +1,15 @@
 FactoryGirl.define do
   factory :auction do
     association :user, factory: :admin_user
-    started_at { quartile_minute(Time.now - 3.days) }
-    ended_at { quartile_minute(Time.now + 3.days) }
+    started_at { TimeHelpers::quartile_minute(Time.now - 3.days) }
+    ended_at { TimeHelpers::quartile_minute(Time.now + 3.days) }
     result :not_applicable
     title { Faker::Company.catch_phrase }
     type :multi_bid
     published :published
     summary Faker::Lorem.paragraph
     description Faker::Lorem.paragraphs(3, true).join("\n\n")
-    delivery_due_at { quartile_minute(Time.now + 10.days) }
+    delivery_due_at { TimeHelpers::quartile_minute(Time.now + 10.days) }
 
     trait :single_bid_with_tie do
       single_bid
@@ -73,17 +73,17 @@ FactoryGirl.define do
     end
 
     trait :available do
-      started_at { quartile_minute(Time.now - 2.days) }
-      ended_at { quartile_minute(Time.now + 2.days) }
+      started_at { TimeHelpers::quartile_minute(Time.now - 2.days) }
+      ended_at { TimeHelpers::quartile_minute(Time.now + 2.days) }
     end
 
     trait :closed do
-      ended_at { quartile_minute(Time.now - 2.days) }
+      ended_at { TimeHelpers::quartile_minute(Time.now - 2.days) }
     end
 
     trait :delivered do
-      ended_at { quartile_minute(Time.now - 2.days) }
-      delivery_due_at { quartile_minute(Time.now - 1.day) }
+      ended_at { TimeHelpers::quartile_minute(Time.now - 2.days) }
+      delivery_due_at { TimeHelpers::quartile_minute(Time.now - 1.day) }
       delivery_url 'https://github.com/foo/bar'
     end
 
@@ -101,16 +101,16 @@ FactoryGirl.define do
     end
 
     trait :expiring do
-      ended_at { quartile_minute(Time.now + 3.hours) }
+      ended_at { TimeHelpers::quartile_minute(Time.now + 3.hours) }
     end
 
     trait :future do
-      started_at { quartile_minute(Time.now + 1.day) }
+      started_at { TimeHelpers::quartile_minute(Time.now + 1.day) }
     end
 
     trait :delivery_due_at_expired do
       closed
-      delivery_due_at { quartile_minute(ended_at + 1.day) }
+      delivery_due_at { TimeHelpers::quartile_minute(ended_at + 1.day) }
     end
 
     trait :accepted do

--- a/spec/support/quartile_minute.rb
+++ b/spec/support/quartile_minute.rb
@@ -1,5 +1,0 @@
-def quartile_minute(time)
-  # This is for Factory-created auctions to match the 0/15/30/45
-  # quartiles that auctions created in the admin form
-  Time.local(time.year, time.month, time.day, time.hour, time.min/15*15)
-end

--- a/spec/support/time_helpers.rb
+++ b/spec/support/time_helpers.rb
@@ -1,0 +1,7 @@
+module TimeHelpers
+  def self.quartile_minute(time)
+    # This is for Factory-created auctions to match the 0/15/30/45
+    # quartiles that auctions created in the admin form
+    Time.local(time.year, time.month, time.day, time.hour, time.min/15*15)
+  end
+end


### PR DESCRIPTION
* Was not loading before
* Because things in `spec/support` are loaded in test env only