### PR TITLE
Update styles to prevent ribbon and title overlap

### DIFF
--- a/app/assets/stylesheets/components/_auction-show.scss
+++ b/app/assets/stylesheets/components/_auction-show.scss
@@ -111,12 +111,6 @@
 
 .issue-title {
   font-size: 2.5rem;
-  margin-bottom: $base-padding-lite;
-  margin-top: 1rem;
-
-  span {
-    font-weight: $font-normal;
-  }
 }
 
 .issue-list-item-details,

--- a/app/assets/stylesheets/components/_auctions-index.scss
+++ b/app/assets/stylesheets/components/_auctions-index.scss
@@ -24,6 +24,11 @@
   margin-top: $site-margins;
 }
 
+.index-issue-title {
+  font-size: 2.5rem;
+  margin-top: 1rem;
+}
+
 .issue-vitals {
   font-size: $h5-font-size;
   font-style: oblique;

--- a/app/view_models/auction_list_item.rb
+++ b/app/view_models/auction_list_item.rb
@@ -5,16 +5,16 @@ class AuctionListItem
     @auction = auction
   end
 
-  def auction_title_partial
-    'auctions/title'
-  end
-
   def title
     auction.title
   end
 
   def id
     auction.id
+  end
+
+  def auction_title_partial
+    'auctions/title'
   end
 
   def html_summary

--- a/app/views/admin/auctions/_title.html.erb
+++ b/app/views/admin/auctions/_title.html.erb
@@ -1,5 +1,5 @@
 <div class="usa-width-three-fourths">
-  <h3 class="issue-title">
+  <h3 class="index-issue-title">
     <%= link_to auction.title, admin_auction_path(auction.id) %>
   </h3>
 </div>

--- a/app/views/auctions/_title.html.erb
+++ b/app/views/auctions/_title.html.erb
@@ -1,5 +1,5 @@
 <div class="usa-width-one-whole">
-  <h3 class="issue-title">
+  <h3 class="index-issue-title">
     <%= link_to auction.title, auction_path(auction.id) %>
   </h3>
 </div>


### PR DESCRIPTION
* Seeing this on currently live auction

show page before and after (not more ribbon overlap with title):

![screen shot 2016-08-22 at 4 31 32 pm](https://cloud.githubusercontent.com/assets/601515/17875292/0ea12fcc-6886-11e6-8680-de9675aa211c.png)

index page before and after (no change):

![screen shot 2016-08-22 at 4 27 49 pm](https://cloud.githubusercontent.com/assets/601515/17875295/11e94f3e-6886-11e6-933f-2ce20cec59e5.png)

