### PR TITLE
Allow admin to publish closed, unapproved auctions

### DIFF
--- a/app/view_models/admin/edit_auction_view_model.rb
+++ b/app/view_models/admin/edit_auction_view_model.rb
@@ -38,7 +38,7 @@ class Admin::EditAuctionViewModel < Admin::BaseViewModel
   end
 
   def published_options
-    if auction.c2_approved_at.present?
+    if closed? || auction.c2_approved_at.present?
       Auction.publisheds.keys.to_a
     else
       ['unpublished']
@@ -61,5 +61,9 @@ class Admin::EditAuctionViewModel < Admin::BaseViewModel
 
   def default_date_time
     @_default_date_time ||= DefaultDateTime.new.convert
+  end
+
+  def closed?
+    AuctionStatus.new(auction).over?
   end
 end

--- a/spec/view_models/admin/edit_auction_view_model_spec.rb
+++ b/spec/view_models/admin/edit_auction_view_model_spec.rb
@@ -1,6 +1,40 @@
 require 'rails_helper'
 
 describe Admin::EditAuctionViewModel do
+  describe '#published_options' do
+    context 'auction does not have c2_approved_at' do
+      context 'auction is closed' do
+        it 'returns all options' do
+          auction = create(:auction, :closed, c2_approved_at: nil)
+
+          view_model = Admin::EditAuctionViewModel.new(auction)
+
+          expect(view_model.published_options).to eq(['unpublished', 'published'])
+        end
+      end
+
+      context 'auction is not closed' do
+        it 'does not return published option' do
+          auction = create(:auction, :future, c2_approved_at: nil)
+
+          view_model = Admin::EditAuctionViewModel.new(auction)
+
+          expect(view_model.published_options).to eq(['unpublished'])
+        end
+      end
+    end
+
+    context 'auction does have c2_approved_at' do
+      it 'returns all options' do
+        auction = create(:auction, c2_approved_at: Time.current)
+
+        view_model = Admin::EditAuctionViewModel.new(auction)
+
+        expect(view_model.published_options).to eq(['unpublished', 'published'])
+      end
+    end
+  end
+
   describe '#hour_default' do
     context 'time present' do
       it 'returns hour in DC time' do


### PR DESCRIPTION
* We have old auctions that are published but do not have a c2 proposal
  url. When we edit them, they cannot be set to "published"
* Closes https://github.com/18F/micropurchase/issues/875