### PR TITLE
Prevent ineligible vendor from getting paid.

### DIFF
--- a/app/controllers/admin/auctions_controller.rb
+++ b/app/controllers/admin/auctions_controller.rb
@@ -39,7 +39,9 @@ class Admin::AuctionsController < ApplicationController
 
   def update
     auction = Auction.find(params[:id])
-    if UpdateAuction.new(auction, params, current_user).perform
+    update_auction = UpdateAuction.new(auction, params)
+
+    if update_auction.perform
       redirect_to admin_auctions_path
     else
       error_messages = auction.errors.full_messages.to_sentence

--- a/app/models/auction.rb
+++ b/app/models/auction.rb
@@ -13,7 +13,7 @@ class Auction < ActiveRecord::Base
   # Disable STI
   self.inheritance_column = :__disabled
 
-  validate :start_price_equal_to_or_less_than_max_if_not_contracting_officer
+  validate :user_is_contracting_officer_if_above_micropurchase
   validates :delivery_due_at, presence: true, if: :published?
   validates :description, presence: true, if: :published?
   validates :ended_at, presence: true
@@ -38,7 +38,7 @@ class Auction < ActiveRecord::Base
     bids.sort_by(&:amount).first.try(:amount)
   end
 
-  def start_price_equal_to_or_less_than_max_if_not_contracting_officer
+  def user_is_contracting_officer_if_above_micropurchase
     if user && !user.contracting_officer? && start_price > AuctionThreshold::MICROPURCHASE
       errors.add(
         :start_price,

--- a/app/services/update_auction.rb
+++ b/app/services/update_auction.rb
@@ -1,12 +1,29 @@
-class UpdateAuction < Struct.new(:auction, :params, :user)
+class UpdateAuction
+  def initialize(auction, params)
+    @auction = auction
+    @params = params
+  end
+
   def perform
     auction.assign_attributes(attributes)
+    create_purchase_request
 
+    if vendor_ineligible?
+      auction.errors.add(:base, 'The vendor cannot be paid')
+      false
+    else
+      auction.save
+    end
+  end
+
+  private
+
+  attr_reader :auction, :params
+
+  def create_purchase_request
     if should_create_cap_proposal?
       CreateCapProposalJob.perform_later(auction.id)
     end
-
-    auction.save
   end
 
   def should_create_cap_proposal?
@@ -14,7 +31,10 @@ class UpdateAuction < Struct.new(:auction, :params, :user)
       winning_bidder_is_eligible_to_be_paid?
   end
 
-  private
+  def vendor_ineligible?
+    auction_accepted_and_cap_proposal_is_blank? &&
+      !winning_bidder_is_eligible_to_be_paid?
+  end
 
   def auction_accepted_and_cap_proposal_is_blank?
     attributes[:result] == 'accepted' && auction.cap_proposal_url.blank?
@@ -49,10 +69,6 @@ class UpdateAuction < Struct.new(:auction, :params, :user)
   end
 
   def attributes
-    parser.attributes
-  end
-
-  def parser
-    @_parser ||= AuctionParser.new(params, user)
+    @_attributes ||= AuctionParser.new(params, auction.user).attributes
   end
 end

--- a/features/admin_approves_delivery.feature
+++ b/features/admin_approves_delivery.feature
@@ -14,3 +14,13 @@ Feature: Admin approves delivery of a project
     Then the proposal should have a CAP Proposal URL
     When I visit the admin edit page for that auction
     Then I should see that the auction has a CAP Proposal URL
+
+    Scenario: Marking an auction as accepted where the vendor cannot be paid
+      Given I am an administrator
+      And there is an auction where the winning vendor is not eligible to be paid
+      And I sign in
+      When I visit the admin edit page for that auction
+      And I select the result as accepted
+      And I click on the "Update" button
+      Then the proposal should not have a CAP Proposal URL
+      And I should see an error that "The vendor cannot be paid"

--- a/features/step_definitions/auction_attributes_steps.rb
+++ b/features/step_definitions/auction_attributes_steps.rb
@@ -78,6 +78,11 @@ Then(/^the proposal should have a CAP Proposal URL$/) do
   expect(@auction.cap_proposal_url).not_to eq ""
 end
 
+Then(/^the proposal should not have a CAP Proposal URL$/) do
+  @auction.reload
+  expect(@auction.cap_proposal_url).to eq ""
+end
+
 Then(/^I should see a preview of the auction$/) do
   expect(page).to have_text(@unpublished_auction.description)
 end

--- a/features/step_definitions/auction_create_steps.rb
+++ b/features/step_definitions/auction_create_steps.rb
@@ -63,3 +63,12 @@ end
 Given(/^there are complete and successful auctions$/) do
   @complete_and_successful = FactoryGirl.create_list(:auction, 2, :complete_and_successful)
 end
+
+Given(/^there is an auction where the winning vendor is not eligible to be paid$/) do
+  @auction = FactoryGirl.create(
+    :auction,
+    :between_micropurchase_and_sat_threshold,
+    :winning_vendor_is_non_small_business,
+    :evaluation_needed
+  )
+end

--- a/features/step_definitions/flash_message_steps.rb
+++ b/features/step_definitions/flash_message_steps.rb
@@ -31,8 +31,13 @@ Then(/^I should not see an alert that my DUNS number was not found in Sam\.gov$/
 end
 
 Then(/^I should see a warning that "([^"]*)"$/) do |message|
-  # expect(page).to have_content(message)
   within("div.usa-alert.usa-alert-warning") do
+    expect(page).to have_content(message)
+  end
+end
+
+Then(/^I should see an error that "([^"]*)"$/) do |message|
+  within("div.usa-alert.usa-alert-error") do
     expect(page).to have_content(message)
   end
 end

