### PR TITLE
Winning vendor marks an auction as paid

### DIFF
--- a/app/controllers/receipts_controller.rb
+++ b/app/controllers/receipts_controller.rb
@@ -7,6 +7,19 @@ class ReceiptsController < ApplicationController
 
     if current_user != winning_bidder || auction.paid_at.nil?
       redirect_to root_path
+    else
+      @view_model = AuctionReceiptViewModel.new(
+        auction: auction,
+        current_user: current_user
+      )
+      render 'auctions/show'
     end
+  end
+
+  def create
+    auction = Auction.find(params[:auction_id])
+    auction.update(c2_approval_status: :payment_confirmed)
+
+    redirect_to auction_path(auction)
   end
 end

--- a/app/models/auction.rb
+++ b/app/models/auction.rb
@@ -14,7 +14,7 @@ class Auction < ActiveRecord::Base
   enum type: { sealed_bid: 0, reverse: 1 }
   enum published: { unpublished: 0, published: 1 }
   enum purchase_card: { default: 0, other: 1 }
-  enum c2_approval_status: { not_requested: 0, pending: 1, sent: 2, approved: 3 }
+  enum c2_approval_status: { not_requested: 0, pending: 1, sent: 2, approved: 3, c2_paid: 4, payment_confirmed: 5 }
 
   # Disable STI
   self.inheritance_column = :__disabled

--- a/app/models/bid_status_presenter_factory.rb
+++ b/app/models/bid_status_presenter_factory.rb
@@ -35,6 +35,8 @@ class BidStatusPresenterFactory
       BidStatusPresenter::OverUserIsWinnerPendingAcceptance
     elsif auction.delivery_url.present?
       BidStatusPresenter::OverUserIsWinnerWorkInProgress
+    elsif auction.c2_approval_status == 'payment_confirmed'
+      BidStatusPresenter::OverUserIsWinnerPaymentConfirmed
     else
       BidStatusPresenter::OverUserIsWinner
     end

--- a/app/presenters/bid_status_presenter/over_user_is_winner_payment_confirmed.rb
+++ b/app/presenters/bid_status_presenter/over_user_is_winner_payment_confirmed.rb
@@ -1,0 +1,29 @@
+class BidStatusPresenter::OverUserIsWinnerPaymentConfirmed < BidStatusPresenter::Base
+  def header
+    I18n.t('auctions.show.status.payment_confirmed.header')
+  end
+
+  def body
+    I18n.t(
+      'auctions.show.status.payment_confirmed.body',
+      end_date: end_date,
+      accepted_date: accepted_date,
+      amount: winning_amount,
+      paid_at: paid_date
+    )
+  end
+
+  private
+
+  def accepted_date
+    DcTimePresenter.convert_and_format(auction.accepted_at)
+  end
+
+  def winning_amount
+    Currency.new(WinningBid.new(auction).find.amount)
+  end
+
+  def paid_date
+    DcTimePresenter.convert_and_format(auction.paid_at)
+  end
+end

--- a/app/presenters/bid_status_presenter/payment_confirmation_needed_user_is_winner.rb
+++ b/app/presenters/bid_status_presenter/payment_confirmation_needed_user_is_winner.rb
@@ -1,0 +1,19 @@
+class BidStatusPresenter::PaymentConfirmationNeededUserIsWinner < BidStatusPresenter::Base
+  def header
+    I18n.t('auctions.show.status.payment_confirmation_needed.header')
+  end
+
+  def body
+    I18n.t('auctions.show.status.payment_confirmation_needed.body', payment_date: paid_at)
+  end
+
+  def action_partial
+    'receipts/confirm_payment'
+  end
+
+  private
+
+  def paid_at
+    DcTimePresenter.convert_and_format(auction.paid_at)
+  end
+end

--- a/app/view_models/auction_receipt_view_model.rb
+++ b/app/view_models/auction_receipt_view_model.rb
@@ -1,0 +1,8 @@
+class AuctionReceiptViewModel < AuctionShowViewModel
+  def bid_status
+    BidStatusPresenter::PaymentConfirmationNeededUserIsWinner.new(
+      auction: auction,
+      user: current_user
+    )
+  end
+end

--- a/app/views/receipts/_confirm_payment.html.erb
+++ b/app/views/receipts/_confirm_payment.html.erb
@@ -1,0 +1,6 @@
+<%= link_to(
+      t('auctions.show.status.payment_confirmation_needed.action'),
+      auction_receipts_path(status.auction),
+      method: :post,
+      class: 'usa-button usa-button-outline auction-button'
+) %>

--- a/config/locales/auctions/en.yml
+++ b/config/locales/auctions/en.yml
@@ -30,6 +30,16 @@ en:
             18F is working to determine if <a href=%{delivery_url}>your pull
             request</a> meets the auction's acceptance criteria. You will receive an email
             once this determination is made.
