### PR TITLE
Allow admin to update old auctions

### DIFF
--- a/app/controllers/admin/auctions_controller.rb
+++ b/app/controllers/admin/auctions_controller.rb
@@ -40,7 +40,7 @@ class Admin::AuctionsController < Admin::BaseController
 
   def update
     auction = Auction.find(params[:id])
-    update_auction = UpdateAuction.new(auction, params)
+    update_auction = UpdateAuction.new(auction: auction, params: params, current_user: current_user)
 
     if update_auction.perform
       return_to_stored(default: admin_auctions_path)

--- a/app/models/auction_parser.rb
+++ b/app/models/auction_parser.rb
@@ -12,7 +12,7 @@ class AuctionParser
       ended_at: ended_at,
       started_at: started_at,
       user: user
-    )
+    ).delete_if { |_key, value| value.nil? }
   end
 
   private

--- a/app/services/update_auction.rb
+++ b/app/services/update_auction.rb
@@ -1,7 +1,8 @@
 class UpdateAuction
-  def initialize(auction, params)
+  def initialize(auction:, params:, current_user:)
     @auction = auction
     @params = params
+    @current_user = current_user
   end
 
   def perform
@@ -18,7 +19,7 @@ class UpdateAuction
 
   private
 
-  attr_reader :auction, :params
+  attr_reader :auction, :params, :current_user
 
   def create_purchase_request
     if should_create_cap_proposal?
@@ -69,6 +70,10 @@ class UpdateAuction
   end
 
   def attributes
-    @_attributes ||= AuctionParser.new(params, auction.user).attributes
+    @_attributes ||= AuctionParser.new(params, user).attributes
+  end
+
+  def user
+    auction.user || current_user
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,9 +3,26 @@ Rails.application.routes.draw do
     mount LetterOpenerWeb::Engine => "letter_opener"
   end
 
-  # Web requests
   root 'auctions#index'
 
+  # Map current API requests to new controller for now
+  namespace :api, defaults: { format: 'json' } do
+    namespace :v0 do
+      resources :auctions, only: [:index, :show] do
+        resources :bids, only: [:create]
+      end
+
+      namespace :admin do
+        resources :auctions, only: [:index, :show]
+        resources :users, only: [:index]
+      end
+    end
+  end
+
+  # Temporarily send JSON requests to web to API
+  match '*path.:format', to: redirect("/api/v0/%{path}"), via: [:get, :post], constraints: { format: :json }
+
+  # Web requests
   get '/auth/:provider/callback', to: 'authentications#create'
   get '/login', to: 'logins#index'
   get '/logout', to: 'authentications#destroy'
@@ -25,9 +42,6 @@ Rails.application.routes.draw do
     resources :drafts, only: [:index]
   end
 
-  # Temporarily send JSON requests to web to API
-  match '*path.:format', to: redirect("/api/v0/%{path}"), via: [:get, :post], constraints: { format: :json }
-
   resources :auctions, only: [:index, :show] do
     resources :bid_confirmations, only: [:create]
     resources :bids, only: [:create]
@@ -36,18 +50,4 @@ Rails.application.routes.draw do
   resources :bids, only: [:index]
   resources :users, only: [:update]
   get 'edit_user', to: 'users#edit'
-
-  # Map current API requests to new controller for now
-  namespace :api, defaults: { format: 'json' } do
-    namespace :v0 do
-      resources :auctions, only: [:index, :show] do
-        resources :bids, only: [:create]
-      end
-
-      namespace :admin do
-        resources :auctions, only: [:index, :show]
-        resources :users, only: [:index]
-      end
-    end
-  end
 end

--- a/spec/controllers/admin/auctions_controller_spec.rb
+++ b/spec/controllers/admin/auctions_controller_spec.rb
@@ -38,5 +38,26 @@ describe Admin::AuctionsController do
         expect(controller).to render_template :edit
       end
     end
