### PR TITLE
Rejected auctions with no bids would crash action items

### DIFF
--- a/app/models/bid.rb
+++ b/app/models/bid.rb
@@ -2,11 +2,11 @@ class Bid < ActiveRecord::Base
   belongs_to :auction
   belongs_to :bidder, class_name: 'User'
 
-  def bidder?
-    !bidder.nil?
-  end
-
   def bidder_name
     bidder.name
+  end
+
+  def decorated_bidder
+    UserPresenter.new(bidder)
   end
 end

--- a/app/models/bid.rb
+++ b/app/models/bid.rb
@@ -2,6 +2,10 @@ class Bid < ActiveRecord::Base
   belongs_to :auction
   belongs_to :bidder, class_name: 'User'
 
+  def bidder?
+    !bidder.nil?
+  end
+
   def bidder_name
     bidder.name
   end

--- a/app/models/null_bid.rb
+++ b/app/models/null_bid.rb
@@ -1,8 +1,4 @@
 class NullBid
-  def bidder?
-    false
-  end
-
   def amount
     nil
   end
@@ -17,5 +13,9 @@ class NullBid
 
   def bidder_name
     nil
+  end
+
+  def decorated_bidder
+    NullBidder.new
   end
 end

--- a/app/models/null_bid.rb
+++ b/app/models/null_bid.rb
@@ -1,4 +1,8 @@
 class NullBid
+  def bidder?
+    false
+  end
+
   def amount
     nil
   end

--- a/app/models/null_bidder.rb
+++ b/app/models/null_bidder.rb
@@ -1,0 +1,9 @@
+class NullBidder
+  def name
+    nil
+  end
+
+  def admin_user_page_link_partial
+    'components/null'
+  end
+end

--- a/app/presenters/user_presenter.rb
+++ b/app/presenters/user_presenter.rb
@@ -27,6 +27,10 @@ class UserPresenter < SimpleDelegator
     'components/null'
   end
 
+  def admin_user_page_link_partial
+    'components/admin_user_page_link'
+  end
+
   def admin_edit_auction_partial
     if admin?
       'auctions/edit_auction_link'

--- a/app/view_models/admin/action_item_list_item.rb
+++ b/app/view_models/admin/action_item_list_item.rb
@@ -13,16 +13,8 @@ class Admin::ActionItemListItem < Admin::BaseViewModel
     @_winner ||= WinningBid.new(auction).find
   end
 
-  def winning_bidder?
-    winning_bid.bidder?
-  end
-
-  def winning_bidder_id
-    winning_bid.bidder_id
-  end
-
-  def winning_bidder_name
-    winning_bid.bidder_name
+  def winning_bidder
+    winning_bid.decorated_bidder
   end
 
   def id

--- a/app/view_models/admin/action_item_list_item.rb
+++ b/app/view_models/admin/action_item_list_item.rb
@@ -13,6 +13,10 @@ class Admin::ActionItemListItem < Admin::BaseViewModel
     @_winner ||= WinningBid.new(auction).find
   end
 
+  def winning_bidder?
+    winning_bid.bidder?
+  end
+
   def winning_bidder_id
     winning_bid.bidder_id
   end

--- a/app/views/admin/action_items/_rejected_auctions.html.erb
+++ b/app/views/admin/action_items/_rejected_auctions.html.erb
@@ -15,7 +15,7 @@
       <td><%= link_to(auction.title, admin_auction_path(auction.id)) %></td>
       <td><%= auction.delivery_due_at %></td>
       <td><%= auction.delivery_url %></td>
-      <td><%= link_to auction.winning_bidder_name, admin_user_path(auction.winning_bidder_id) %></td>
+      <td><% if auction.winning_bidder? %><%= link_to auction.winning_bidder_name, admin_user_path(auction.winning_bidder_id) %><% end %></td>
       <td><%= auction.rejected_at %></td>
       <td><%= link_to('edit', edit_admin_auction_path(auction.id)) %></td>
     </tr>

--- a/app/views/admin/action_items/_rejected_auctions.html.erb
+++ b/app/views/admin/action_items/_rejected_auctions.html.erb
@@ -15,7 +15,7 @@
       <td><%= link_to(auction.title, admin_auction_path(auction.id)) %></td>
       <td><%= auction.delivery_due_at %></td>
       <td><%= auction.delivery_url %></td>
-      <td><% if auction.winning_bidder? %><%= link_to auction.winning_bidder_name, admin_user_path(auction.winning_bidder_id) %><% end %></td>
+      <td><%= render partial: auction.winning_bidder.admin_user_page_link_partial, locals: {bidder: auction.winning_bidder} %></td>
       <td><%= auction.rejected_at %></td>
       <td><%= link_to('edit', edit_admin_auction_path(auction.id)) %></td>
     </tr>

--- a/app/views/components/_admin_user_page_link.html.erb
+++ b/app/views/components/_admin_user_page_link.html.erb
@@ -1,0 +1,1 @@
+<%= link_to bidder.name, admin_user_path(bidder.id) %>

--- a/features/admin_views_action_items.feature
+++ b/features/admin_views_action_items.feature
@@ -23,3 +23,8 @@ Feature: Admin view action items
     Given there is a rejected auction
     When I visit the admin action items page
     Then I should see the rejected auction as an action item
+
+  Scenario: Viewing rejected auction with no bids
+    Given there is a rejected auction with no bids
+    When I visit the admin action items page
+    Then I should see the rejected auction as an action item

--- a/features/step_definitions/admin_views_action_items_steps.rb
+++ b/features/step_definitions/admin_views_action_items_steps.rb
@@ -8,7 +8,7 @@ Then(/^I should see the rejected auction as an action item$/) do
   end
 
   [auction.title, auction.delivery_due_at, auction.delivery_url,
-   auction.winning_bidder_name, auction.rejected_at].each_with_index do |expected, i|
+   auction.winning_bidder.name, auction.rejected_at].each_with_index do |expected, i|
     within(:xpath, cel_xpath(table_id: 'table-rejected', column: i + 1)) do
       expect(page).to have_content(expected)
     end

--- a/features/step_definitions/auction_create_steps.rb
+++ b/features/step_definitions/auction_create_steps.rb
@@ -105,6 +105,10 @@ Given(/^there is a rejected auction$/) do
   @rejected = FactoryGirl.create(:auction, :closed, :with_bidders, :delivered, :rejected)
 end
 
+Given(/^there is a rejected auction with no bids$/) do
+  @rejected = FactoryGirl.create(:auction, :closed, :rejected)
+end
+
 Given(/^there is an auction where the winning vendor is not eligible to be paid$/) do
   @auction = FactoryGirl.create(
     :auction,


### PR DESCRIPTION
Fixes #865 

It would be good to get a more elegant way of checking if there is a bidder before I generate the link, so suggestions welcome.