### PR TITLE
Use a more consistent naming convention for bid status presenters

### DIFF
--- a/app/models/bid_status_presenter_factory.rb
+++ b/app/models/bid_status_presenter_factory.rb
@@ -22,67 +22,67 @@ class BidStatusPresenterFactory
 
   def future_message
     if admin?
-      BidStatusPresenter::FutureUserIsAdmin
+      BidStatusPresenter::Future::Admin
     elsif guest?
-      BidStatusPresenter::FutureUserIsGuest
+      BidStatusPresenter::Future::Guest
     else
-      BidStatusPresenter::FutureUserIsVendor
+      BidStatusPresenter::Future::Vendor
     end
   end
 
   def over_winning_bidder_message
     if auction.pending_acceptance?
-      BidStatusPresenter::OverUserIsWinnerPendingAcceptance
+      BidStatusPresenter::Over::Vendor::Winner::PendingAcceptance
     elsif auction.accepted?
-      BidStatusPresenter::OverUserIsWinnerPendingPayment
+      BidStatusPresenter::Over::Vendor::Winner::PendingPayment
     elsif auction.delivery_url.present?
-      BidStatusPresenter::OverUserIsWinnerWorkInProgress
-    elsif auction.c2_status == 'payment_confirmed'
-      BidStatusPresenter::OverUserIsWinnerPaymentConfirmed
+      BidStatusPresenter::Over::Vendor::Winner::WorkInProgress
+    elsif auction.payment_confirmed?
+      BidStatusPresenter::Over::Vendor::Winner::PaymentConfirmed
     else
-      BidStatusPresenter::OverUserIsWinner
+      BidStatusPresenter::Over::Vendor::Winner::WorkNotStarted
     end
   end
 
   def over_message
     if user_is_bidder?
-      BidStatusPresenter::OverUserIsBidder
+      BidStatusPresenter::Over::Vendor::Bidder
     elsif auction.bids.any?
-      BidStatusPresenter::OverWithBids
+      BidStatusPresenter::Over::WithBids
     else
-      BidStatusPresenter::OverNoBids
+      BidStatusPresenter::Over::NoBids
     end
   end
 
   def available_message
     if admin?
-      BidStatusPresenter::AvailableUserIsAdmin
+      BidStatusPresenter::Available::Admin
     elsif guest?
-      BidStatusPresenter::AvailableUserIsGuest
+      BidStatusPresenter::Available::Guest
     elsif ineligible?
       ineligible_presenter
     elsif rules.user_can_bid?(user)
       user_can_bid_message
     elsif auction.type == 'reverse'
-      BidStatusPresenter::AvailableUserIsWinningBidder
+      BidStatusPresenter::Available::Vendor::WinningBidder
     else # sealed bid, user is bidder
-      BidStatusPresenter::AvailableSealedUserIsBidder
+      BidStatusPresenter::Available::Vendor::SealedAuctionBidder
     end
   end
 
   def user_can_bid_message
     if user_bids.any?
-      BidStatusPresenter::AvailableReverseUserIsOutbid
+      BidStatusPresenter::Available::Vendor::ReverseAuctionOutbid
     else
-      BidStatusPresenter::AvailableUserIsEligible
+      BidStatusPresenter::Available::Vendor::Eligible
     end
   end
 
   def ineligible_presenter
     if user.sam_status != 'sam_accepted'
-      BidStatusPresenter::AvailableUserNotSamVerified
+      BidStatusPresenter::Available::Vendor::NotSamVerified
     else
-      BidStatusPresenter::AvailableUserNotSmallBusiness
+      BidStatusPresenter::Available::Vendor::NotSmallBusiness
     end
   end
 

--- a/app/presenters/bid_status_presenter/available/admin.rb
+++ b/app/presenters/bid_status_presenter/available/admin.rb
@@ -1,4 +1,4 @@
-class BidStatusPresenter::AvailableUserIsAdmin < BidStatusPresenter::Base
+class BidStatusPresenter::Available::Admin < BidStatusPresenter::Base
   def body
     "This auction is accepting bids until #{end_date}."
   end

--- a/app/presenters/bid_status_presenter/available/guest.rb
+++ b/app/presenters/bid_status_presenter/available/guest.rb
@@ -1,4 +1,4 @@
-class BidStatusPresenter::AvailableUserIsGuest < BidStatusPresenter::Base
+class BidStatusPresenter::Available::Guest < BidStatusPresenter::Base
   def body
     "This auction is accepting bids until #{end_date}. #{sign_in_link} or
     #{sign_up_link} with GitHub to bid."

