### PR TITLE
Update ribbon css

### DIFF
--- a/app/assets/stylesheets/components/_ribbon.scss
+++ b/app/assets/stylesheets/components/_ribbon.scss
@@ -22,6 +22,7 @@ $ribbon-hang: .25em;
   width: $ribbon-w;
 
   [class*="auction-label-"] {
+    font-size: $base-font-size;
     color: $color-white;
     float: right;
     margin: 0;


### PR DESCRIPTION
* Got messed up after `span` global style was removed in https://github.com/18F/micropurchase/pull/831/files

Before:
![screen shot 2016-07-11 at 1 11 56 pm](https://cloud.githubusercontent.com/assets/601515/16745076/1a76e96a-4769-11e6-8b3f-6c8f38836091.png)


After:

![screen shot 2016-07-11 at 1 11 27 pm](https://cloud.githubusercontent.com/assets/601515/16745085/1dbad05a-4769-11e6-913d-6d5b553bb390.png)

