### PR TITLE
Add bidding history to user show page in admin

### DIFF
--- a/app/models/auction_query.rb
+++ b/app/models/auction_query.rb
@@ -98,7 +98,7 @@ class AuctionQuery
       .find(id)
   end
 
-  def user_has_bid(user_id)
+  def with_bid_from_user(user_id)
     @relation
       .joins(:bids)
       .where(bids: { bidder_id: user_id })

--- a/app/models/auction_query.rb
+++ b/app/models/auction_query.rb
@@ -98,7 +98,7 @@ class AuctionQuery
       .find(id)
   end
 
-  def my_bids(user_id)
+  def user_has_bid(user_id)
     @relation
       .joins(:bids)
       .where(bids: { bidder_id: user_id })

--- a/app/presenters/dc_time_presenter.rb
+++ b/app/presenters/dc_time_presenter.rb
@@ -13,8 +13,8 @@ class DcTimePresenter
     new(time).convert
   end
 
-  def self.convert_and_format(time, format = FORMAT)
-    new(time).convert_and_format(format)
+  def self.convert_and_format(time, format = FORMAT, timezone_label: true)
+    new(time).convert_and_format(format, timezone_label: timezone_label)
   end
 
   def self.time_zone
@@ -26,9 +26,11 @@ class DcTimePresenter
     time.in_time_zone(time_zone)
   end
 
-  def convert_and_format(format = FORMAT)
+  def convert_and_format(format = FORMAT, timezone_label: true)
     if time
-      convert.strftime(format) + " #{timezone_label}"
+      str = convert.strftime(format)
+      str += " #{timezone_string}" if timezone_label
+      str
     else
       NULL
     end
@@ -38,7 +40,7 @@ class DcTimePresenter
     self.class.time_zone
   end
 
-  def timezone_label
+  def timezone_string
     convert.zone
   end
 end

--- a/app/view_models/admin/user_auction_view_model.rb
+++ b/app/view_models/admin/user_auction_view_model.rb
@@ -18,11 +18,11 @@ class Admin::UserAuctionViewModel
   end
 
   def start_date
-    DcTimePresenter.convert_and_format(auction.started_at, DATE_FORMAT, timezone_label: false)
+    DcTimePresenter.convert_and_format(auction.started_at, DATE_FORMAT)
   end
 
   def end_date
-    DcTimePresenter.convert_and_format(auction.ended_at, DATE_FORMAT, timezone_label: false)
+    DcTimePresenter.convert_and_format(auction.ended_at, DATE_FORMAT)
   end
 
   def user_bid_count

--- a/app/view_models/admin/user_auction_view_model.rb
+++ b/app/view_models/admin/user_auction_view_model.rb
@@ -2,7 +2,7 @@ class Admin::UserAuctionViewModel
   attr_reader :auction, :user
 
   DATE_FORMAT = '%m/%d/%Y'.freeze
-  NA_RESPONSE_STRING = '-'
+  NA_RESPONSE_STRING = '-'.freeze
 
   def initialize(auction, user)
     @auction = auction
@@ -30,24 +30,20 @@ class Admin::UserAuctionViewModel
   end
 
   def user_won_label
-    if auction_over?
-      if user_won?
-        'Yes'
-      else
-        'No'
-      end
+    if user_won?
+      'Yes'
+    elsif auction_over?
+      'No'
     else
       NA_RESPONSE_STRING
     end
   end
 
   def accepted_label
-    if user_won?
-      if auction_accepted?
-        'Yes'
-      else
-        'No'
-      end
+    if user_won? && auction_accepted?
+      'Yes'
+    elsif user_won?
+      'No'
     else
       NA_RESPONSE_STRING
     end