--- a/app/presenters/bid_status_presenter/available/vendor/eligible.rb
+++ b/app/presenters/bid_status_presenter/available/vendor/eligible.rb
@@ -1,4 +1,4 @@
-class BidStatusPresenter::AvailableUserIsEligible < BidStatusPresenter::Base
+class BidStatusPresenter::Available::Vendor::Eligible < BidStatusPresenter::Base
   def body
     "The maximum you can bid is #{max_allowed_bid_as_currency}."
   end

--- a/app/presenters/bid_status_presenter/available/vendor/not_sam_verified.rb
+++ b/app/presenters/bid_status_presenter/available/vendor/not_sam_verified.rb
@@ -1,4 +1,4 @@
-class BidStatusPresenter::AvailableUserNotSamVerified < BidStatusPresenter::Base
+class BidStatusPresenter::Available::Vendor::NotSamVerified < BidStatusPresenter::Base
   def header
     I18n.t('auctions.show.status.open.vendor.not_verified.header')
   end

--- a/app/presenters/bid_status_presenter/available/vendor/not_small_business.rb
+++ b/app/presenters/bid_status_presenter/available/vendor/not_small_business.rb
@@ -1,4 +1,4 @@
-class BidStatusPresenter::AvailableUserNotSmallBusiness < BidStatusPresenter::Base
+class BidStatusPresenter::Available::Vendor::NotSmallBusiness < BidStatusPresenter::Base
   def header
     I18n.t('auctions.show.status.open.vendor.not_small_business.header')
   end

--- a/app/presenters/bid_status_presenter/available/vendor/reverse_auction_outbid.rb
+++ b/app/presenters/bid_status_presenter/available/vendor/reverse_auction_outbid.rb
@@ -1,4 +1,4 @@
-class BidStatusPresenter::AvailableReverseUserIsOutbid < BidStatusPresenter::Base
+class BidStatusPresenter::Available::Vendor::ReverseAuctionOutbid < BidStatusPresenter::Base
   def header
     'Place bid'
   end

--- a/app/presenters/bid_status_presenter/available/vendor/sealed_auction_bidder.rb
+++ b/app/presenters/bid_status_presenter/available/vendor/sealed_auction_bidder.rb
@@ -1,4 +1,4 @@
-class BidStatusPresenter::AvailableSealedUserIsBidder < BidStatusPresenter::Base
+class BidStatusPresenter::Available::Vendor::SealedAuctionBidder < BidStatusPresenter::Base
   def header
     ''
   end

--- a/app/presenters/bid_status_presenter/available/vendor/winning_bidder.rb
+++ b/app/presenters/bid_status_presenter/available/vendor/winning_bidder.rb
@@ -1,4 +1,4 @@
-class BidStatusPresenter::AvailableUserIsWinningBidder < BidStatusPresenter::Base
+class BidStatusPresenter::Available::Vendor::WinningBidder < BidStatusPresenter::Base
   def header
     'Bid placed'
   end

--- a/app/presenters/bid_status_presenter/future/admin.rb
+++ b/app/presenters/bid_status_presenter/future/admin.rb
@@ -1,4 +1,4 @@
-class BidStatusPresenter::FutureUserIsAdmin < BidStatusPresenter::Base
+class BidStatusPresenter::Future::Admin < BidStatusPresenter::Base
   include Rails.application.routes.url_helpers
   include ActionView::Helpers::UrlHelper
 

--- a/app/presenters/bid_status_presenter/future/guest.rb
+++ b/app/presenters/bid_status_presenter/future/guest.rb
@@ -1,4 +1,4 @@
-class BidStatusPresenter::FutureUserIsGuest < BidStatusPresenter::Base
+class BidStatusPresenter::Future::Guest < BidStatusPresenter::Base
   def body
     "This auction starts on #{start_date}. #{sign_in_link} or
     #{sign_up_link} with GitHub to bid."

--- a/app/presenters/bid_status_presenter/future/vendor.rb
+++ b/app/presenters/bid_status_presenter/future/vendor.rb
@@ -1,4 +1,4 @@
-class BidStatusPresenter::FutureUserIsVendor < BidStatusPresenter::Base
+class BidStatusPresenter::Future::Vendor < BidStatusPresenter::Base
   def header
     I18n.t('auctions.status.future.vendor.header')
   end

--- a/app/presenters/bid_status_presenter/over/no_bids.rb
+++ b/app/presenters/bid_status_presenter/over/no_bids.rb
@@ -1,4 +1,4 @@
-class BidStatusPresenter::OverNoBids < BidStatusPresenter::Base
+class BidStatusPresenter::Over::NoBids < BidStatusPresenter::Base
   def header
     'Auction Now Closed'
   end

--- a/app/presenters/bid_status_presenter/over/vendor/bidder.rb
+++ b/app/presenters/bid_status_presenter/over/vendor/bidder.rb
@@ -1,4 +1,4 @@
-class BidStatusPresenter::OverUserIsBidder < BidStatusPresenter::Base
+class BidStatusPresenter::Over::Vendor::Bidder < BidStatusPresenter::Base
   def header
     'You are not the winner'
   end

