### PR TITLE
Use new VERSIONED API endpoint for winners page

### DIFF
--- a/app/assets/javascripts/winners/previousWinners.js
+++ b/app/assets/javascripts/winners/previousWinners.js
@@ -3,16 +3,14 @@
 (function (window) {
   window.winners = {
     onReady: function(){
-      $.getJSON('/auctions.json').success(function(data){
+      $.getJSON('/api/v0/auctions.json').success(function(data) {
         var auctions = _.sortBy(data.auctions, 'id');
         window.winners.metrics = new Metrics(auctions);
         window.winners.charts = new Charts(auctions);
-
       })
       .error(function(error){
         throw "Error retrieving auction data";
       });
-
     }
   }
 


### PR DESCRIPTION
* Old endpoints redirect, but we should use the versioned endpoint