+        payment_confirmation_needed:
+          header: "Payment confirmation needed"
+          body: >
+            18F issued payment on %{payment_date} via your payment URL. Please
+            confirm that you've received payment.
+          action: 'Got it!'
+        payment_confirmed:
+          header: 'Paid'
+          body: >
+            You won this auction on %{end_date}, your pull request was accepted on %{accepted_date}, and you were paid %{amount} on %{paid_at}.
         open:
           vendor:
             not_verified:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,7 +53,7 @@ Rails.application.routes.draw do
   resources :auctions, only: [:show] do
     resources :bid_confirmations, only: [:create]
     resources :bids, only: [:create]
-    resources :receipts, only: [:new]
+    resources :receipts, only: [:new, :create]
   end
 
   resources :bids, only: [:index]

--- a/features/step_definitions/auction_create_steps.rb
+++ b/features/step_definitions/auction_create_steps.rb
@@ -38,6 +38,10 @@ When(/^the auction is paid$/) do
   @auction.update(paid_at: Time.current)
 end
 
+When(/^the auction is accepted$/) do
+  @auction.update(accepted_at: Time.current)
+end
+
 Given(/^there is a closed bidless auction$/) do
   @auction = FactoryGirl.create(:auction, :closed)
 end

--- a/features/step_definitions/auction_status_steps.rb
+++ b/features/step_definitions/auction_status_steps.rb
@@ -75,6 +75,28 @@ Then(/^I should see the open auction message for vendors who are not small busin
   )
 end
 
+Then(/^I should see the payment confirmation needed message$/) do
+  expect(page).to have_content(
+    I18n.t('auctions.show.status.payment_confirmation_needed.header')
+  )
+end
+
+
+Then(/^I should see the payment confirmed message$/) do
+  expect(page).to have_content(
+    I18n.t('auctions.show.status.payment_confirmed.header')
+  )
+  expect(page).to have_content(
+    I18n.t(
+      'auctions.show.status.payment_confirmed.body',
+      end_date: end_date,
+      accepted_date: DcTimePresenter.convert_and_format(@auction.accepted_at),
+      amount: Currency.new(WinningBid.new(@auction).find.amount),
+      paid_at: DcTimePresenter.convert_and_format(@auction.paid_at)
+    )
+  )
+end
+
 def end_date
   DcTimePresenter.convert_and_format(@auction.ended_at)
 end

--- a/features/step_definitions/link_and_button_steps.rb
+++ b/features/step_definitions/link_and_button_steps.rb
@@ -52,6 +52,11 @@ When(/^I click on the add customer button$/) do
   step("I click on the \"#{add_link}\" link")
 end
 
+When(/^I click on the confirm received payment button$/) do
+  link = I18n.t('auctions.show.status.payment_confirmation_needed.action')
+  step("I click on the \"#{link}\" button")
+end
+
 When(/^I click on the create customer button$/) do
   create_button = I18n.t('helpers.submit.create', model: 'Customer')
   step("I click on the \"#{create_button}\" button")

--- a/features/winning_vendor_confirms_payment.feature
+++ b/features/winning_vendor_confirms_payment.feature
@@ -10,6 +10,7 @@ Feature: Winning vendor confirms payment
     And the auction is paid
     When I visit the auction receipt page
     Then I should be on the auction receipt page
+    And I should see the payment confirmation needed message
 
   Scenario: Winning vendor visit receipts page when logged out
     Given I am an authenticated vendor
@@ -20,3 +21,13 @@ Feature: Winning vendor confirms payment
     When I visit the auction receipt page
     And I click on the "Authorize with GitHub" button
     Then I should be on the auction receipt page
+
+  Scenario: Winning vendor confirms payment
+    Given I am an authenticated vendor
+    And I am going to win an auction
+    And the auction ends
+    And the auction is accepted
+    And the auction is paid
+    When I visit the auction receipt page
+    And I click on the confirm received payment button
+    Then I should see the payment confirmed message

--- a/spec/controllers/receipts_controller_spec.rb
+++ b/spec/controllers/receipts_controller_spec.rb
@@ -13,7 +13,7 @@ describe ReceiptsController do
           get :new, { auction_id: auction.id }, user_id: current_user.id
 
           expect(response.code).to eq '200'
-          expect(response).to render_template(:new)
+          expect(response).to render_template('auctions/show')
         end
       end
 


### PR DESCRIPTION
* Closes #978
* This PR adds functionality for winning vendor to indicate payment was
  received

New receipt view (visited via link in email to vendor):
<img width="357" alt="screen shot 2016-08-16 at 1 04 12 pm" src="https://cloud.githubusercontent.com/assets/601515/17715104/973738f0-63b7-11e6-80c9-5b3f372bf306.png">

Winning vendor view after indicating that payment was received:

<img width="342" alt="screen shot 2016-08-16 at 1 37 28 pm" src="https://cloud.githubusercontent.com/assets/601515/17715123/a7372864-63b7-11e6-995b-8e4423ecded9.png">

