### PR TITLE
Change cucumber output format

### DIFF
--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -1,7 +1,7 @@
 <%
 rerun = File.file?('rerun.txt') ? IO.read('rerun.txt') : ""
 rerun_opts = rerun.to_s.strip.empty? ? "--format #{ENV['CUCUMBER_FORMAT'] || 'progress'} features" : "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} #{rerun}"
-std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} --strict --tags ~@wip"
+std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'progress'} --strict --tags ~@wip"
 %>
 default: <%= std_opts %> features
 wip: --tags @wip:3 --wip features


### PR DESCRIPTION
* This outputs dots instead of full scenarios
* Still get verbose error messages, but less scroll back to see them!

![screen shot 2016-07-28 at 10 05 10 am](https://cloud.githubusercontent.com/assets/601515/17222162/c26c488c-54ab-11e6-876a-1d24df45ed64.png)
