### PR TITLE
Bids on admin auction show page now link to user

### DIFF
--- a/app/view_models/admin/bid_list_item.rb
+++ b/app/view_models/admin/bid_list_item.rb
@@ -6,6 +6,10 @@ class Admin::BidListItem
     @user = user
   end
 
+  def bidder_id
+    bid.bidder_id
+  end
+
   def veiled_name
     bid.bidder.name
   end

--- a/app/views/admin/auctions/_bids.html.erb
+++ b/app/views/admin/auctions/_bids.html.erb
@@ -1,0 +1,29 @@
+<div class="js-auction-view hide">
+  <div class="auction-body">
+    <%= render partial: auction_bids.sealed_bids_partial %>
+
+    <table class="usa-table-borderless">
+      <thead>
+        <tr>
+          <th scope="col">Bidder</th>
+          <th scope="col">DUNS</th>
+          <th scope="col">Amount</th>
+          <th scope="col">Date (EST)</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% auction_bids.veiled_bids.each do |bid| %>
+          <tr>
+            <td><%= link_to bid.veiled_name, admin_user_path(bid.bidder_id) %></td>
+            <td><%= bid.veiled_duns_number %></td>
+            <td><%= bid.amount_to_currency_with_asterisk %></td>
+            <td><%= bid.created_at %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+    <p>
+      &#42; - winning bid
+    </p>
+  </div>
+</div>

--- a/app/views/admin/auctions/show.html.erb
+++ b/app/views/admin/auctions/show.html.erb
@@ -26,7 +26,7 @@
 
   <div class="usa-width-two-thirds">
     <%= render partial: 'admin/auctions/auction', locals: { auction: @view_model } %>
-    <%= render partial: 'auctions/bids', locals: { auction_bids: @view_model } %>
+    <%= render partial: 'admin/auctions/bids', locals: { auction_bids: @view_model } %>
   </div>
 
   <div class="usa-width-one-third">


### PR DESCRIPTION
I want the auction bid history in admin view to link to user pages, so this is a PR for that.

I am kinda tempted to drop the `veiled_` parity for the admin BidListItem objects because these will never be veiled and we shouldn't suggest they will be, but that's up for future discussion.