### PR TITLE
Vendor messaging - Auction show page - Need verified DUNS number to bid

### DIFF
--- a/app/models/bid_status_presenter_factory.rb
+++ b/app/models/bid_status_presenter_factory.rb
@@ -25,6 +25,8 @@ class BidStatusPresenterFactory
       BidStatusPresenter::AvailableUserIsAdmin.new(auction: auction)
     elsif guest?
       BidStatusPresenter::AvailableUserIsGuest.new(auction: auction)
+    elsif user.sam_status != 'sam_accepted'
+      BidStatusPresenter::AvailableUserNotSamVerified.new
     elsif auction.type == 'reverse'
       BidStatusPresenter::AvailableUserIsWinningBidder.new(bid_amount: lowest_user_bid.try(:amount))
     else # sealed bid, user is bidder

--- a/app/presenters/bid_status_presenter/available_user_not_sam_verified.rb
+++ b/app/presenters/bid_status_presenter/available_user_not_sam_verified.rb
@@ -1,0 +1,9 @@
+class BidStatusPresenter::AvailableUserNotSamVerified < BidStatusPresenter::Base
+  def header
+    I18n.t('auctions.show.status.open.vendor.not_verified.header')
+  end
+
+  def body
+    I18n.t('auctions.show.status.open.vendor.not_verified.body')
+  end
+end

--- a/app/view_models/auction_show_view_model.rb
+++ b/app/view_models/auction_show_view_model.rb
@@ -76,7 +76,8 @@ class AuctionShowViewModel
     if !available? ||
        user_not_vendor? ||
        reverse_auction_available_user_is_winner? ||
-       sealed_bid_auction_user_is_bidder?
+       sealed_bid_auction_user_is_bidder? ||
+       current_user.sam_status != 'sam_accepted'
       'auctions/bid_status'
     else
       'components/null'

--- a/config/locales/auctions/en.yml
+++ b/config/locales/auctions/en.yml
@@ -30,3 +30,10 @@ en:
             18F is working to determine if <a href=%{delivery_url}>your pull
             request</a> meets the auction's acceptance criteria. You will receive an email
             once this determination is made.
+        open:
+          vendor:
+            not_verified:
+              header: Please update your profile
+              body: >
+                Your profile must contain a valid DUNS number before you can place a bid. Please
+                <a href="/profile">update your profile</a>.

--- a/features/step_definitions/auction_status_steps.rb
+++ b/features/step_definitions/auction_status_steps.rb
@@ -63,6 +63,12 @@ Then(/^I should see that the C2 status for an auction pending C2 approval$/) do
   )
 end
 
+Then(/^I should see the open auction message for vendors not verified by Sam\.gov$/) do
+  expect(page).to have_content(
+    I18n.t('auctions.show.status.open.vendor.not_verified.header')
+  )
+end
+
 def end_date
   DcTimePresenter.convert_and_format(@auction.ended_at)
 end

--- a/features/vendor_views_open_auction.feature
+++ b/features/vendor_views_open_auction.feature
@@ -18,3 +18,10 @@ Feature: Vendor views an open auction
     And I click on the auction's title
     And I should see the maximum bid amount in the bidding form
     And I should see I do not have the winning bid
+
+  Scenario: Vendor is not verified via Sam.gov
+    Given there is an open auction
+    And I am a user without a verified SAM account
+    And I sign in
+    When I visit the auction page
+    Then I should see the open auction message for vendors not verified by Sam.gov


### PR DESCRIPTION
* Closes #1007

For an open auction, a signed in vendor with either no DUNS or a non-verified DUNS will see this:

<img width="338" alt="screen shot 2016-08-10 at 1 05 01 pm" src="https://cloud.githubusercontent.com/assets/601515/17568984/1c336d56-5efb-11e6-93f0-de72ab9dd98d.png">
