### PR TITLE
Added copy for winners page

### DIFF
--- a/app/views/auctions/_faqs.erb
+++ b/app/views/auctions/_faqs.erb
@@ -1,0 +1,29 @@
+<section class="usa-width-full">
+  <section class="usa-grid usa-grid-top-padding">
+
+    <section>
+      <h1>FAQ</h1>
+
+      <!-- <h2 class="h3" id="agency-savings">Is Micropurchase saving agencies money?</h2> -->
+      <h2 class="h3" id="agency-savings">Lorem ipsum?</h2>
+      <p>Lorem ipsum by doing this and that</p>
+
+      <!-- <h2 class="h3">How does the GSA avoid split purchases?</h2> -->
+      <h2 class="h3">Ipsum lorem?</h2>
+      <p>Lorem ipsum by doing this and that</p>
+
+      <!-- <h2 class="h3">What kind of projects can I use Micropurchase for?</h2> -->
+      <h2 class="h3">Ipsum lorem?</h2>
+      <p>Lorem ipsum dolor sit amet, consectetor. To learn more, check out <a class="link-highlighted" href="#">all archived opportunities <icon class="fa fa-angle-double-right"></icon></a></p>
+
+      <!-- <h2 class="h3">What if it isn’t successful?</h2> -->
+      <h2 class="h3">Lorem ipsum?</h2>
+      <p>Lorem ipsum dolor sit amet, consecttetor. To learn more, check out <a class="link-highlighted" href="#">these unsuccessful opportunities <icon class="fa fa-angle-double-right"></icon></a></p>
+
+      <!-- <h2 class="h3" id="auction-length">How long does an auction last?</h2> -->
+      <h2 class="h3" id="auction-length">Lorem ipsum?</h2>
+      <p>Lorem ipsum dolor sit amet, consecttetor.</p>
+
+    </section>
+  </section>
+</section>

--- a/app/views/auctions/previous_winners.erb
+++ b/app/views/auctions/previous_winners.erb
@@ -48,7 +48,7 @@
         <div class="usa-width-one-half" id="donut-by-language"></div>
 
       </div>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+      <p>All micro-purchase auctions are for open source code contributions to public code repositories (repos) hosted on GitHub. Auction winners submit code to a repository for review, and if the code passes the acceptance criteria, the owner of the repository will accept the code into the repository. On the left, you can see a breakdown of the various repos that have incorporated code from micro-purchase auction winners. On the right, you can see what programming languages have been used in micro-purchase solutions. Move your mouse over a section to see the name of that category.</p>
     </section>
   </section>
 </section>
@@ -60,7 +60,7 @@
       <h2 class="h4">What bids are winning these days?</h2>
       <p class="winners-chart-directions">Only auctions with at least one bid are represented.</p>
       <div id="chart2"></div>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+      <p>All micro-purchase reverse auctions start at $3,500 and vendors bid down the price they accept for completing the tasks presented. The graph above shows how the winning price for auctions have changed over time. Place your mouse over an auction to see exact bid numbers. Winning bids have ranged across the spectrum from $1 to near the $3,500 cap.</p>
 
     </section>
   </section>
@@ -73,7 +73,7 @@
       <h2 class="h4">The Micropurchase platform is growing.</h2>
       <p class="winners-chart-directions">Use the subchart below to navigate past community figures</p>
       <div id="chart4"></div>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+      <p>The micro-purchase platform has tapped into an interested community of both government product owners and open source contributors. As the 18F team ramps up capacity to host more auctions for more projects, we’re also seeing an increase in bidders. This is all positive evidence that there is an untapped marketplace for small, open source contributions to government projects. Drag and adjust the black box on the bottom bar to see a more detailed view of each date.</p>
     </section>
   </section>
 </section>
@@ -84,39 +84,11 @@
       <h1>Bids by auction</h1>
       <h2 class="h4">Are number of bids and winning bid related?</h2>
       <div id="chart5"></div>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+      <p>Mouse over each circle to see how many bids that auction received and the price of the winning bid. As we explore this market, we’re excited to analyze trends in bidding volume, winning price, and auction type.</p>
     </section>
   </section>
 </section>
 
-<section class="usa-width-full">
-  <section class="usa-grid usa-grid-top-padding">
-
-    <section>
-      <h1>FAQ</h1>
-
-      <!-- <h2 class="h3" id="agency-savings">Is Micropurchase saving agencies money?</h2> -->
-      <h2 class="h3" id="agency-savings">Lorem ipsum?</h2>
-      <p>Lorem ipsum by doing this and that</p>
-
-      <!-- <h2 class="h3">How does the GSA avoid split purchases?</h2> -->
-      <h2 class="h3">Ipsum lorem?</h2>
-      <p>Lorem ipsum by doing this and that</p>
-
-      <!-- <h2 class="h3">What kind of projects can I use Micropurchase for?</h2> -->
-      <h2 class="h3">Ipsum lorem?</h2>
-      <p>Lorem ipsum dolor sit amet, consectetor. To learn more, check out <a class="link-highlighted" href="#">all archived opportunities <icon class="fa fa-angle-double-right"></icon></a></p>
-
-      <!-- <h2 class="h3">What if it isn’t successful?</h2> -->
-      <h2 class="h3">Lorem ipsum?</h2>
-      <p>Lorem ipsum dolor sit amet, consecttetor. To learn more, check out <a class="link-highlighted" href="#">these unsuccessful opportunities <icon class="fa fa-angle-double-right"></icon></a></p>
-
-      <!-- <h2 class="h3" id="auction-length">How long does an auction last?</h2> -->
-      <h2 class="h3" id="auction-length">Lorem ipsum?</h2>
-      <p>Lorem ipsum dolor sit amet, consecttetor.</p>
-
-    </section>
-  </section>
-</section>
+<!-- <%= render partial: 'auctions/faqs' %> -->
 
 <%= javascript_include_tag "winners-bundle" %>


### PR DESCRIPTION
This commit adds the copy for the winners page and would close #578.

In this commit, I extracted the FAQ as a partial to make it easier to keep
track of things. And then, because there are no actual FAQs right now, I
commented the render tag. When we add FAQs, all we'll need to do is
uncomment the render tag.