### PR TITLE
Move highlighted_bid logic to Rules classes

### DIFF
--- a/app/models/highlighted_bid.rb
+++ b/app/models/highlighted_bid.rb
@@ -7,36 +7,12 @@ class HighlightedBid
   end
 
   def find
-    if !auction.bids.any?
-      NullBid.new
-    elsif available_sealed_bid? && user_is_bidder?
-      lowest_user_bid
-    elsif available_sealed_bid?
-      NullBid.new
-    else
-      auction.lowest_bid
-    end
+    auction_rules.highlighted_bid(user)
   end
 
   private
 
-  def available_sealed_bid?
-    available? && auction.type == "sealed_bid"
-  end
-
-  def available?
-    AuctionStatus.new(auction).available?
-  end
-
-  def user_is_bidder?
-    user_bids.any?
-  end
-
-  def lowest_user_bid
-    user_bids.first
-  end
-
-  def user_bids
-    auction.bids.where(bidder: user).order(amount: :asc)
+  def auction_rules
+    RulesFactory.new(auction).create
   end
 end

--- a/app/models/rules/reverse_auction.rb
+++ b/app/models/rules/reverse_auction.rb
@@ -3,6 +3,10 @@ class Rules::ReverseAuction < Rules::BaseRules
     auction.lowest_bid || NullBid.new
   end
 
+  def highlighted_bid(_user)
+    winning_bid
+  end
+
   def veiled_bids(_user)
     auction.bids
   end

--- a/app/models/rules/sealed_bid_auction.rb
+++ b/app/models/rules/sealed_bid_auction.rb
@@ -7,6 +7,14 @@ class Rules::SealedBidAuction < Rules::BaseRules
     end
   end
 
+  def highlighted_bid(user)
+    if auction_available?
+      lowest_user_bid(user)
+    else
+      winning_bid
+    end
+  end
+
   def veiled_bids(user)
     if auction_available?
       auction.bids.where(bidder: user)
@@ -15,8 +23,12 @@ class Rules::SealedBidAuction < Rules::BaseRules
     end
   end
 
+  def user_is_bidder?(user)
+    user_bids(user).any?
+  end
+
   def user_can_bid?(user)
-    super && auction.bids.where(bidder: user).empty?
+    super && !user_is_bidder?(user)
   end
 
   def max_allowed_bid
@@ -25,5 +37,15 @@ class Rules::SealedBidAuction < Rules::BaseRules
 
   def show_bids?
     !auction_available?
+  end
+
+  private
+
+  def lowest_user_bid(user)
+    user_bids(user).first || NullBid.new
+  end
+
+  def user_bids(user)
+    auction.bids.where(bidder: user).order(amount: :asc)
   end
 end


### PR DESCRIPTION
I noticed this while I was working on the great renaming refactor. It seems like this logic is better located within the Rules objects, so we can avoid having to look at the model type in other classes.

