### PR TITLE
Fix the issue with the pending iso8601 test

### DIFF
--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -52,7 +52,6 @@ describe Api::V0::Admin::UsersController do
       end
 
       it 'returns iso8601 dates' do
-        skip 'until the bug can be solved'
         expect(json_non_admin_users.map { |a| a['created_at'] }).to all(be_iso8601)
         expect(json_non_admin_users.map { |a| a['updated_at'] }).to all(be_iso8601)
       end

--- a/spec/support/iso8601_matcher.rb
+++ b/spec/support/iso8601_matcher.rb
@@ -1,6 +1,7 @@
 RSpec::Matchers.define :be_iso8601 do |expected|
   def to_iso8601(string)
-    DateTime.parse(string).iso8601
+    # JSON iso has 3 digits of milliseconds sometimes, but don't include if 000
+    DateTime.parse(string).iso8601(3).gsub('.000+', '+')
   end
 
   match do |actual|


### PR DESCRIPTION
The issue is that the JSON includes milliseconds sometimes, but iso8601 doesn't normally put them out