### PR TITLE
Fix login issue for users without name in GitHub

### DIFF
--- a/app/models/login_user.rb
+++ b/app/models/login_user.rb
@@ -25,7 +25,8 @@ class LoginUser < Struct.new(:auth_hash, :session)
     attribute = field.to_sym
 
     if user.send(attribute).blank?
-      user.send("#{attribute}=", auth_hash[:info][attribute])
+      value = auth_hash[:info][attribute] || ''
+      user.send("#{attribute}=", value)
     end
   end
 end

--- a/spec/controllers/authentications_controller_spec.rb
+++ b/spec/controllers/authentications_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe AuthenticationsController do
+describe AuthenticationsController do
   describe '#create' do
     it 'should store the github uid in the session' do
       request.env["omniauth.auth"] = OmniAuth.config.mock_auth[:github]

--- a/spec/models/login_user_spec.rb
+++ b/spec/models/login_user_spec.rb
@@ -2,6 +2,28 @@ require 'rails_helper'
 
 describe LoginUser do
   describe '#perform' do
+    context 'user does not have name in github' do
+      it 'creates the user without a name' do
+        github_id = '1234'
+        auth_hash = {
+          uid: github_id,
+          info: {
+            nickname: 'github_username',
+            name: nil,
+            email: 'test@example.com'
+          }
+        }
+
+        login_user = LoginUser.new(auth_hash, {})
+        login_user.perform
+
+        user = User.last
+        expect(user.github_login).to eq 'github_username'
+        expect(user.name).to eq ''
+        expect(user.email).to eq 'test@example.com'
+      end
+    end
+
     context 'user does not have github username, name, or email' do
       it 'updates from auth hash' do
         github_id = '1234'
@@ -92,22 +114,22 @@ describe LoginUser do
         expect(session[:user_id]).to eq(user.id)
       end
     end
-  end
 
-  def auth_hash
-    OmniAuth::AuthHash.new(
-      provider: 'github',
-      uid: github_id_from_oauth,
-      info: {
-        nickname: 'github_username',
-        name: 'Kane',
-        email: 'email@example.com',
-        image: 'github-image.png'
-      }
-    )
-  end
+    def auth_hash
+      OmniAuth::AuthHash.new(
+        provider: 'github',
+        uid: github_id_from_oauth,
+        info: {
+          nickname: 'github_username',
+          name: 'Kane',
+          email: 'email@example.com',
+          image: 'github-image.png'
+        }
+      )
+    end
 
-  def github_id_from_oauth
-    '12345'
+    def github_id_from_oauth
+      '12345'
+    end
   end
 end


### PR DESCRIPTION
* If a user does not have a name in github, `name` key has a value of
  `null`
* We require `name` at the postgres level, but default to `""`
* Check for `null` in login user so we don't have problems when ppl
  without a name in GH try to log in