### PR TITLE
Admin taken to "action items" page after logging in

### DIFF
--- a/app/constraints/admin_constraint.rb
+++ b/app/constraints/admin_constraint.rb
@@ -1,0 +1,10 @@
+class AdminConstraint
+  def matches?(request)
+    user = current_user(request)
+    Admins.verify?(user.github_id)
+  end
+
+  def current_user(request)
+    User.where(id: request.session[:user_id]).first || Guest.new
+  end
+end

--- a/app/models/guest.rb
+++ b/app/models/guest.rb
@@ -1,4 +1,8 @@
 class Guest
+  def github_id
+    nil
+  end
+
   def decorate
     GuestPresenter.new
   end

--- a/app/views/components/_nav_header.erb
+++ b/app/views/components/_nav_header.erb
@@ -4,7 +4,7 @@
   <div class="header-wrap">
     <div class="usa-grid-one-half">
       <div class="header-title">
-        <a href="/" class="logo" title="Home">
+        <%= link_to auctions_path, title: 'Home' do %>
           <div class="logo">
             <%= image_tag '18F-Logo-2016-Blue.svg', alt: '18f-logo', class: 'logo-img' %>
             <div class="title-wrapper">
@@ -12,7 +12,7 @@
               <div class="subtitle">A marketplace for the federal government’s open source projects</div>
             </div>
           </div>
-        </a>
+        <% end %>
       </div>
     </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,10 @@ Rails.application.routes.draw do
   end
 
   # Web requests
+  constraints AdminConstraint.new do
+    root to: 'admin/action_items#index', as: :admin_root
+  end
+
   root 'auctions#index'
 
   get '/auth/:provider/callback', to: 'authentications#create'

--- a/features/admin_signs_in.feature
+++ b/features/admin_signs_in.feature
@@ -1,0 +1,8 @@
+Feature: Admin signs in
+  As an admin
+  I want be taken to the admin panel when I log in
+
+  Scenario: Admin signs in
+    Given I am an administrator
+    And I sign in
+    Then I should be on the admin action items page

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -109,3 +109,9 @@ end
 Then(/^I should be on the sign up page$/) do
   expect(page.current_path).to eq(sign_up_path)
 end
+
+When(/^I should be on the admin action items page$/) do
+  expect(page).to have_content('Delivery past due')
+  expect(page).to have_content('Evaluation needed')
+  expect(page).to have_content('Payment needed')
+end


### PR DESCRIPTION
* Different root url for admins vs guests or regular users
* Closes https://github.com/18F/micropurchase/issues/840