### PR TITLE
Update stats page

### DIFF
--- a/app/views/winners/index.html.erb
+++ b/app/views/winners/index.html.erb
@@ -41,6 +41,12 @@
     } %>
     <%= render partial: 'hero_metric',
       locals: {
+      href: '#',
+      statistic: @view_model.average_delivery_time,
+      label: 'average delivery time'
+    } %>
+    <%= render partial: 'hero_metric',
+      locals: {
       href: '#chart-winning-bid',
       statistic: @view_model.average_winning_bid,
       label: 'average winning bid'
@@ -49,7 +55,7 @@
       locals: {
       href: '#',
       statistic: @view_model.small_business_count,
-      label: 'small businesses'
+      label: 'small businesses registered'
     } %>
   </div>
   </section>


### PR DESCRIPTION
- use broader count for total auctions (use all finished auctions, not just complete + successful. here, "successful" implies all payments went through. We need to update that data, and that shouldn't matter too much for this stat)

- add "average delivery time"

<img width="982" alt="screen shot 2016-06-28 at 12 15 52 pm" src="https://cloud.githubusercontent.com/assets/86790/16423563/8382701c-3d2a-11e6-8304-e0b3b443fded.png">

Fixes https://github.com/18F/micropurchase/issues/705
