### PR TITLE
Update "total" count on insights page

### DIFF
--- a/app/models/auction_query.rb
+++ b/app/models/auction_query.rb
@@ -28,7 +28,7 @@ class AuctionQuery
     relation
       .delivery_due_at_expired
       .delivered
-      .accepted
+      .delivery_accepted
       .c2_submitted
       .paid
   end
@@ -49,7 +49,7 @@ class AuctionQuery
     relation
       .delivery_due_at_expired
       .delivered
-      .accepted
+      .delivery_accepted
       .c2_submitted
       .not_paid
   end

--- a/app/models/concerns/auction_scopes.rb
+++ b/app/models/concerns/auction_scopes.rb
@@ -3,6 +3,7 @@ module AuctionScopes
 
   included do
     scope :accepted, -> { where(result: results['accepted']) }
+    scope :delivery_accepted, -> { where(result: results['accepted']).where.not(accepted_at: nil) }
     scope :c2_not_submitted, -> { where(c2_proposal_url: [nil, '']) }
     scope :c2_submitted, -> { where.not(c2_proposal_url: [nil, '']) }
     scope :closed_within_last_24_hours, -> { where(ended_at: last_24_hours..next_24_hours) }

--- a/app/models/skill_query.rb
+++ b/app/models/skill_query.rb
@@ -10,6 +10,6 @@ class SkillQuery
   end
 
   def accepted_auction_count
-    Auction.accepted.includes(:skills).where(skills: { id: skill.id }).count
+    Auction.delivery_accepted.includes(:skills).where(skills: { id: skill.id }).count
   end
 end

--- a/app/models/statistics/average_delivery_time.rb
+++ b/app/models/statistics/average_delivery_time.rb
@@ -16,6 +16,6 @@ class Statistics::AverageDeliveryTime
   end
 
   def accepted_auctions
-    @_accepted_auctions ||= Auction.published.accepted
+    @_accepted_auctions ||= Auction.delivery_accepted
   end
 end

--- a/app/services/update_auction.rb
+++ b/app/services/update_auction.rb
@@ -54,7 +54,7 @@ class UpdateAuction
   end
 
   def perform_approved_auction_tasks
-    if auction.accepted? && auction.accepted_at.nil?
+    if auction.accepted? && auction.accepted_at.nil? && auction.bids.any?
       AcceptAuction.new(
         auction: auction,
         payment_url: winning_bidder.payment_url

--- a/app/view_models/insights_view_model.rb
+++ b/app/view_models/insights_view_model.rb
@@ -9,7 +9,7 @@ class InsightsViewModel
 
   def hero_metrics
     [
-      published_auction_stat,
+      total_auction_stat,
       accepted_auction_stat,
       unique_winners_stat,
       average_bids_stat,
@@ -34,9 +34,9 @@ class InsightsViewModel
     Skill.all.map { |skill| SkillPresenter.new(skill) }
   end
 
-  def published_auction_stat
+  def total_auction_stat
     {
-      statistic: published_auction_count,
+      statistic: accepted_and_rejected_auction_count,
       label: 'total auctions',
       href: 'chart-bids-by-auction'
     }
@@ -115,14 +115,11 @@ class InsightsViewModel
   end
 
   def accepted_and_rejected_auction_count
-    accepted_auctions_count + AuctionQuery.new.rejected.count
+    @_accepted_and_rejected_auction_count ||=
+      accepted_auctions_count + AuctionQuery.new.rejected.count
   end
 
   def accepted_auctions_count
-    @_accepted_auctions_count ||= Auction.published.accepted.count
-  end
-
-  def published_auction_count
-    @_published_auction_count ||= Auction.published.count
+    @_accepted_auctions_count ||= Auction.delivery_accepted.count
   end
 end

--- a/spec/services/update_auction_spec.rb
+++ b/spec/services/update_auction_spec.rb
@@ -93,7 +93,7 @@ describe UpdateAuction do
 
       context 'auction is between micropurchase and SAT threshold' do
         context 'winning vendor is a small business' do
-          it 'calls the UpdateC2ProposalJob' do
+          it 'calls the AcceptAuctionJob' do
             auction = create(
               :auction,
               :between_micropurchase_and_sat_threshold,
@@ -123,6 +123,21 @@ describe UpdateAuction do
             accept_double = double(perform: true)
             allow(AcceptAuction).to receive(:new).
               with(auction: auction, payment_url: "https://some-website.com/pay").
+              and_return(accept_double)
+            params = { auction: { result: 'accepted' } }
+
+            UpdateAuction.new(auction: auction, params: params, current_user: auction.user).perform
+
+            expect(accept_double).not_to have_received(:perform)
+          end
+        end
+
+        context 'there are no bidders' do
+          it 'does not call AcceptAuction' do
+            auction = create(:auction)
+            accept_double = double(perform: true)
+            allow(AcceptAuction).to receive(:new).
+              with(auction: auction, payment_url: nil).
               and_return(accept_double)
             params = { auction: { result: 'accepted' } }
 


### PR DESCRIPTION
* Should include accepted and rejected count, regardless of published
  status
* Adding this revealed some issues around accepting and rejecting
  auctions without bids
* Closes https://github.com/18F/micropurchase/issues/902