### PR TITLE
Better table for rejected auctions in action items

### DIFF
--- a/app/models/bid.rb
+++ b/app/models/bid.rb
@@ -1,4 +1,8 @@
 class Bid < ActiveRecord::Base
   belongs_to :auction
   belongs_to :bidder, class_name: 'User'
+
+  def bidder_name
+    bidder.name
+  end
 end

--- a/app/models/null_bid.rb
+++ b/app/models/null_bid.rb
@@ -7,6 +7,10 @@ class NullBid
     nil
   end
 
+  def bidder_name
+    nil
+  end
+
   def bidder
     nil
   end

--- a/app/services/update_auction.rb
+++ b/app/services/update_auction.rb
@@ -15,6 +15,7 @@ class UpdateAuction
       false
     else
       perform_approved_auction_tasks
+      perform_rejected_auction_tasks
       auction.save
     end
   end
@@ -58,6 +59,12 @@ class UpdateAuction
     end
   end
 
+  def perform_rejected_auction_tasks
+    if auction_rejected? && auction.rejected_at.nil?
+      auction.rejected_at = Time.current
+    end
+  end
+
   def should_create_cap_proposal?
     auction_accepted_and_cap_proposal_is_blank? &&
       auction.purchase_card == "default"
@@ -74,6 +81,10 @@ class UpdateAuction
 
   def auction_accepted?
     attributes[:result] == 'accepted'
+  end
+
+  def auction_rejected?
+    attributes[:result] == 'rejected'
   end
 
   def winning_bidder_is_eligible_to_be_paid?

--- a/app/view_models/admin/action_item_list_item.rb
+++ b/app/view_models/admin/action_item_list_item.rb
@@ -9,12 +9,32 @@ class Admin::ActionItemListItem < Admin::BaseViewModel
     auction.title
   end
 
+  def winning_bid
+    @_winner ||= WinningBid.new(auction).find
+  end
+
+  def winning_bidder_id
+    winning_bid.bidder_id
+  end
+
+  def winning_bidder_name
+    winning_bid.bidder_name
+  end
+
   def id
     auction.id
   end
 
   def delivery_due_at_expires_in
     HumanTime.new(time: auction.delivery_due_at).relative_time
+  end
+
+  def delivery_due_at
+    DcTimePresenter.convert_and_format(auction.delivery_due_at)
+  end
+
+  def rejected_at
+    DcTimePresenter.convert_and_format(auction.rejected_at)
   end
 
   def delivery_url

--- a/app/view_models/auction_show_view_model.rb
+++ b/app/view_models/auction_show_view_model.rb
@@ -154,7 +154,7 @@ class AuctionShowViewModel
   end
 
   def lowest_bidder_name
-    auction.lowest_bid.bidder.name
+    auction.lowest_bid.bidder_name
   end
 
   def available_and_user_is_bidder?

--- a/app/views/admin/action_items/_rejected_auctions.html.erb
+++ b/app/views/admin/action_items/_rejected_auctions.html.erb
@@ -1,0 +1,24 @@
+<table class="usa-table-borderless" id="table-rejected">
+  <thead>
+    <tr>
+      <th scope="col">Title</th>
+      <th scope="col">Delivery Deadline</th>
+      <th scope="col">Delivery URL</th>
+      <th scope="col">Vendor Name</th>
+      <th scope="col">Rejected At</th>
+      <th scope="col"></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% auctions.each do |auction| %>
+    <tr>
+      <td><%= link_to(auction.title, admin_auction_path(auction.id)) %></td>
+      <td><%= auction.delivery_due_at %></td>
+      <td><%= auction.delivery_url %></td>
+      <td><%= link_to auction.winning_bidder_name, admin_user_path(auction.winning_bidder_id) %></td>
+      <td><%= auction.rejected_at %></td>
+      <td><%= link_to('edit', edit_admin_auction_path(auction.id)) %></td>
+    </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/admin/action_items/index.html.erb
+++ b/app/views/admin/action_items/index.html.erb
@@ -19,5 +19,5 @@
   locals: { id: 'successful', auctions: @view_model.complete_and_successful } %>
 
 <h2>Rejected</h2>
-<%= render partial: 'items',
-  locals: { id: 'rejected', auctions: @view_model.rejected } %>
+<%= render partial: 'rejected_auctions',
+  locals: { auctions: @view_model.rejected } %>