+
+    context 'auction does not belong to a user' do
+      it 'assigns current user as user' do
+        user = create(:admin_user)
+        auction = create(:auction)
+        auction.user = nil
+        auction.save(validate: false)
+
+        params = {
+          id: auction.id,
+          auction: {
+            title: 'new title'
+          }
+        }
+
+        put :update, params, user_id: user.id
+
+        expect(controller).not_to render_template :edit
+        expect(auction.reload.user).to eq user
+      end
+    end
   end
 end

--- a/spec/requests/redirect_spec.rb
+++ b/spec/requests/redirect_spec.rb
@@ -8,11 +8,10 @@ RSpec.describe "Redirection to API" do
   describe 'a get request' do
     it 'should return a redirect to the correct location' do
       login
-      auction = create(:auction, :with_bidders)
-      get "/auctions/#{auction.id}.json", nil, headers
+      get "/auctions.json", nil, headers
 
       expect(response.status).to eq 301
-      expect(response.headers["Location"]).to include("/api/v0/auctions/#{auction.id}")
+      expect(response.headers["Location"]).to include("/api/v0/auctions")
     end
   end
 end

--- a/spec/services/update_auction_spec.rb
+++ b/spec/services/update_auction_spec.rb
@@ -8,7 +8,7 @@ describe UpdateAuction do
         new_title = 'The New Title'
         params = { auction: { title: new_title } }
 
-        updater = UpdateAuction.new(auction, params)
+        updater = UpdateAuction.new(auction: auction, params: params, current_user: auction.user)
 
         expect { updater.perform }.to change { auction.title }.to(new_title)
       end
@@ -28,7 +28,7 @@ describe UpdateAuction do
             .and_return(nil)
           params = { auction: { result: 'accepted' } }
 
-          UpdateAuction.new(auction, params).perform
+          UpdateAuction.new(auction: auction, params: params, current_user: auction.user).perform
 
           expect(CreateCapProposalJob).to have_received(:perform_later).with(auction.id)
         end
@@ -48,7 +48,7 @@ describe UpdateAuction do
               .and_return(nil)
             params = { auction: { result: 'accepted' } }
 
-            UpdateAuction.new(auction, params).perform
+            UpdateAuction.new(auction: auction, params: params, current_user: auction.user).perform
 
             expect(CreateCapProposalJob).to have_received(:perform_later).with(auction.id)
           end
@@ -67,7 +67,7 @@ describe UpdateAuction do
               .and_return(nil)
             params = { auction: { result: 'accepted' } }
 
-            UpdateAuction.new(auction, params).perform
+            UpdateAuction.new(auction: auction, params: params, current_user: auction.user).perform
 
             expect(CreateCapProposalJob).to_not have_received(:perform_later).with(auction.id)
           end
@@ -80,7 +80,7 @@ describe UpdateAuction do
         auction = create(:auction, :delivery_due_at_expired)
         params = { auction: { result: 'rejected' } }
 
-        updater = UpdateAuction.new(auction, params)
+        updater = UpdateAuction.new(auction: auction, params: params, current_user: auction.user)
 
         expect { updater.perform }.to_not change { auction.cap_proposal_url }
         expect(auction.cap_proposal_url).to eq ""
@@ -93,7 +93,7 @@ describe UpdateAuction do
           .with(auction.id)
           .and_return(nil)
 
-        UpdateAuction.new(auction, params)
+        UpdateAuction.new(auction: auction, params: params, current_user: auction.user)
 
         expect(CreateCapProposalJob).to_not have_received(:perform_later).with(auction.id)
       end
@@ -112,7 +112,7 @@ describe UpdateAuction do
           .with(auction.id)
         params = { auction: { result: 'accepted' } }
 
-        UpdateAuction.new(auction, params).perform
+        UpdateAuction.new(auction: auction, params: params,current_user: auction.user).perform
 
         expect(CreateCapProposalJob).not_to have_received(:perform_later)
       end


### PR DESCRIPTION
* Old auctions do not belong to a user
* This is a new validation
* Closes https://github.com/18F/micropurchase/issues/736