### PR TITLE
Auction automatically accepted when vendor adds payment information

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,14 +1,12 @@
 class UsersController < ApplicationController
-  def edit
-    require_authentication
+  before_action :require_authentication
 
+  def edit
     @user = current_user
     @user.decorate.sam_status_message_for(flash)
   end
 
   def update
-    require_authentication
-
     updater = UpdateUser.new(params, current_user)
     if updater.save
       redirect_to root_path

--- a/app/models/auction_query.rb
+++ b/app/models/auction_query.rb
@@ -108,6 +108,14 @@ class AuctionQuery
       .uniq
   end
 
+  def accepted_with_bid_from_user(user_id)
+    @relation
+      .accepted
+      .joins(:bids)
+      .where(bids: { bidder_id: user_id })
+      .uniq
+  end
+
   module Scopes
     def delivery_due_at_expired
       where('delivery_due_at < ?', Time.current)
@@ -181,7 +189,6 @@ class AuctionQuery
       today = Time.current.to_date
       last_24_hours = today - 24.hours
       next_24_hours = today + 24.hours
-
       where(ended_at: last_24_hours..next_24_hours)
     end
 

--- a/app/services/accept_auction.rb
+++ b/app/services/accept_auction.rb
@@ -1,17 +1,20 @@
 class AcceptAuction
-  attr_reader :auction
+  attr_reader :auction, :credit_card_form_url
 
-  def initialize(auction)
+  def initialize(auction:, credit_card_form_url: '')
     @auction = auction
+    @credit_card_form_url = credit_card_form_url
   end
 
   def perform
-    if winning_bidder && winning_bidder.credit_card_form_url.blank?
-      AuctionMailer.winning_bidder_missing_payment_method(auction: auction).deliver_later
+    if credit_card_form_url.blank?
+      AuctionMailer
+        .winning_bidder_missing_payment_method(auction: auction)
+        .deliver_later
     else
       auction.accepted_at = Time.current
-      UpdateC2ProposalJob.perform_later(auction.id)
       send_customer_email
+      update_purchase_request
     end
   end
 
@@ -23,7 +26,15 @@ class AcceptAuction
 
   def send_customer_email
     if customer && customer.email.present?
-      AuctionMailer.auction_accepted_customer_notification(auction: auction).deliver_later
+      AuctionMailer
+        .auction_accepted_customer_notification(auction: auction)
+        .deliver_later
+    end
+  end
+
+  def update_purchase_request
+    if auction.purchase_card == "default"
+      UpdateC2ProposalJob.perform_later(auction.id)
     end
   end
 

--- a/app/services/accept_auction.rb
+++ b/app/services/accept_auction.rb
@@ -8,9 +8,7 @@ class AcceptAuction
 
   def perform
     if credit_card_form_url.blank?
-      AuctionMailer
-        .winning_bidder_missing_payment_method(auction: auction)
-        .deliver_later
+      send_winning_vendor_email
     else
       auction.accepted_at = Time.current
       send_customer_email
@@ -20,8 +18,10 @@ class AcceptAuction
 
   private
 
-  def winning_bidder
-    WinningBid.new(auction).find.bidder
+  def send_winning_vendor_email
+    AuctionMailer
+      .winning_bidder_missing_payment_method(auction: auction)
+      .deliver_later
   end
 
   def send_customer_email

--- a/app/services/update_auction.rb
+++ b/app/services/update_auction.rb
@@ -55,7 +55,10 @@ class UpdateAuction
 
   def perform_approved_auction_tasks
     if auction.accepted? && auction.accepted_at.nil?
-      AcceptAuction.new(auction).perform
+      AcceptAuction.new(
+        auction: auction,
+        credit_card_form_url: winning_bidder.credit_card_form_url
+      ).perform
     end
   end
 

--- a/app/services/update_user.rb
+++ b/app/services/update_user.rb
@@ -31,7 +31,7 @@ class UpdateUser < Struct.new(:params, :current_user)
   def update_auctions
     if added_payment_information?
       AuctionQuery.new.accepted_with_bid_from_user(user.id).each do |auction|
-        if auction.accepted_at.nil? && winning_bidder_for(auction) == user
+        if user_payment_info_needed_for?(auction)
           accept(auction)
         end
       end
@@ -42,6 +42,10 @@ class UpdateUser < Struct.new(:params, :current_user)
     user.credit_card_form_url_changed? &&
       user.credit_card_form_url_was == '' &&
       user.valid?