--- a/db/migrate/20160705175025_add_rejected_at_to_auctions.rb
+++ b/db/migrate/20160705175025_add_rejected_at_to_auctions.rb
@@ -1,0 +1,5 @@
+class AddRejectedAtToAuctions < ActiveRecord::Migration
+  def change
+    add_column :auctions, :rejected_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160630211309) do
+ActiveRecord::Schema.define(version: 20160705175025) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,6 +39,7 @@ ActiveRecord::Schema.define(version: 20160630211309) do
     t.integer  "purchase_card",    default: 0,    null: false
     t.datetime "paid_at"
     t.datetime "accepted_at"
+    t.datetime "rejected_at"
   end
 
   add_index "auctions", ["user_id"], name: "index_auctions_on_user_id", using: :btree
@@ -94,8 +95,8 @@ ActiveRecord::Schema.define(version: 20160630211309) do
     t.datetime "created_at",                           null: false
     t.datetime "updated_at",                           null: false
     t.string   "email"
-    t.string   "credit_card_form_url", default: "",    null: false
     t.string   "github_login"
+    t.string   "credit_card_form_url", default: "",    null: false
     t.integer  "sam_status",           default: 0,     null: false
     t.boolean  "contracting_officer",  default: false, null: false
     t.boolean  "small_business",       default: false, null: false

--- a/features/step_definitions/admin_views_action_items_steps.rb
+++ b/features/step_definitions/admin_views_action_items_steps.rb
@@ -1,9 +1,15 @@
 Then(/^I should see the rejected auction as an action item$/) do
   auction = Admin::ActionItemListItem.new(@rejected)
 
-  [auction.title, auction.delivery_due_at_expires_in, auction.delivery_url, auction.result,
-   auction.cap_proposal_url, auction.paid?].each_with_index do |expected, i|
-    within(:xpath, cel_xpath(table_id: 'table-rejected', column: i+1)) do
+  ['Title', 'Delivery Deadline', 'Delivery URL', 'Vendor Name', 'Rejected At'].each_with_index do |header, i|
+    within(:xpath, th_xpath(table_id: 'table-rejected', column: i + 1)) do
+      expect(page).to have_content(header)
+    end
+  end
+
+  [auction.title, auction.delivery_due_at, auction.delivery_url,
+   auction.winning_bidder_name, auction.rejected_at].each_with_index do |expected, i|
+    within(:xpath, cel_xpath(table_id: 'table-rejected', column: i + 1)) do
       expect(page).to have_content(expected)
     end
   end

--- a/features/step_definitions/auction_create_steps.rb
+++ b/features/step_definitions/auction_create_steps.rb
@@ -92,7 +92,7 @@ Given(/^there are complete and successful auctions$/) do
 end
 
 Given(/^there is a rejected auction$/) do
-  @rejected = FactoryGirl.create(:auction, :rejected)
+  @rejected = FactoryGirl.create(:auction, :closed, :with_bidders, :delivered, :rejected)
 end
 
 Given(/^there is an auction where the winning vendor is not eligible to be paid$/) do

--- a/spec/factories/auctions.rb
+++ b/spec/factories/auctions.rb
@@ -117,10 +117,12 @@ FactoryGirl.define do
 
     trait :accepted do
       result :accepted
+      accepted_at { Time.now }
     end
 
     trait :rejected do
       result :rejected
+      rejected_at { Time.now }
     end
 
     trait :not_paid do

--- a/spec/services/update_auction_spec.rb
+++ b/spec/services/update_auction_spec.rb
@@ -118,6 +118,15 @@ describe UpdateAuction do
     end
 
     context 'when result is set to rejected' do
+      it 'sets rejected_at to the time the auction was rejected' do
+        auction = create(:auction, :delivery_due_at_expired)
+        params = { auction: { result: 'rejected' } }
+
+        updater = UpdateAuction.new(auction: auction, params: params, current_user: auction.user)
+
+        expect { updater.perform }.to change { auction.rejected_at }
+      end
+
       it 'does not set cap_proposal_url' do
         auction = create(:auction, :delivery_due_at_expired)
         params = { auction: { result: 'rejected' } }


### PR DESCRIPTION
Fixes #790 

This meant adding a rejected_at field to the database to record when auctions are rejected. I also cleaned up a few issues where the Law of Demeter should be observed.