--- a/app/view_models/admin/user_auction_view_model.rb
+++ b/app/view_models/admin/user_auction_view_model.rb
@@ -1,0 +1,77 @@
+class Admin::UserAuctionViewModel
+  attr_reader :auction, :user
+
+  DATE_FORMAT = '%m/%d/%Y'.freeze
+  NA_RESPONSE_STRING = '-'
+
+  def initialize(auction, user)
+    @auction = auction
+    @user = user
+  end
+
+  def title
+    auction.title
+  end
+
+  def id
+    auction.id
+  end
+
+  def start_date
+    DcTimePresenter.convert_and_format(auction.started_at, DATE_FORMAT, timezone_label: false)
+  end
+
+  def end_date
+    DcTimePresenter.convert_and_format(auction.ended_at, DATE_FORMAT, timezone_label: false)
+  end
+
+  def user_bid_count
+    user_bids.count
+  end
+
+  def user_won_label
+    if auction_over?
+      if user_won?
+        'Yes'
+      else
+        'No'
+      end
+    else
+      NA_RESPONSE_STRING
+    end
+  end
+
+  def accepted_label
+    if user_won?
+      if auction_accepted?
+        'Yes'
+      else
+        'No'
+      end
+    else
+      NA_RESPONSE_STRING
+    end
+  end
+
+  private
+
+  def user_won?
+    auction_over? && WinningBid.new(auction).find.bidder == user
+  end
+
+  def auction_over?
+    AuctionStatus.new(auction).over?
+  end
+
+  def auction_accepted?
+    auction.accepted?
+  end
+
+  def auction_rules
+    RulesFactory.new(auction).create
+  end
+
+  def user_bids
+    auction.bids.where(bidder: user).sort_by(&:amount)
+  end
+end

--- a/app/view_models/admin/user_show_view_model.rb
+++ b/app/view_models/admin/user_show_view_model.rb
@@ -62,6 +62,6 @@ class Admin::UserShowViewModel < Admin::BaseViewModel
   end
 
   def user_auctions
-    AuctionQuery.new.user_has_bid(user.id).map { |auction| Admin::UserAuctionViewModel.new(auction, user) }
+    AuctionQuery.new.with_bid_from_user(user.id).map { |auction| Admin::UserAuctionViewModel.new(auction, user) }
   end
 end

--- a/app/view_models/admin/user_show_view_model.rb
+++ b/app/view_models/admin/user_show_view_model.rb
@@ -49,6 +49,14 @@ class Admin::UserShowViewModel < Admin::BaseViewModel
     end
   end
 
+  def bids_partial
+    if bids?
+      'bid_history'
+    else
+      'components/null'
+    end
+  end
+
   def bids?
     user_auctions.count > 0
   end

--- a/app/view_models/admin/user_show_view_model.rb
+++ b/app/view_models/admin/user_show_view_model.rb
@@ -48,4 +48,12 @@ class Admin::UserShowViewModel < Admin::BaseViewModel
       "No"
     end
   end
+
+  def bids?
+    user_auctions.count > 0
+  end
+
+  def user_auctions
+    AuctionQuery.new.user_has_bid(user.id).map { |auction| Admin::UserAuctionViewModel.new(auction, user) }
+  end
 end

--- a/app/views/admin/users/_bid_history.html.erb
+++ b/app/views/admin/users/_bid_history.html.erb
@@ -12,7 +12,7 @@
     </tr>
   </thead>
   <tbody>
-    <% @view_model.user_auctions.each do |auction| %>
+    <% view_model.user_auctions.each do |auction| %>
       <tr>
         <td><%= link_to auction.title, admin_auction_path(auction.id) %></td>
         <td><%= auction.start_date %></td>

--- a/app/views/admin/users/_bid_history.html.erb
+++ b/app/views/admin/users/_bid_history.html.erb
@@ -1,0 +1,25 @@
+<h2>Bidding History</h2>
+
+<table class="usa-table-borderless" id="bidding-history">
+  <thead>
+    <tr>
+      <th scope="col">Auction</th>
+      <th scope="col">Start Date</th>
+      <th scope="col">End Date</th>
+      <th scope="col">User Bids</th>
+      <th scope="col">User Won?</th>
+      <th scope="col">Accepted?</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @view_model.user_auctions.each do |auction| %>
+      <tr>
+        <td><%= link_to auction.title, admin_auction_path(auction.id) %></td>
+        <td><%= auction.start_date %></td>
+        <td><%= auction.end_date %></td>
+        <td><%= auction.user_bid_count %></td>
+        <td><%= auction.user_won_label %></td>
+        <td><%= auction.accepted_label %></td>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -9,3 +9,31 @@
   <li><b>Small business</b>: <%= @view_model.small_business %></li>
   <li><b>Contracting officer</b>: <%= @view_model.contracting_officer %></li>
 </ul>