+  end
+
+  def user_payment_info_needed_for?(auction)
+    auction.accepted_at.nil? && winning_bidder_for(auction) == user
   end
 
   def winning_bidder_for(auction)

--- a/app/view_models/auction_show_view_model.rb
+++ b/app/view_models/auction_show_view_model.rb
@@ -92,8 +92,20 @@ class AuctionShowViewModel
     end
   end
 
+  def accepted_at_partial
+    if auction.accepted_at.nil?
+      'components/null'
+    else
+      'auctions/accepted_at'
+    end
+  end
+
   def formatted_paid_at
     formatted_date(auction.paid_at)
+  end
+
+  def formatted_accepted_at
+    formatted_date(auction.accepted_at)
   end
 
   def tag_data_value_status

--- a/app/views/auctions/_accepted_at.html.erb
+++ b/app/views/auctions/_accepted_at.html.erb
@@ -1,0 +1,4 @@
+<div>
+  <h6>Accepted at:</h6>
+  <p class="auction-label-info"><%= auction.formatted_accepted_at %></p>
+</div>

--- a/app/views/auctions/_paid_at.html.erb
+++ b/app/views/auctions/_paid_at.html.erb
@@ -1,4 +1,4 @@
 <div>
-  <p class="auction-label">Paid at:</p>
+  <h6>Paid at:</h6>
   <p class="auction-label-info"><%= auction.formatted_paid_at %></p>
 </div>

--- a/app/views/auctions/show.html.erb
+++ b/app/views/auctions/show.html.erb
@@ -61,9 +61,8 @@
         <%= @view_model.capitalized_type %>
         (<%= link_to 'rules', @view_model.rules_path %>)
         </p>
-
         <%= render partial: @view_model.paid_at_partial, locals: { auction: @view_model } %>
-
+        <%= render partial: @view_model.accepted_at_partial, locals: { auction: @view_model } %>
         <p>
         <i class="fa fa-github"></i>
         <%= link_to 'View on GitHub <icon class="fa fa-angle-double-right"></icon>'.html_safe,

--- a/features/step_definitions/auction_attributes_steps.rb
+++ b/features/step_definitions/auction_attributes_steps.rb
@@ -60,10 +60,15 @@ Then(/^I should see the start price for the auction is \$(\d+)$/) do |price|
 end
 
 Then(/^I should see that the auction was accepted$/) do
-  expect(@auction.accepted_at).not_to eq nil
+  expect(@auction.reload.accepted_at).not_to eq nil
   expect(page).to have_content(
     DcTimePresenter.convert_and_format(@auction.accepted_at)
   )
+end
+
+Then(/^I should see that the auction was not accepted$/) do
+  expect(page).not_to have_content("Accepted at")
+  expect(@auction.reload.accepted_at).to eq nil
 end
 
 Then(/^I should see the number of bid for the auction$/) do

--- a/features/step_definitions/auction_create_steps.rb
+++ b/features/step_definitions/auction_create_steps.rb
@@ -142,11 +142,19 @@ Given(/^there is an auction with an associated customer$/) do
 end
 
 Given(/^there is an auction where the winning vendor is missing a payment method$/) do
+  @auction = FactoryGirl.create( :auction, :with_bidders, :evaluation_needed)
+  @winning_bidder = WinningBid.new(@auction).find.bidder
+  @winning_bidder.update(credit_card_form_url: '')
+end
+
+Given(/^there is an accepted auction where the winning vendor is missing a payment method$/) do
   @auction = FactoryGirl.create(
     :auction,
     :with_bidders,
-    :evaluation_needed,
-    c2_proposal_url: 'www.example.com'
+    :published,
+    result: :accepted,
+    accepted_at: nil,
+    c2_proposal_url: 'https://c2-dev.18f.gov/proposals/2486'
   )
   @winning_bidder = WinningBid.new(@auction).find.bidder
   @winning_bidder.update(credit_card_form_url: '')

--- a/features/step_definitions/login_steps.rb
+++ b/features/step_definitions/login_steps.rb
@@ -20,3 +20,9 @@ When(/^I sign in and verify my account information/) do
   step "I visit my profile page"
   click_on "Submit"
 end
