### PR TITLE
Redirect guests when trying to access `sign_up` page

### DIFF
--- a/app/controllers/sign_ups_controller.rb
+++ b/app/controllers/sign_ups_controller.rb
@@ -1,4 +1,6 @@
 class SignUpsController < ApplicationController
+  before_action :require_authentication
+
   def show
   end
 end


### PR DESCRIPTION
* This is the page you see when you first sign up
* It requires that the current user be a user, not a guest