+
+<% if @view_model.bids? %>
+<h2>Bidding History</h2>
+
+<table class="usa-table-borderless" id="bidding-history">
+  <thead>
+    <tr>
+      <th scope="col">Auction</th>
+      <th scope="col">Start Date</th>
+      <th scope="col">End Date</th>
+      <th scope="col">User Bids</th>
+      <th scope="col">User Won?</th>
+      <th scope="col">Accepted?</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @view_model.user_auctions.each do |auction| %>
+      <tr>
+        <td><%= link_to auction.title, admin_auction_path(auction.id) %></td>
+        <td><%= auction.start_date %></td>
+        <td><%= auction.end_date %></td>
+        <td><%= auction.user_bid_count %></td>
+        <td><%= auction.user_won_label %></td>
+        <td><%= auction.accepted_label %></td>
+    <% end %>
+  </tbody>
+</table>
+<% end %>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -10,30 +10,4 @@
   <li><b>Contracting officer</b>: <%= @view_model.contracting_officer %></li>
 </ul>
 
-<% if @view_model.bids? %>
-<h2>Bidding History</h2>
-
-<table class="usa-table-borderless" id="bidding-history">
-  <thead>
-    <tr>
-      <th scope="col">Auction</th>
-      <th scope="col">Start Date</th>
-      <th scope="col">End Date</th>
-      <th scope="col">User Bids</th>
-      <th scope="col">User Won?</th>
-      <th scope="col">Accepted?</th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @view_model.user_auctions.each do |auction| %>
-      <tr>
-        <td><%= link_to auction.title, admin_auction_path(auction.id) %></td>
-        <td><%= auction.start_date %></td>
-        <td><%= auction.end_date %></td>
-        <td><%= auction.user_bid_count %></td>
-        <td><%= auction.user_won_label %></td>
-        <td><%= auction.accepted_label %></td>
-    <% end %>
-  </tbody>
-</table>
-<% end %>
+<%= render partial: @view_model.bids_partial %>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -10,4 +10,4 @@
   <li><b>Contracting officer</b>: <%= @view_model.contracting_officer %></li>
 </ul>
 
-<%= render partial: @view_model.bids_partial %>
+<%= render partial: @view_model.bids_partial, locals: {view_model: @view_model} %>

--- a/features/admin_views_user.feature
+++ b/features/admin_views_user.feature
@@ -3,10 +3,25 @@ Feature: Admin views user
   I want to be able to click to see a user's information
   So that I do not need to ssh in order to do so
 
-  Scenario: Admin navigates to show page from list of all users
+  Background:
     Given I am an administrator
     And I sign in
+
+  Scenario: Admin navigates to show page from list of all users
     And there are users in the system
     When I visit the admin users page
     And I click on the name of the first user
     Then I should see that user's information
+
+  Scenario: I see a user's bid history on the user show page
+    Given there is a user in the system who has bid on an auction
+    When I visit the admin users page
+    And I click on the name of the first user
+    Then I should see a section labeled "Bidding History"
+    And in that section I should see a table of the user's bids
+
+  Scenario: I see a user who has not bid
+    Given there are users in the system
+    When I visit the admin users page
+    And I click on the name of the first user
+    Then I should not see a section labeled "Bidding History"

