### PR TITLE
Auctions not using 18F default payment method can be marked as paid

### DIFF
--- a/app/models/auction_parser.rb
+++ b/app/models/auction_parser.rb
@@ -11,7 +11,8 @@ class AuctionParser
       delivery_due_at: delivery_due_at,
       ended_at: ended_at,
       started_at: started_at,
-      user: user
+      user: user,
+      paid_at: paid_at
     ).delete_if { |_key, value| value.nil? }
   end
 
@@ -65,6 +66,12 @@ class AuctionParser
 
   def started_at
     parse_datetime("started_at")
+  end
+
+  def paid_at
+    if params[:auction][:paid_at] == '1'
+      Time.current
+    end
   end
 
   def parse_datetime(field)

--- a/app/services/update_auction.rb
+++ b/app/services/update_auction.rb
@@ -24,7 +24,7 @@ class UpdateAuction
   attr_reader :auction, :params, :current_user
 
   def assign_attributes
-    auction.assign_attributes(attributes)
+    auction.assign_attributes(parsed_attributes)
   end
 
   def update_auction_ended_job
@@ -50,7 +50,7 @@ class UpdateAuction
   end
 
   def updating_ended_at?
-    attributes.key?(:ended_at)
+    parsed_attributes.key?(:ended_at)
   end
 
   def perform_approved_auction_tasks
@@ -73,11 +73,11 @@ class UpdateAuction
   end
 
   def auction_accepted?
-    attributes[:result] == 'accepted'
+    parsed_attributes[:result] == 'accepted'
   end
 
   def auction_rejected?
-    attributes[:result] == 'rejected'
+    parsed_attributes[:result] == 'rejected'
   end
 
   def winning_bidder_is_eligible_to_be_paid?
@@ -108,8 +108,8 @@ class UpdateAuction
     WinningBid.new(auction).find.bidder
   end
 
-  def attributes
-    @_attributes ||= AuctionParser.new(params, user).attributes
+  def parsed_attributes
+    @_parsed_attributes ||= AuctionParser.new(params, user).attributes
   end
 
   def user

--- a/app/view_models/admin/edit_auction_view_model.rb
+++ b/app/view_models/admin/edit_auction_view_model.rb
@@ -49,6 +49,24 @@ class Admin::EditAuctionViewModel < Admin::BaseViewModel
     ([auction.customer] + Customer.sorted).uniq.compact
   end
 
+  def c2_proposal_partial
+    if auction.purchase_card == "default"
+      'admin/auctions/c2_proposal_url'
+    else
+      'components/null'
+    end
+  end
+
+  def paid_at_partial
+    if auction.purchase_card == "default" || auction.result != "accepted"
+      'components/null'
+    elsif auction.paid_at.present?
+      'admin/auctions/disabled_paid_at'
+    else
+      'admin/auctions/paid_at'
+    end
+  end
+
   private
 
   def dc_time(field)

--- a/app/views/admin/auctions/_c2_proposal_url.html.erb
+++ b/app/views/admin/auctions/_c2_proposal_url.html.erb
@@ -1,0 +1,1 @@
+<%= f.input :c2_proposal_url, disabled: true %>

--- a/app/views/admin/auctions/_disabled_paid_at.html.erb
+++ b/app/views/admin/auctions/_disabled_paid_at.html.erb
@@ -1,0 +1,4 @@
+<%= f.input :paid_at,
+  as: :boolean,
+  input_html: { checked: true },
+  disabled: true %>

--- a/app/views/admin/auctions/_edit_form.html.erb
+++ b/app/views/admin/auctions/_edit_form.html.erb
@@ -1,3 +1,4 @@
 <%= f.input :delivery_url %>
 <%= f.input :result, collection: Auction.results.keys.to_a %>
-<%= f.input :c2_proposal_url, disabled: true %>
+<%= render partial: auction.c2_proposal_partial, locals: { f: f } %>
+<%= render partial: auction.paid_at_partial, locals: { f: f } %>

--- a/app/views/admin/auctions/_paid_at.html.erb
+++ b/app/views/admin/auctions/_paid_at.html.erb
@@ -1,0 +1,1 @@
+<%= f.input :paid_at, as: :boolean %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -76,8 +76,8 @@ en:
         from: "The 18F Micro-purchase team"
       winning_bidder_missing_payment_method:
         subject: "Please update your profile so Micro-purchase can pay you for your great work!"
-        para_1: "18F wants to pay you for your work! Our team recently accepted your work on \"%{auction_title}\". 
-          We'd like to pay you %{amount}, but we need you to tell us where we can enter our credit card information. 
+        para_1: "18F wants to pay you for your work! Our team recently accepted your work on \"%{auction_title}\".
+          We'd like to pay you %{amount}, but we need you to tell us where we can enter our credit card information.
           To get paid, please go to %{profile_url} and enter a payment URL."
         para_2: "Questions? Please contact us at microupurchase@gsa.gov"
         sign_off: "Sincerely,"

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -14,7 +14,7 @@ en:
         issue_url: "GitHub issue URL"
         github_repo: "GitHub repo URL"
         c2_proposal_url: "C2 proposal URL"
-        paid_at: "Paid at"
+        paid_at: "Paid"
         start_price: "Start price"
       bid:
         amount: "Your bid"

--- a/features/admin_edits_auction.feature
+++ b/features/admin_edits_auction.feature
@@ -2,12 +2,10 @@ Feature: Admin edits auctions in the admins panel
   As an admin
   I should be able to modify existing auctions
 
-  Background:
+  Scenario: Updating an auction
     Given I am an administrator
     And I sign in