--- a/app/presenters/bid_status_presenter/over/vendor/winner/payment_confirmed.rb
+++ b/app/presenters/bid_status_presenter/over/vendor/winner/payment_confirmed.rb
@@ -1,4 +1,4 @@
-class BidStatusPresenter::OverUserIsWinnerPaymentConfirmed < BidStatusPresenter::Base
+class BidStatusPresenter::Over::Vendor::Winner::PaymentConfirmed < BidStatusPresenter::Base
   def header
     I18n.t('auctions.show.status.payment_confirmed.header')
   end

--- a/app/presenters/bid_status_presenter/over/vendor/winner/pending_acceptance.rb
+++ b/app/presenters/bid_status_presenter/over/vendor/winner/pending_acceptance.rb
@@ -1,4 +1,4 @@
-class BidStatusPresenter::OverUserIsWinnerPendingAcceptance < BidStatusPresenter::Base
+class BidStatusPresenter::Over::Vendor::Winner::PendingAcceptance < BidStatusPresenter::Base
   def header
     I18n.t('auctions.show.status.pending_acceptance.header')
   end

--- a/app/presenters/bid_status_presenter/over/vendor/winner/pending_payment.rb
+++ b/app/presenters/bid_status_presenter/over/vendor/winner/pending_payment.rb
@@ -1,4 +1,4 @@
-class BidStatusPresenter::OverUserIsWinnerPendingPayment < BidStatusPresenter::Base
+class BidStatusPresenter::Over::Vendor::Winner::PendingPayment < BidStatusPresenter::Base
   def header
     I18n.t('auctions.show.status.pending_payment.header')
   end

--- a/app/presenters/bid_status_presenter/over/vendor/winner/pending_payment_confirmation.rb
+++ b/app/presenters/bid_status_presenter/over/vendor/winner/pending_payment_confirmation.rb
@@ -1,4 +1,4 @@
-class BidStatusPresenter::PaymentConfirmationNeededUserIsWinner < BidStatusPresenter::Base
+class BidStatusPresenter::Over::Vendor::Winner::PendingPaymentConfirmation < BidStatusPresenter::Base
   def header
     I18n.t('auctions.show.status.payment_confirmation_needed.header')
   end

--- a/app/presenters/bid_status_presenter/over/vendor/winner/work_in_progress.rb
+++ b/app/presenters/bid_status_presenter/over/vendor/winner/work_in_progress.rb
@@ -1,4 +1,4 @@
-class BidStatusPresenter::OverUserIsWinnerWorkInProgress < BidStatusPresenter::Base
+class BidStatusPresenter::Over::Vendor::Winner::WorkInProgress < BidStatusPresenter::Base
   include Rails.application.routes.url_helpers
   include ActionView::Helpers::UrlHelper
 

--- a/app/presenters/bid_status_presenter/over/vendor/winner/work_not_started.rb
+++ b/app/presenters/bid_status_presenter/over/vendor/winner/work_not_started.rb
@@ -1,4 +1,4 @@
-class BidStatusPresenter::OverUserIsWinner < BidStatusPresenter::Base
+class BidStatusPresenter::Over::Vendor::Winner::WorkNotStarted < BidStatusPresenter::Base
   def header
     I18n.t('auctions.show.status.ready_for_work.header')
   end

--- a/app/presenters/bid_status_presenter/over/with_bids.rb
+++ b/app/presenters/bid_status_presenter/over/with_bids.rb
@@ -1,0 +1,5 @@
+class BidStatusPresenter::Over::WithBids < BidStatusPresenter::Base
+  def header
+    'Auction Now Closed'
+  end
+end

--- a/app/presenters/bid_status_presenter/over_with_bids.rb
+++ b/app/presenters/bid_status_presenter/over_with_bids.rb
@@ -1,5 +1,0 @@
-class BidStatusPresenter::OverWithBids < BidStatusPresenter::Base
-  def header
-    'Auction Now Closed'
-  end
-end

--- a/app/view_models/auction_receipt_view_model.rb
+++ b/app/view_models/auction_receipt_view_model.rb
@@ -1,6 +1,6 @@
 class AuctionReceiptViewModel < AuctionShowViewModel
   def bid_status_presenter
-    BidStatusPresenter::PaymentConfirmationNeededUserIsWinner.new(
+    BidStatusPresenter::Over::Vendor::Winner::PendingPaymentConfirmation.new(
       auction: auction,
       user: current_user
     )


### PR DESCRIPTION
* First namespace is auction status
* Second / third  namespace, if any, is the user type
* Only use role namespace if there are multiple presenters for that user type