--- a/features/step_definitions/admin_views_user_steps.rb
+++ b/features/step_definitions/admin_views_user_steps.rb
@@ -1,0 +1,19 @@
+Then(/^in that section I should see a table of the user's bids$/) do
+  table_headers = ['Auction', 'Start Date', 'End Date', 'User Bids', 'User Won?', 'Accepted?']
+
+  table_headers.each_with_index do |header, index|
+    within(:xpath, "//table[@id='bidding-history']/thead/tr/th[#{index + 1}]") do
+      expect(page).to have_content(header)
+    end
+  end
+
+  view_model = Admin::UserAuctionViewModel.new(@auction, @user)
+
+  values = [view_model.title, view_model.start_date, view_model.end_date, view_model.user_bid_count, view_model.user_won_label, view_model.accepted_label]
+
+  values.each_with_index do |value, index|
+    within(:xpath, "//table[@id='bidding-history']/tbody/tr/td[#{index + 1}]") do
+      expect(page).to have_content(value)
+    end
+  end
+end

--- a/features/step_definitions/page_content_steps.rb
+++ b/features/step_definitions/page_content_steps.rb
@@ -69,8 +69,10 @@ Then(/^I should see a page title "([^"]+)"$/) do |title|
   expect(page).to have_title title
 end
 
-Then(/^I should see a header "([^"]+)"$/) do |header|
-  within(:css, 'h2') do
-    expect(page).to have_content(header)
-  end
+Then(/^I should see a section labeled "([^"]+)"$/) do |header|
+  page.find('h2', text: header)
+end
+
+Then(/^I should not see a section labeled "([^"]+)"$/) do |header|
+  expect(page.first('h2', text: header)).to be_nil
 end

--- a/features/step_definitions/user_create_steps.rb
+++ b/features/step_definitions/user_create_steps.rb
@@ -66,3 +66,8 @@ Given(/^there are users in the system$/) do
   @number_of_users = 1
   FactoryGirl.create(:user)
 end
+
+Given(/^there is a user in the system who has bid on an auction$/) do
+  @user = FactoryGirl.create(:user, sam_status: :sam_accepted)
+  @auction = FactoryGirl.create(:auction, :closed, :with_bidders, bidder_ids: [@user.id])
+end

--- a/spec/models/auction_query_spec.rb
+++ b/spec/models/auction_query_spec.rb
@@ -237,4 +237,20 @@ describe AuctionQuery do
       end
     end
   end
+
+  describe '#user_has_bid' do
+    it 'returns auctions where the user has placed a bid' do
+      auction = create(:auction, :with_bidders)
+      bidder = auction.bids.first.bidder
+
+      expect(AuctionQuery.new.user_has_bid(bidder.id)).to eq([auction])
+    end
+
+    it 'does not return auctions where the user has not bid' do
+      create(:auction, :with_bidders)
+      user = create(:user)
+
+      expect(AuctionQuery.new.user_has_bid(user.id)).to eq([])
+    end
+  end
 end

--- a/spec/models/auction_query_spec.rb
+++ b/spec/models/auction_query_spec.rb
@@ -238,19 +238,19 @@ describe AuctionQuery do
     end
   end
 
-  describe '#user_has_bid' do
+  describe '#with_bid_from_user' do
     it 'returns auctions where the user has placed a bid' do
       auction = create(:auction, :with_bidders)
       bidder = auction.bids.first.bidder
 
-      expect(AuctionQuery.new.user_has_bid(bidder.id)).to eq([auction])
+      expect(AuctionQuery.new.with_bid_from_user(bidder.id)).to eq([auction])
     end
 
     it 'does not return auctions where the user has not bid' do
       create(:auction, :with_bidders)
       user = create(:user)
 
-      expect(AuctionQuery.new.user_has_bid(user.id)).to eq([])
+      expect(AuctionQuery.new.with_bid_from_user(user.id)).to eq([])
     end
   end
 end