--- a/spec/controllers/admin/auctions_controller_spec.rb
+++ b/spec/controllers/admin/auctions_controller_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 describe Admin::AuctionsController do
-
   describe '#index' do
     it 'assigns presented auctions' do
       user = create(:admin_user)
@@ -47,9 +46,7 @@ describe Admin::AuctionsController do
         put :update, params, user_id: user.id
         auction = assigns(:auction)
 
-        expect(auction).to be_a(Admin::EditAuctionViewModel)
         expect(auction.record.id).to eq(auction_record.id)
-
         expect(controller).to render_template :edit
       end
     end

--- a/spec/services/update_auction_spec.rb
+++ b/spec/services/update_auction_spec.rb
@@ -35,10 +35,12 @@ describe UpdateAuction do
       context 'and the auction is between micropurchase and SAT threshold' do
         context 'and the winning vendor is a small business' do
           it 'calls the CreateCapProposalJob' do
-            auction = create(:auction,
-                             :between_micropurchase_and_sat_threshold,
-                             :winning_vendor_is_small_business,
-                             :delivery_due_at_expired)
+            auction = create(
+              :auction,
+              :between_micropurchase_and_sat_threshold,
+              :winning_vendor_is_small_business,
+              :delivery_due_at_expired
+            )
             allow(CreateCapProposalJob).to receive(:perform_later)
               .with(auction.id)
               .and_return(nil)
@@ -52,11 +54,12 @@ describe UpdateAuction do
 
         context 'and the winning vendor is not a small business' do
           it 'does not call the CreateCapProposalJob' do
-            auction = create(:auction,
-                             :between_micropurchase_and_sat_threshold,
-                             :winning_vendor_is_non_small_business,
-                             :delivery_due_at_expired)
-            
+            auction = create(
+              :auction,
+              :between_micropurchase_and_sat_threshold,
+              :winning_vendor_is_non_small_business,
+              :delivery_due_at_expired
+            )
             allow(CreateCapProposalJob).to receive(:perform_later)
               .with(auction.id)
               .and_return(nil)
@@ -88,46 +91,9 @@ describe UpdateAuction do
           .with(auction.id)
           .and_return(nil)
 
-        updater = UpdateAuction.new(auction, params)
+        UpdateAuction.new(auction, params)
 
         expect(CreateCapProposalJob).to_not have_received(:perform_later).with(auction.id)
-      end
-    end
-  end
-
-  describe '#should_create_cap_proposal?' do
-    context 'when there already is a cap_proposal_url' do
-      it 'should return false' do
-        auction = create(:auction, :payment_pending)
-        params = { auction: { title: 'A new auction title' } }
-
-        updater = UpdateAuction.new(auction, params)
-
-        expect(updater.should_create_cap_proposal?).to be(false)
-      end
-    end
-
-    context 'when there is not already a cap_proposal_url' do
-      context 'and params contains result=accepted' do
-        it 'should return true' do
-          auction = create(:auction, :payment_needed)
-          params = { auction: { result: 'accepted' } }
-
-          updater = UpdateAuction.new(auction, params)
-
-          expect(updater.should_create_cap_proposal?).to be(true)
-        end
-      end
-
-      context 'and auction.result is set to rejected' do
-        it 'should return false' do
-          auction = create(:auction, :payment_needed)
-          params = { auction: { result: 'rejected' } }
-
-          updater = UpdateAuction.new(auction, params)
-
-          expect(updater.should_create_cap_proposal?).to be(false)
-        end
       end
     end
   end


### PR DESCRIPTION
* Closes #574
* Added spec for Admin::AuctionsController#update
* Removed `let` from Admin::AuctionsController specs

Opening as new version of https://github.com/18F/micropurchase/pull/630/