### PR TITLE
Set `accepted_at` when an auction is accepted

### DIFF
--- a/app/controllers/admin/auctions_controller.rb
+++ b/app/controllers/admin/auctions_controller.rb
@@ -43,7 +43,7 @@ class Admin::AuctionsController < Admin::BaseController
     update_auction = UpdateAuction.new(auction: auction, params: params, current_user: current_user)
 
     if update_auction.perform
-      return_to_stored(default: admin_auctions_path)
+      return_to_stored(default: admin_auction_path(auction))
     else
       error_messages = auction.errors.full_messages.to_sentence
       flash[:error] = error_messages

--- a/app/view_models/admin/auction_show_view_model.rb
+++ b/app/view_models/admin/auction_show_view_model.rb
@@ -49,6 +49,14 @@ class Admin::AuctionShowViewModel < Admin::BaseViewModel
     formatted_time(auction.paid_at)
   end
 
+  def accepted_at
+    formatted_time(auction.accepted_at)
+  end
+
+  def cap_proposal_url
+    auction.cap_proposal_url
+  end
+
   def html_summary
     return '' if auction.summary.blank?
     MarkdownRender.new(auction.summary).to_s

--- a/app/views/admin/auctions/show.html.erb
+++ b/app/views/admin/auctions/show.html.erb
@@ -17,7 +17,15 @@
 </div>
 
 <div>
+  <b>Accepted at:</b> <%= @view_model.accepted_at %>
+</div>
+
+<div>
   <b>Paid at:</b> <%= @view_model.paid_at %>
+</div>
+
+<div>
+  <b>CAP proposal URL:</b> <%= @view_model.cap_proposal_url %>
 </div>
 
 <div>

--- a/db/migrate/20160627225519_add_accepted_at_to_auctions.rb
+++ b/db/migrate/20160627225519_add_accepted_at_to_auctions.rb
@@ -4,7 +4,8 @@ class AddAcceptedAtToAuctions < ActiveRecord::Migration
 
     execute <<-SQL
       UPDATE auctions
-      SET accepted_at = delivery_due_at;
+      SET accepted_at = delivery_due_at
+      WHERE result = 1;
     SQL
   end
 

--- a/db/migrate/20160627225519_add_accepted_at_to_auctions.rb
+++ b/db/migrate/20160627225519_add_accepted_at_to_auctions.rb
@@ -1,0 +1,14 @@
+class AddAcceptedAtToAuctions < ActiveRecord::Migration
+  def up
+    add_column :auctions, :accepted_at, :datetime
+
+    execute <<-SQL
+      UPDATE auctions
+      SET accepted_at = delivery_due_at;
+    SQL
+  end
+
+  def down
+    remove_column :auctions, :accepted_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160615205001) do
+ActiveRecord::Schema.define(version: 20160627225519) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,6 +38,7 @@ ActiveRecord::Schema.define(version: 20160615205001) do
     t.integer  "user_id"
     t.integer  "purchase_card",    default: 0,    null: false
     t.datetime "paid_at"
+    t.datetime "accepted_at"
   end
 
   add_index "auctions", ["user_id"], name: "index_auctions_on_user_id", using: :btree

--- a/features/admin_accepts_delivery.feature
+++ b/features/admin_accepts_delivery.feature
@@ -1,4 +1,4 @@
-Feature: Admin approves delivery of a project
+Feature: Admin accepts delivery of a project
   As an admin
   I want to set an auction result to be approved
   And have the CAP Proposal created automatically
@@ -11,9 +11,8 @@ Feature: Admin approves delivery of a project
     When I visit the admin form for that auction
     And I select the result as accepted
     And I click on the "Update" button
-    Then the proposal should have a CAP Proposal URL
-    When I visit the admin form for that auction
     Then I should see that the auction has a CAP Proposal URL
+    And I should see that the auction was accepted
 
     Scenario: Marking an auction as accepted where the vendor cannot be paid
       Given I am an administrator
@@ -22,5 +21,5 @@ Feature: Admin approves delivery of a project
       When I visit the admin form for that auction
       And I select the result as accepted
       And I click on the "Update" button
-      Then the proposal should not have a CAP Proposal URL
+      Then I should see that the auction does not have a CAP Proposal URL
       And I should see an error that "The vendor cannot be paid"

--- a/features/step_definitions/admin_auction_form_steps.rb
+++ b/features/step_definitions/admin_auction_form_steps.rb
@@ -16,10 +16,9 @@ When(/^I select the result as accepted$/) do
   select("accepted", from: "auction_result")
 end
 
-Then(/^I should see that the auction has a CAP Proposal URL$/) do
-  expect(find_field(I18n.t('simple_form.labels.auction.cap_proposal_url')).value).to eq(
-    @auction.cap_proposal_url
-  )
+Then(/^I should see that the auction does not have a CAP Proposal URL$/) do
+  field = find_field(I18n.t('simple_form.labels.auction.cap_proposal_url'))
+  expect(field.value).to eq('')
 end
 
 Then(/^I expect my auction changes to have been saved$/) do

--- a/features/step_definitions/auction_attributes_steps.rb
+++ b/features/step_definitions/auction_attributes_steps.rb
@@ -48,6 +48,17 @@ Then(/^I should see the start price for the auction is \$(\d+)$/) do |price|
   expect(page).to have_field('auction_start_price', with: price)
 end
 
+Then(/^I should see that the auction has a CAP Proposal URL$/) do
+  expect(page).to have_content("CAP proposal URL: #{@auction.reload.cap_proposal_url}")
+end
+
+Then(/^I should see that the auction was accepted$/) do
+  expect(@auction.accepted_at).not_to eq nil
+  expect(page).to have_content(
+    DcTimePresenter.convert_and_format(@auction.accepted_at)
+  )
+end
+
 Then(/^I should see the number of bid for the auction$/) do
   number_of_bids = "#{@auction.bids.length} bids"
   expect(page).to have_content(number_of_bids)
@@ -74,16 +85,6 @@ Then(/^I should not see that the auction indicates it is for small business only
                 .find(:xpath, "..")
 
   expect(auction_div).to_not have_content('Small-business only')
-end
-
-Then(/^the proposal should have a CAP Proposal URL$/) do
-  @auction.reload
-  expect(@auction.cap_proposal_url).not_to eq ""
-end
-
-Then(/^the proposal should not have a CAP Proposal URL$/) do
-  @auction.reload
-  expect(@auction.cap_proposal_url).to eq ""
 end
 
 Then(/^I should see a preview of the auction$/) do

--- a/spec/services/update_auction_spec.rb
+++ b/spec/services/update_auction_spec.rb
@@ -32,6 +32,19 @@ describe UpdateAuction do
 
           expect(CreateCapProposalJob).to have_received(:perform_later).with(auction.id)
         end
+
+        it 'sets accepted_at' do
+          time = Time.parse('10:00:00 UTC')
+
+          Timecop.freeze(time) do
+            auction = create(:auction, accepted_at: nil)
+            params = { auction: { result: 'accepted' } }
+
+            UpdateAuction.new(auction: auction, params: params, current_user: auction.user).perform
+
+            expect(auction.accepted_at).to eq time
+          end
+        end
       end
 
       context 'auction is between micropurchase and SAT threshold' do


### PR DESCRIPTION
* Show timestamp on admin/auctions#show
* This data will help us with our stats page
* Part of https://github.com/18F/micropurchase/issues/705