### PR TITLE
Fix typo in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-C2_HOST='http://c2-dev.gov'
+C2_HOST='https://c2-dev.18f.gov'
 MICROPURCHASE_C2_OAUTH_KEY=''
 MICROPURCHASE_C2_OAUTH_SECRET=''
 MICROPURCHASE_GITHUB_CLIENT_ID="your-client-id"


### PR DESCRIPTION
There was a typo in C2_HOST in .env.example which, when copied to .env, would cause the db:seed rake task to fail. Hardcoded sample C2 URLs are checked against the value of C2_HOST from .env.