### PR TITLE
Do not show C2 fields on admin/auctions#show for auctions for other p…

### DIFF
--- a/app/view_models/admin/action_item_list_item.rb
+++ b/app/view_models/admin/action_item_list_item.rb
@@ -42,7 +42,11 @@ class Admin::ActionItemListItem < Admin::BaseViewModel
   end
 
   def c2_proposal_url
-    auction.c2_proposal_url
+    if auction.purchase_card == 'default'
+      auction.c2_proposal_url
+    else
+      'N/A'
+    end
   end
 
   def paid?

--- a/spec/view_models/admin/action_item_list_item_spec.rb
+++ b/spec/view_models/admin/action_item_list_item_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe Admin::ActionItemListItem do
+  describe '#c2_proposal_url' do
+    context 'auction for default purchase card' do
+      it 'returns c2 proposal URL' do
+        auction = create(:auction, purchase_card: :default)
+
+        view_model = Admin::ActionItemListItem.new(auction)
+
+        expect(view_model.c2_proposal_url).to eq auction.c2_proposal_url
+      end
+    end
+
+    context 'auction for other purchase card' do
+      it 'returns n/a' do
+        auction = create(:auction, purchase_card: :other)
+
+        view_model = Admin::ActionItemListItem.new(auction)
+
+        expect(view_model.c2_proposal_url).to eq 'N/A'
+      end
+    end
+  end
+end

--- a/spec/view_models/admin/auction_show_view_model_spec.rb
+++ b/spec/view_models/admin/auction_show_view_model_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+describe Admin::AuctionShowViewModel do
+  context 'auction for default purchase card' do
+    it 'returns c2 proposal URL and approved at fields' do
+      auction = create(:auction, purchase_card: :default)
+      user = create(:user)
+
+      view_model = Admin::AuctionShowViewModel.new(auction: auction, current_user: user)
+      data = view_model.admin_data
+
+      expect(data).to have_key('C2 proposal URL')
+      expect(data).to have_key('C2 approved at')
+    end
+  end
+
+  context 'auction for other purchase card' do
+    it 'does not return c2 proposal URL or approved at fields' do
+      auction = create(:auction, purchase_card: :other)
+      user = create(:user)
+
+      view_model = Admin::AuctionShowViewModel.new(auction: auction, current_user: user)
+      data = view_model.admin_data
+
+      expect(data).not_to have_key('C2 proposal URL')
+      expect(data).not_to have_key('C2 approved at')
+    end
+  end
+end


### PR DESCRIPTION
…urchase cards

* Also show 'N/A' on action items page instead of nothing
* Closes https://github.com/18F/micropurchase/issues/915