### PR TITLE
Unpublished auctions should not be available

### DIFF
--- a/app/models/auction_status.rb
+++ b/app/models/auction_status.rb
@@ -4,7 +4,7 @@ class AuctionStatus
   end
 
   def available?
-    started_in_past? && ends_in_future?
+    published? && started_in_past? && ends_in_future?
   end
 
   def over?
@@ -22,6 +22,10 @@ class AuctionStatus
   private
 
   attr_reader :auction
+
+  def published?
+    auction.published?
+  end
 
   def ends_in_future?
     auction.ended_at > Time.current

--- a/spec/models/auction_status_spec.rb
+++ b/spec/models/auction_status_spec.rb
@@ -1,155 +1,115 @@
-require "rails_helper"
+require 'rails_helper'
 
 describe AuctionStatus do
-  describe "#available?" do
-    context "start datetime in past, end datetime in future" do
-      it "is true" do
-        auction = FactoryGirl.build(:auction, started_at: yesterday, ended_at: tomorrow)
-
+  describe '#available?' do
+    context 'start datetime in past, end datetime in future' do
+      it 'is true' do
+        auction = FactoryGirl.build(:auction, :available)
         status = AuctionStatus.new(auction)
-
         expect(status).to be_available
       end
+    end
 
-      context "start datetime in past, end datetime in past" do
-        it "is false" do
-          auction = FactoryGirl.build(:auction, started_at: yesterday, ended_at: yesterday)
-
-          status = AuctionStatus.new(auction)
-
-          expect(status).not_to be_available
-        end
-      end
-
-      context "start datetime in future, end datetime in future" do
-        it "is false" do
-          auction = FactoryGirl.build(:auction, started_at: tomorrow, ended_at: tomorrow)
-
-          status = AuctionStatus.new(auction)
-
-          expect(status).not_to be_available
-        end
+    context 'start datetime in past, end datetime in past' do
+      it 'is false' do
+        auction = FactoryGirl.build(:auction, :closed)
+        status = AuctionStatus.new(auction)
+        expect(status).not_to be_available
       end
     end
 
-    describe "#over?" do
-      context "end datetime is in past" do
-        it "is true" do
-          auction = FactoryGirl.build(:auction, ended_at: yesterday)
-
-          status = AuctionStatus.new(auction)
-
-          expect(status).to be_over
-        end
-      end
-
-      context "end datetime is in future" do
-        it "is false" do
-          auction = FactoryGirl.build(:auction, ended_at: tomorrow)
-
-          status = AuctionStatus.new(auction)
-
-          expect(status).not_to be_over
-        end
-      end
-
-      context "end datetime is nil" do
-        it "is false" do
-          auction = FactoryGirl.build(:auction, ended_at: nil)
-
-          status = AuctionStatus.new(auction)
-
-          expect(status).not_to be_over
-        end
+    context 'start datetime in future, end datetime in future' do
+      it 'is false' do
+        auction = FactoryGirl.build(:auction, :future)
+        status = AuctionStatus.new(auction)
+        expect(status).not_to be_available
       end
     end
 
-    describe "#future?" do
-      context "start datetime is in future" do
-        it "is true" do
-          auction = FactoryGirl.build(:auction, started_at: tomorrow)
-
-          status = AuctionStatus.new(auction)
-
-          expect(status).to be_future
-        end
+    context 'the auction is not published' do
+      it 'is false' do
+        auction = FactoryGirl.build(:auction, :available, published: false)
+        status = AuctionStatus.new(auction)
+        expect(status).to_not be_available
       end
+    end
+  end
 
-      context "start datetime is in past" do
-        it "is false" do
-          auction = FactoryGirl.build(:auction, started_at: yesterday)
-
-          status = AuctionStatus.new(auction)
-
-          expect(status).not_to be_future
-        end
-      end
-
-      context "start datetime is nil" do
-        it "is true" do
-          auction = FactoryGirl.build(:auction, started_at: nil)
-
-          status = AuctionStatus.new(auction)
-
-          expect(status).to be_future
-        end
+  describe '#over?' do
+    context 'end datetime is in past' do
+      it 'is true' do
+        auction = FactoryGirl.build(:auction, :closed)
+        status = AuctionStatus.new(auction)
+        expect(status).to be_over
       end
     end
 
-    describe "expiring?" do
-      context "auction in progress and expiring in less than 12 hours" do
-        it "is true" do
-          auction = FactoryGirl.build(
-            :auction,
-            started_at: yesterday,
-            ended_at: one_hour_from_now
-          )
-
-          status = AuctionStatus.new(auction)
-
-          expect(status).to be_expiring
-        end
-      end
-
-      context "auction not started and expiring in less than 12 hours" do
-        it "is false" do
-          auction = FactoryGirl.build(
-            :auction,
-            started_at: tomorrow,
-            ended_at: one_hour_from_now
-          )
-
-          status = AuctionStatus.new(auction)
-
-          expect(status).not_to be_expiring
-        end
-      end
-
-      context "auction in progress and expiring in more than 12 hours" do
-        it "is false" do
-          auction = FactoryGirl.build(
-            :auction,
-            started_at: yesterday,
-            ended_at: tomorrow
-          )
-
-          status = AuctionStatus.new(auction)
-
-          expect(status).not_to be_expiring
-        end
+    context 'end datetime is in future' do
+      it 'is false' do
+        auction = FactoryGirl.build(:auction, :future)
+        status = AuctionStatus.new(auction)
+        expect(status).not_to be_over
       end
     end
 
-    def yesterday
-      @_yesterday ||= Time.current - 1.day
+    context 'end datetime is nil' do
+      it 'is false' do
+        auction = FactoryGirl.build(:auction, ended_at: nil)
+        status = AuctionStatus.new(auction)
+        expect(status).not_to be_over
+      end
+    end
+  end
+
+  describe '#future?' do
+    context 'start datetime is in future' do
+      it 'is true' do
+        auction = FactoryGirl.build(:auction, :future)
+        status = AuctionStatus.new(auction)
+        expect(status).to be_future
+      end
     end
 
-    def tomorrow
-      @_tomorrow ||= Time.current + 1.day
+    context 'start datetime is in past' do
+      it 'is false' do
+        auction = FactoryGirl.build(:auction, :available)
+        status = AuctionStatus.new(auction)
+        expect(status).not_to be_future
+      end
     end
 
-    def one_hour_from_now
-      @_one_hour_from_now ||= Time.current + 1.hour
+    context 'start datetime is nil' do
+      it 'is true' do
+        auction = FactoryGirl.build(:auction, started_at: nil)
+        status = AuctionStatus.new(auction)
+        expect(status).to be_future
+      end
+    end
+  end
+
+  describe 'expiring?' do
+    context 'auction in progress and expiring in less than 12 hours' do
+      it 'is true' do
+        auction = FactoryGirl.build(:auction, :expiring)
+        status = AuctionStatus.new(auction)
+        expect(status).to be_expiring
+      end
+    end
+
+    context 'auction not started and expiring in less than 12 hours' do
+      it 'is false' do
+        auction = FactoryGirl.build(:auction, :future)
+        status = AuctionStatus.new(auction)
+        expect(status).not_to be_expiring
+      end
+    end
+
+    context 'auction in progress and expiring in more than 12 hours' do
+      it 'is false' do
+        auction = FactoryGirl.build(:auction, :available)
+        status = AuctionStatus.new(auction)
+        expect(status).not_to be_expiring
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #898

Rather than make an integration test for a negative feature, I just added an rspec test to make sure the status available returns false if the auction is not published