--- a/spec/view_models/admin/user_auction_view_model_spec.rb
+++ b/spec/view_models/admin/user_auction_view_model_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+describe Admin::UserAuctionViewModel do
+  let(:user) { create(:user) }
+
+  describe '#start_date' do
+    it 'should return a mm/dd/yy date in EST' do
+      auction = create(:auction, started_at: '2016-04-01 00:00 UTC')
+      expect(Admin::UserAuctionViewModel.new(auction, user).start_date).to eq('03/31/2016')
+    end
+  end
+
+  describe '#end_date' do
+    it 'should return a mm/dd/yy date in EST' do
+      auction = create(:auction, ended_at: '2016-04-01 00:00 UTC')
+      expect(Admin::UserAuctionViewModel.new(auction, user).end_date).to eq('03/31/2016')
+    end
+  end
+
+  describe '#user_bid_count' do
+    it 'should return the total number of bids the user has made' do
+      user2 = create(:user)
+      auction = create(:auction, :with_bidders, bidder_ids: [user.id, user2.id, user.id, user2.id, user.id])
+
+      expect(Admin::UserAuctionViewModel.new(auction, user).user_bid_count).to eq(3)
+    end
+  end
+
+  describe '#user_won_label' do
+    context 'when the auction is not over yet' do
+      it 'should return "-"' do
+        auction = create(:auction, :running, :with_bidders)
+        user = WinningBid.new(auction).find.bidder
+
+        expect(Admin::UserAuctionViewModel.new(auction, user).user_won_label).to eq('-')
+      end
+    end
+
+    context 'when the auction is over' do
+      it 'should return "Yes" if the user has the winning bid' do
+        auction = create(:auction, :closed, :with_bidders)
+        user = WinningBid.new(auction).find.bidder
+
+        expect(Admin::UserAuctionViewModel.new(auction, user).user_won_label).to eq('Yes')
+      end
+
+      it 'should return "No" if the user does not have the winning bid' do
+        auction = create(:auction, :closed, :with_bidders)
+        expect(Admin::UserAuctionViewModel.new(auction, user).user_won_label).to eq('No')
+      end
+    end
+  end
+
+  describe '#accepted_label' do
+    context 'when the user is the winning_bidder' do
+      it 'returns "Yes" when the auction was accepted' do
+        auction = create(:auction, :closed, :with_bidders, :accepted)
+        bidder = WinningBid.new(auction).find.bidder
+        expect(Admin::UserAuctionViewModel.new(auction, bidder).accepted_label).to eq('Yes')
+      end
+
+      it 'returns "No" when auction was not accepted yet' do
+        auction = create(:auction, :closed, :rejected, :with_bidders)
+        bidder = WinningBid.new(auction).find.bidder
+        expect(Admin::UserAuctionViewModel.new(auction, bidder).accepted_label).to eq('No')
+      end
+    end
+
+    context 'when the user is not the winning bidder' do
+      it 'returns "-"' do
+        auction = create(:auction, :closed, :with_bidders, accepted_at: Time.now)
+        expect(Admin::UserAuctionViewModel.new(auction, user).accepted_label).to eq('-')
+      end
+    end
+  end
+end

--- a/spec/view_models/admin/user_auction_view_model_spec.rb
+++ b/spec/view_models/admin/user_auction_view_model_spec.rb
@@ -6,14 +6,14 @@ describe Admin::UserAuctionViewModel do
   describe '#start_date' do
     it 'should return a mm/dd/yy date in EST' do
       auction = create(:auction, started_at: '2016-04-01 00:00 UTC')
-      expect(Admin::UserAuctionViewModel.new(auction, user).start_date).to eq('03/31/2016')
+      expect(Admin::UserAuctionViewModel.new(auction, user).start_date).to eq('03/31/2016 EDT')
     end
   end
 
   describe '#end_date' do
     it 'should return a mm/dd/yy date in EST' do
       auction = create(:auction, ended_at: '2016-04-01 00:00 UTC')
-      expect(Admin::UserAuctionViewModel.new(auction, user).end_date).to eq('03/31/2016')
+      expect(Admin::UserAuctionViewModel.new(auction, user).end_date).to eq('03/31/2016 EDT')
     end
   end
 


### PR DESCRIPTION
Fixes #775

Generally I have tried to amend existing objects/methods where possible to add this new functionality. There are a few things worth mentioning that should be singled out for review:

1. I needed a good wrapper for displaying user-specific information about an auction (such as the user's bid count for the auction). I created a new class `Admin::UserAuctionViewModel` in the view_models, but I'm not too thrilled at my name for it.
2. I added a specific step definition file `admin_views_user_steps` because I had a step definition that was specific to that one feature file and this is the convention I've proposed for Cucumber steps are only linked to a specific feature.
3. The AuctionQuery object had defined a `my_bids` query, but it wasn't used anywhere in the code that I could see. So I renamed it and used it here (as well as added a test). This would be useful if we bring back the my_bids endpoint too.