-
-  Scenario: Updating an auction
-    Given there is an open auction
+    And there is an open auction
     And there is a client account to bill to
     And there is a skill in the system
     And I visit the auctions admin page
@@ -26,11 +24,12 @@ Feature: Admin edits auctions in the admins panel
     Then I should see new content on the page
 
   Scenario: Associating an auction with a customer
-    Given there is an open auction
+    Given I am an administrator
+    And I sign in
+    And there is an open auction
     And there is a customer
-    And I visit the auctions admin page
 
-    When I click to edit the auction
+    When I visit the admin form for that auction
     Then I should see a select box with all the customers in the system
 
     When I select a customer on the form
@@ -40,12 +39,39 @@ Feature: Admin edits auctions in the admins panel
     When I click to edit the auction
     Then I should see the customer selected for the auction
 
-  Scenario: Associating a auction with a skill
-    Given there is an open auction
+  Scenario: Associating an auction with a skill
+    Given I am an administrator
+    And I sign in
+    And there is an open auction
     And there is a skill in the system
-    And I visit the auctions admin page
-    When I click to edit the auction
+    When I visit the admin form for that auction
     And I select a skill on the form
     And I click on the "Update" button
     And I click to edit the auction
     Then I should see the skill that I set for the auction selected
+
+  Scenario: Marking accepted auction as paid
+    Given I am an administrator
+    And I sign in
+    And there is an accepted auction
+    And the auction is for a different purchase card
+    When I visit the admin form for that auction
+    And I check the "Paid" checkbox
+    And I click on the "Update" button
+    Then I should see when the winning vendor was paid in ET
+
+  Scenario: Accepted auction already marked as paid
+    Given I am an administrator
+    And I sign in
+    And there is a paid auction
+    And the auction is for a different purchase card
+    When I visit the admin form for that auction
+    Then I should see the disabled "Paid" checkbox
+
+  Scenario: Marking non-accepted auction as paid
+    Given I am an administrator
+    And I sign in
+    And there is an auction that needs evaluation
+    And the auction is for a different purchase card
+    When I visit the admin form for that auction
+    Then I should not see the "Paid" checkbox

--- a/features/step_definitions/admin_auction_form_steps.rb
+++ b/features/step_definitions/admin_auction_form_steps.rb
@@ -194,3 +194,15 @@ Then(/^I should see that the form preserves the previously entered values$/) do
   billable = find_field('auction_billable_to')
   expect(billable.value).to eq(@billable.to_s)
 end
+
+When(/^I check the "Paid" checkbox$/) do
+  check('auction_paid_at')
+end
+
+When(/^I should see the disabled "Paid" checkbox$/) do
+  expect(page).to have_checked_field('auction_paid_at', disabled: true)
+end
+
+When(/^I should not see the "Paid" checkbox$/) do
+  expect(page).not_to have_field('auction_paid_at')
+end

--- a/features/step_definitions/auction_attributes_steps.rb
+++ b/features/step_definitions/auction_attributes_steps.rb
@@ -41,6 +41,7 @@ Then(/^I should see the delivery_due_at timestamp in ET$/) do
 end
 
 Then(/^I should see when the winning vendor was paid in ET$/) do
+  @auction.reload
   expect(page).to have_text(DcTimePresenter.convert_and_format(@auction.paid_at))
 end
 

--- a/features/step_definitions/auction_create_steps.rb
+++ b/features/step_definitions/auction_create_steps.rb
@@ -122,7 +122,7 @@ Given(/^there is an auction where the winning vendor is not eligible to be paid$
 end
 
 Given(/^there is a paid auction$/) do
-  @auction = FactoryGirl.create(:auction, :closed, :paid)
+  @auction = FactoryGirl.create(:auction, :closed, :accepted, :paid)
 end
 
 Given(/^the auction is for the default purchase card$/) do
@@ -171,4 +171,14 @@ Given(/^there is an accepted auction where the winning vendor is missing a payme
   )
   @winning_bidder = WinningBid.new(@auction).find.bidder
   @winning_bidder.update(payment_url: '')
+end
+
+Given(/^there is an accepted auction$/) do
+  @auction = FactoryGirl.create(
+    :auction,
+    :with_bidders,
+    :published,
+    result: :accepted,
+    accepted_at: nil,
+  )
 end

--- a/vendor/assets/stylesheets/uswds_overrides/components/_forms.scss
+++ b/vendor/assets/stylesheets/uswds_overrides/components/_forms.scss
@@ -1,6 +1,4 @@
-.usa-checklist-checked {
-  &::before {
-    background-image: image-url('uswds/correct9.png');
-    background-image: image-url('uswds/correct9.svg');
-  }
+input[type="checkbox"]:checked + label::before {
+  background-image: image-url("uswds/correct8.png");
+  background-image: image-url("uswds/correct8.svg");
 }


### PR DESCRIPTION
For an auction that uses "other" purchase card, on edit:
  * If the auction is not accepted, the checkbox does not show
  * If the auction is accepted and not marked as paid, checkbox shows
  * If auction is paid, checkbox shows but is disabled

* Closes https://github.com/18F/micropurchase/issues/886

Checked:

![screen shot 2016-07-20 at 3 38 09 pm](https://cloud.githubusercontent.com/assets/601515/17005584/f4c7aaf0-4e8f-11e6-9fab-8cea042778cb.png)


Disabled:

![screen shot 2016-07-20 at 3 26 36 pm](https://cloud.githubusercontent.com/assets/601515/17005586/f8d99a36-4e8f-11e6-8caf-95fe93cba791.png)