+
+When(/^I am the winning bidder$/) do
+  @user = @winning_bidder
+  @github_id = @user.github_id
+  mock_sign_in(@winning_bidder.github_id, @winning_bidder.name)
+end

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -11,7 +11,6 @@ Then(/^I visit my bids page$/) do
 end
 
 When(/^I visit my profile page$/) do
-  @user = User.find_by(github_id: @github_id)
   visit profile_path
 end
 

--- a/features/vendor_provides_credit_card_url.feature
+++ b/features/vendor_provides_credit_card_url.feature
@@ -39,3 +39,15 @@ Feature: Vendor updates Credit Card Form URL
     And I click on the "Submit" button
     Then I should see "Credit card form url is not a valid URL"
     And my Credit Card Form URL should not be set
+
+  Scenario: Vendor is winning bidder and updates credit card form url
+    Given there is an accepted auction where the winning vendor is missing a payment method
+    And I am the winning bidder
+    And I sign in
+    When I visit the auction page
+    Then I should see that the auction was not accepted
+    When I visit my profile page
+    And I fill in the Credit Card Form URL field on my profile page
+    And I click on the "Submit" button
+    And I visit the auction page
+    Then I should see that the auction was accepted

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -6,7 +6,7 @@ FactoryGirl.define do
     duns_number { Faker::Company.duns_number }
     name { Faker::Name.name }
     email
-    github_id 123_456
+    github_id
     github_login 'github_username'
     sam_status :duns_blank
     credit_card_form_url 'https://some-website.com/pay'

--- a/spec/services/accept_auction_spec.rb
+++ b/spec/services/accept_auction_spec.rb
@@ -12,7 +12,7 @@ describe AcceptAuction do
             .with(auction: auction)
             .and_return(mailer_double)
 
-          AcceptAuction.new(auction).perform
+          AcceptAuction.new(auction: auction, credit_card_form_url: 'example.com').perform
 
           expect(AuctionMailer).to have_received(:auction_accepted_customer_notification)
             .with(auction: auction)
@@ -24,11 +24,9 @@ describe AcceptAuction do
         it 'does not send an email to the customer' do
           customer = create(:customer, email: nil)
           auction = create(:auction, :with_bidders, customer: customer)
-          winning_bidder = WinningBid.new(auction).find.bidder
-          winning_bidder.update(credit_card_form_url: 'test@example.com')
           allow(AuctionMailer).to receive(:auction_accepted_customer_notification)
 
-          AcceptAuction.new(auction).perform
+          AcceptAuction.new(auction: auction, credit_card_form_url: 'example.com').perform
 
           expect(AuctionMailer).not_to have_received(:auction_accepted_customer_notification)
         end
@@ -38,11 +36,9 @@ describe AcceptAuction do
     context 'auction does not belong to a customer' do
       it 'does not send an email' do
         auction = create(:auction, :with_bidders, customer: nil)
-        winning_bidder = WinningBid.new(auction).find.bidder
-        winning_bidder.update(credit_card_form_url: 'test@example.com')
         allow(AuctionMailer).to receive(:auction_accepted_customer_notification)
 
-        AcceptAuction.new(auction).perform
+        AcceptAuction.new(auction: auction, credit_card_form_url: 'example.com').perform
 
         expect(AuctionMailer).not_to have_received(:auction_accepted_customer_notification)
       end
@@ -51,14 +47,12 @@ describe AcceptAuction do
     context 'winning bidder does not have credit card information' do
       it 'sends an email to the winner' do
         auction = create(:auction, :with_bidders)
-        winning_bidder = WinningBid.new(auction).find.bidder
-        winning_bidder.update(credit_card_form_url: '')
         mailer_double = double(deliver_later: true)
         allow(AuctionMailer).to receive(:winning_bidder_missing_payment_method)
           .with(auction: auction)
           .and_return(mailer_double)
 
-        AcceptAuction.new(auction).perform
+        AcceptAuction.new(auction: auction, credit_card_form_url: '').perform
 
         expect(AuctionMailer).to have_received(:winning_bidder_missing_payment_method)
           .with(auction: auction)
@@ -66,27 +60,36 @@ describe AcceptAuction do
       end
     end
     context 'winning bidder has credit card information' do
-      it 'enqueues the UpdateC2ProposalJob' do
-        auction = create(:auction, :with_bidders)
-        winning_bidder = WinningBid.new(auction).find.bidder
-        winning_bidder.update(credit_card_form_url: 'test@example.com')
-        allow(UpdateC2ProposalJob).to receive(:perform_later)
+      context 'auction is for 18F purchase card' do
+        it 'enqueues the UpdateC2ProposalJob' do
+          auction = create(:auction, :with_bidders)
+          allow(UpdateC2ProposalJob).to receive(:perform_later)
 
