### PR TITLE
Small style cleanup for new bids toggle

### DIFF
--- a/app/assets/stylesheets/blocks/_auction.scss
+++ b/app/assets/stylesheets/blocks/_auction.scss
@@ -27,13 +27,19 @@ textarea#auction_description {
   height: 500px;
 }
 
-.auction-description {
+.auction-title {
   h1 {
     margin-top: 0;
   }
 }
 
-.github-issue {
+.auction-body {
+  table {
+    margin: 0;
+  }
+}
+
+.auction-description {
   h1 {
     line-height: 1.1em;
     margin-bottom: .5em;
@@ -169,7 +175,6 @@ textarea#auction_description {
   width: 25px;
   max-width: none;
 }
-
 
 .issue-details-label {
   font-size: $h6-font-size;

--- a/app/views/auctions/_auction.html.erb
+++ b/app/views/auctions/_auction.html.erb
@@ -3,7 +3,7 @@
     <%= render partial: 'auctions/header', locals: { auction: auction } %>
   </div>
 
-  <div class="github-issue">
+  <div class="auction-description">
     <%= auction.html_description %>
   </div>
 </div>

--- a/app/views/auctions/show.html.erb
+++ b/app/views/auctions/show.html.erb
@@ -7,10 +7,16 @@
 <%= render partial: @auction.bid_flash_partial,
   locals: { auction: @auction, status: @auction.bid_status_class(flash)  } %>
 
-<div class="usa-grid-full">
-  <p><a class="link-highlighted" href="<%= root_path %>"><icon class="fa fa-angle-double-left"></icon> Back to open projects</a></p>
-  <div class="usa-width-two-thirds auction-description">
-    <h1><%= @auction.title %></h1>
+<div class="usa-grid">
+  <p>
+  <%= link_to "<icon class='fa fa-angle-double-left'></icon>Back to open projects".html_safe,
+    root_path,
+    class: 'link-highlighted' %>
+  </p>
+  <div class="usa-width-two-thirds">
+    <div class="auction-title">
+      <h1><%= @auction.title %></h1>
+    </div>
 
     <%= render partial: 'auctions/auction', locals: { auction: @auction } %>
     <%= render partial: 'auctions/bids', locals: { auction_bids: @auction } %>


### PR DESCRIPTION
* Prevent page from changing width by using `usa-grid` instead of
  `usa-grid-full`
* Remove table margin

Before:
![screen shot 2016-06-17 at 11 08 19 am](https://cloud.githubusercontent.com/assets/601515/16160256/fc46bcae-347b-11e6-9129-d110b5bc1023.png)


After:
![screen shot 2016-06-17 at 11 08 06 am](https://cloud.githubusercontent.com/assets/601515/16160260/016a9318-347c-11e6-8b87-3cdf00c81779.png)
