### PR TITLE
Rename AuctionStatus:: classes to StatusPresenter::

### DIFF
--- a/app/models/status_presenter_factory.rb
+++ b/app/models/status_presenter_factory.rb
@@ -6,7 +6,7 @@ class StatusPresenterFactory
   end
 
   def create
-    "AuctionStatus::#{status_name}".constantize.new(auction)
+    "StatusPresenter::#{status_name}".constantize.new(auction)
   end
 
   private

--- a/app/presenters/status_presenter/available.rb
+++ b/app/presenters/status_presenter/available.rb
@@ -1,4 +1,4 @@
-class AuctionStatus::Available < Struct.new(:auction)
+class StatusPresenter::Available < Struct.new(:auction)
   def start_label
     "Bid start time:"
   end

--- a/app/presenters/status_presenter/expiring.rb
+++ b/app/presenters/status_presenter/expiring.rb
@@ -1,4 +1,4 @@
-class AuctionStatus::Expiring < AuctionStatus::Available
+class StatusPresenter::Expiring < StatusPresenter::Available
   def label_class
     'auction-label-expiring'
   end

--- a/app/presenters/status_presenter/future.rb
+++ b/app/presenters/status_presenter/future.rb
@@ -1,14 +1,14 @@
-class AuctionStatus::Over < Struct.new(:auction)
+class StatusPresenter::Future < Struct.new(:auction)
   def start_label
-    "Auction started at:"
+    "Bid start time:"
   end
 
   def deadline_label
-    "Auction ended at:"
+    "Bid deadline:"
   end
 
   def relative_time
-    "Ended #{HumanTime.new(time: auction.ended_at).relative_time}"
+    "#{HumanTime.new(time: auction.started_at).relative_time} from now"
   end
 
   def time_left_partial
@@ -28,28 +28,22 @@ class AuctionStatus::Over < Struct.new(:auction)
   end
 
   def label_class
-    'auction-label-over'
+    'auction-label-future'
   end
 
   def label
-    'Closed'
+    'Coming Soon'
   end
 
   def tag_data_value_status
-    label
+    HumanTime.new(time: auction.started_at).relative_time
   end
 
   def tag_data_label_2
-    "Winning Bid"
+    "Starting bid"
   end
 
   def tag_data_value_2
-    Currency.new(lowest_bid.amount).to_s
-  end
-
-  private
-
-  def lowest_bid
-    auction.lowest_bid || NullBid.new
+    Currency.new(auction.start_price).to_s
   end
 end

--- a/app/presenters/status_presenter/over.rb
+++ b/app/presenters/status_presenter/over.rb
@@ -1,14 +1,14 @@
-class AuctionStatus::Future < Struct.new(:auction)
+class StatusPresenter::Over < Struct.new(:auction)
   def start_label
-    "Bid start time:"
+    "Auction started at:"
   end
 
   def deadline_label
-    "Bid deadline:"
+    "Auction ended at:"
   end
 
   def relative_time
-    "#{HumanTime.new(time: auction.started_at).relative_time} from now"
+    "Ended #{HumanTime.new(time: auction.ended_at).relative_time}"
   end
 
   def time_left_partial
@@ -28,22 +28,28 @@ class AuctionStatus::Future < Struct.new(:auction)
   end
 
   def label_class
-    'auction-label-future'
+    'auction-label-over'
   end
 
   def label
-    'Coming Soon'
+    'Closed'
   end
 
   def tag_data_value_status
-    HumanTime.new(time: auction.started_at).relative_time
+    label
   end
 
   def tag_data_label_2
-    "Starting bid"
+    "Winning Bid"
   end
 
   def tag_data_value_2
-    Currency.new(auction.start_price).to_s
+    Currency.new(lowest_bid.amount).to_s
+  end
+
+  private
+
+  def lowest_bid
+    auction.lowest_bid || NullBid.new
   end
 end

--- a/spec/presenters/status_presenter/available_spec.rb
+++ b/spec/presenters/status_presenter/available_spec.rb
@@ -1,21 +1,21 @@
 require 'rails_helper'
 
-describe AuctionStatus::Expiring do
-  context "when the auction is expiring soon" do
-    let(:presenter) { AuctionStatus::Expiring.new(auction) }
+describe StatusPresenter::Available do
+  context "when the auction is available" do
+    let(:presenter) { StatusPresenter::Available.new(auction) }
     let(:auction) do
       a = create(
         :auction,
         started_at: Time.now - 3.days,
-        ended_at: Time.now + 3.hours,
+        ended_at: Time.now + 2.days,
         start_price: 3500
       )
-      create(:bid, amount: 3000, auction: a)
+      create(:bid, auction: a, amount: 3000)
       a
     end
 
     it "has a twitter status data value with human readable time expression" do
-      expect(presenter.tag_data_value_status).to eq("about 3 hours left")
+      expect(presenter.tag_data_value_status).to eq("2 days left")
     end
 
     it "has a twitter second label that indicates bidding is open" do

--- a/spec/presenters/status_presenter/expiring_spec.rb
+++ b/spec/presenters/status_presenter/expiring_spec.rb
@@ -1,21 +1,21 @@
 require 'rails_helper'
 
-describe AuctionStatus::Available do
-  context "when the auction is available" do
-    let(:presenter) { AuctionStatus::Available.new(auction) }
+describe StatusPresenter::Expiring do
+  context "when the auction is expiring soon" do
+    let(:presenter) { StatusPresenter::Expiring.new(auction) }
     let(:auction) do
       a = create(
         :auction,
         started_at: Time.now - 3.days,
-        ended_at: Time.now + 2.days,
+        ended_at: Time.now + 3.hours,
         start_price: 3500
       )
-      create(:bid, auction: a, amount: 3000)
+      create(:bid, amount: 3000, auction: a)
       a
     end
 
     it "has a twitter status data value with human readable time expression" do
-      expect(presenter.tag_data_value_status).to eq("2 days left")
+      expect(presenter.tag_data_value_status).to eq("about 3 hours left")
     end
 
     it "has a twitter second label that indicates bidding is open" do

--- a/spec/presenters/status_presenter/future_spec.rb
+++ b/spec/presenters/status_presenter/future_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-describe AuctionStatus::Future do
+describe StatusPresenter::Future do
   context "when the auction is in the future" do
-    let(:presenter) { AuctionStatus::Future.new(auction) }
+    let(:presenter) { StatusPresenter::Future.new(auction) }
     let(:auction) do
       a = create(
         :auction,

--- a/spec/presenters/status_presenter/over_spec.rb
+++ b/spec/presenters/status_presenter/over_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-describe AuctionStatus::Over do
+describe StatusPresenter::Over do
   context "when the auction is over" do
-    let(:presenter) { AuctionStatus::Over.new(auction) }
+    let(:presenter) { StatusPresenter::Over.new(auction) }
     let(:auction) do
       a = create(
         :auction,


### PR DESCRIPTION
Since these are created by the StatusPresenterFactory, I feel like this is less confusing, especially since there is a separate AuctionStatus class.