-        AcceptAuction.new(auction).perform
+          AcceptAuction.new(auction: auction, credit_card_form_url: 'example.com').perform
 
-        expect(UpdateC2ProposalJob).to have_received(:perform_later).with(auction.id)
+          expect(UpdateC2ProposalJob).to have_received(:perform_later).with(auction.id)
+        end
+      end
+
+      context 'auction is for other purchase card' do
+        it 'does not enqueue the UpdateC2ProposalJob' do
+          auction = create(:auction, :with_bidders, purchase_card: :other)
+          allow(UpdateC2ProposalJob).to receive(:perform_later)
+
+          AcceptAuction.new(auction: auction, credit_card_form_url: 'test.com').perform
+
+          expect(UpdateC2ProposalJob).not_to have_received(:perform_later).with(auction.id)
+        end
       end
 
       it 'sets accepted_at' do
         auction = create(:auction, :with_bidders)
-        winning_bidder = WinningBid.new(auction).find.bidder
-        winning_bidder.update(credit_card_form_url: 'test@example.com')
         time = Time.parse('10:00:00 UTC')
 
         Timecop.freeze(time) do
           auction = create(:auction, :with_bidders, accepted_at: nil)
 
-          AcceptAuction.new(auction).perform
+          AcceptAuction.new(auction: auction, credit_card_form_url: 'test.com').perform
 
           expect(auction.accepted_at).to eq time
         end

--- a/spec/services/update_auction_spec.rb
+++ b/spec/services/update_auction_spec.rb
@@ -78,7 +78,9 @@ describe UpdateAuction do
             :delivery_due_at_expired
           )
           accept_double = double(perform: true)
-          allow(AcceptAuction).to receive(:new).with(auction).and_return(accept_double)
+          allow(AcceptAuction).to receive(:new).
+            with(auction: auction, credit_card_form_url: "https://some-website.com/pay").
+            and_return(accept_double)
           params = { auction: { result: 'accepted' } }
 
           UpdateAuction.new(auction: auction, params: params, current_user: auction.user).perform
@@ -97,7 +99,9 @@ describe UpdateAuction do
               :delivery_due_at_expired
             )
             accept_double = double(perform: true)
-            allow(AcceptAuction).to receive(:new).with(auction).and_return(accept_double)
+            allow(AcceptAuction).to receive(:new).
+              with(auction: auction, credit_card_form_url: "https://some-website.com/pay").
+              and_return(accept_double)
             params = { auction: { result: 'accepted' } }
 
             UpdateAuction.new(auction: auction, params: params, current_user: auction.user).perform
@@ -115,7 +119,9 @@ describe UpdateAuction do
               :delivery_due_at_expired
             )
             accept_double = double(perform: true)
-            allow(AcceptAuction).to receive(:new).with(auction).and_return(accept_double)
+            allow(AcceptAuction).to receive(:new).
+              with(auction: auction, credit_card_form_url: "https://some-website.com/pay").
+              and_return(accept_double)
             params = { auction: { result: 'accepted' } }
 
             UpdateAuction.new(auction: auction, params: params, current_user: auction.user).perform
@@ -150,7 +156,7 @@ describe UpdateAuction do
         auction = create(:auction, :delivery_due_at_expired)
         params = { auction: { result: 'rejected' } }
         accept_double = double(perform: true)
-        allow(AcceptAuction).to receive(:new).with(auction).and_return(accept_double)
+        allow(AcceptAuction).to receive(:new).with(auction: auction, credit_card_form_url: "https://some-website.com/pay" ).and_return(accept_double)
 
         UpdateAuction.new(auction: auction, params: params, current_user: auction.user)
 


### PR DESCRIPTION
* When an admin "accepts" an auction but the winning vendor does not
  have payment information in the system, the vendor is sent an email
* The auction result is set to "accepted" but the "accepted_at"
  timestamp is not sent
* When the vendor logs in and adds a valid Credit Card Form URL to their
  profile, the auction is automatically accepted
* Result: `accepted_at` timestamp is set and C2 proposal is updated with
  payment information
* Closes https://github.com/18F/micropurchase/issues/780