### PR TITLE
Display number of auctions that need attention

### DIFF
--- a/app/assets/stylesheets/components/_secondary_nav.scss
+++ b/app/assets/stylesheets/components/_secondary_nav.scss
@@ -44,4 +44,12 @@ $height-nav-secondary: 5rem;
       font-weight: $font-bold;
     }
   }
+
+  .subnav-number-label {
+    border-radius: $border-radius;
+    margin-right: 0.3rem;
+    padding: 0.1rem 0.5rem;
+    background-color: $color-secondary-darkest;
+    color: $color-white;
+  }
 }

--- a/app/assets/stylesheets/components/_secondary_nav.scss
+++ b/app/assets/stylesheets/components/_secondary_nav.scss
@@ -46,9 +46,11 @@ $height-nav-secondary: 5rem;
   }
 
   .subnav-number-label {
-    border-radius: $border-radius;
-    margin-right: 0.3rem;
-    padding: 0.1rem 0.5rem;
+    border-radius: $round-border-radius;
+    font-size: 1.3rem;
+    margin-right: 0.5rem;
+    margin-left: 0.5rem;
+    padding: 0.1rem 0.7rem;
     background-color: $color-secondary-darkest;
     color: $color-white;
   }

--- a/app/models/auction_query.rb
+++ b/app/models/auction_query.rb
@@ -25,18 +25,10 @@ class AuctionQuery
   end
 
   def needs_attention_count
-    unpublished.count +
+    relation.unpublished.count +
       pending_delivery.count +
-      pending_acceptance.count +
+      relation.pending_acceptance.count +
       payment_needed.count
-  end
-
-  def unpublished
-    relation.unpublished
-  end
-
-  def pending_acceptance
-    relation.pending_acceptance
   end
 
   def completed

--- a/app/models/auction_query.rb
+++ b/app/models/auction_query.rb
@@ -24,6 +24,21 @@ class AuctionQuery
       .count
   end
 
+  def needs_attention_count
+    unpublished.count +
+      pending_delivery.count +
+      pending_acceptance.count +
+      payment_needed.count
+  end
+
+  def unpublished
+    relation.unpublished
+  end
+
+  def pending_acceptance
+    relation.pending_acceptance
+  end
+
   def completed
     relation.accepted_or_rejected
   end

--- a/app/view_models/admin/base_view_model.rb
+++ b/app/view_models/admin/base_view_model.rb
@@ -27,6 +27,14 @@ class Admin::BaseViewModel
     AuctionQuery.new.needs_attention_count
   end
 
+  def needs_attention_count_partial
+    if needs_attention_auctions_count > 0
+      'admin/needs_attention_auction_count'
+    else
+      'components/null'
+    end
+  end
+
   def new_auction_nav_class
     ''
   end

--- a/app/view_models/admin/base_view_model.rb
+++ b/app/view_models/admin/base_view_model.rb
@@ -23,6 +23,10 @@ class Admin::BaseViewModel
     ''
   end
 
+  def needs_attention_auctions_count
+    AuctionQuery.new.needs_attention_count
+  end
+
   def new_auction_nav_class
     ''
   end

--- a/app/view_models/admin/needs_attention_auctions_view_model.rb
+++ b/app/view_models/admin/needs_attention_auctions_view_model.rb
@@ -12,7 +12,7 @@ class Admin::NeedsAttentionAuctionsViewModel < Admin::BaseViewModel
   end
 
   def drafts
-    @_drafts ||= AuctionQuery.new.unpublished.map do |auction|
+    @_drafts ||= Auction.unpublished.map do |auction|
       Admin::DraftListItem.new(auction)
     end
   end
@@ -38,7 +38,7 @@ class Admin::NeedsAttentionAuctionsViewModel < Admin::BaseViewModel
   end
 
   def evaluation_needed
-    @_evaluation_needed ||= list_items(AuctionQuery.new.pending_acceptance)
+    @_evaluation_needed ||= list_items(Auction.pending_acceptance)
   end
 
   def payment_needed_partial

--- a/app/view_models/admin/needs_attention_auctions_view_model.rb
+++ b/app/view_models/admin/needs_attention_auctions_view_model.rb
@@ -12,7 +12,7 @@ class Admin::NeedsAttentionAuctionsViewModel < Admin::BaseViewModel
   end
 
   def drafts
-    @_drafts ||= Auction.unpublished.map do |auction|
+    @_drafts ||= AuctionQuery.new.unpublished.map do |auction|
       Admin::DraftListItem.new(auction)
     end
   end
@@ -38,7 +38,7 @@ class Admin::NeedsAttentionAuctionsViewModel < Admin::BaseViewModel
   end
 
   def evaluation_needed
-    @_evaluation_needed ||= list_items(Auction.pending_acceptance)
+    @_evaluation_needed ||= list_items(AuctionQuery.new.pending_acceptance)
   end
 
   def payment_needed_partial

--- a/app/views/admin/_auctions_subnav.html.erb
+++ b/app/views/admin/_auctions_subnav.html.erb
@@ -7,7 +7,11 @@
       class: view_model.auctions_nav_class %></li>
     <li><%= link_to t('links_and_buttons.auctions.needs_attention'),
       admin_auctions_needs_attention_path,
-      class: view_model.needs_attention_auctions_nav_class %></li>
+      class: view_model.needs_attention_auctions_nav_class %>
+      <% if view_model.needs_attention_auctions_count > 0 %>
+         <span class="subnav-number-label"><%= view_model.needs_attention_auctions_count %></span>
+      <% end %>
+    </li>
     <li><%= link_to t('links_and_buttons.auctions.closed'),
       admin_auctions_closed_path,
       class: view_model.closed_auctions_nav_class %></li>

--- a/app/views/admin/_auctions_subnav.html.erb
+++ b/app/views/admin/_auctions_subnav.html.erb
@@ -8,9 +8,8 @@
     <li><%= link_to t('links_and_buttons.auctions.needs_attention'),
       admin_auctions_needs_attention_path,
       class: view_model.needs_attention_auctions_nav_class %>
-      <% if view_model.needs_attention_auctions_count > 0 %>
-         <span class="subnav-number-label"><%= view_model.needs_attention_auctions_count %></span>
-      <% end %>
+      <%= render partial: view_model.needs_attention_count_partial,
+          locals: {count: view_model.needs_attention_auctions_count} %>
     </li>
     <li><%= link_to t('links_and_buttons.auctions.closed'),
       admin_auctions_closed_path,

--- a/app/views/admin/_needs_attention_auction_count.html.erb
+++ b/app/views/admin/_needs_attention_auction_count.html.erb
@@ -1,0 +1,1 @@
+<span class="subnav-number-label"><%= count %></span>

--- a/features/admin_views_needs_attention_auctions.feature
+++ b/features/admin_views_needs_attention_auctions.feature
@@ -7,6 +7,11 @@ Feature: Admin view needs attention auctions
     Given I am an administrator
     And I sign in
 
+  Scenario: The needs attention tab should have a count
+    Given there is each type of auction that needs attention
+    When I visit the auctions admin page
+    Then I should see the total number of auctions needing my attention next to the needs attention link
+
   Scenario: Navigating to the needs attention auctions dashboard
     Given I visit the auctions admin page
     When I click on the needs attention link

--- a/features/admin_views_needs_attention_auctions.feature
+++ b/features/admin_views_needs_attention_auctions.feature
@@ -12,6 +12,10 @@ Feature: Admin view needs attention auctions
     When I visit the auctions admin page
     Then I should see the total number of auctions needing my attention next to the needs attention link
 
+  Scenario: There are no auctions that need attention
+    When I visit the auctions admin page
+    Then I should see the no number next to the needs attention link
+
   Scenario: Navigating to the needs attention auctions dashboard
     Given I visit the auctions admin page
     When I click on the needs attention link

--- a/features/step_definitions/admin_auction_form_steps.rb
+++ b/features/step_definitions/admin_auction_form_steps.rb
@@ -90,7 +90,7 @@ end
 
 Then(/^I should see the updated delivery deadline$/) do
   within('.estimated-delivery-date') do
-    delivery_date = DefaultDateTime.new(5.business_days.after(3.business_days.from_now)).convert
+    delivery_date = DefaultDateTime.new(5.business_days.after(DcTimePresenter.convert(3.business_days.from_now))).convert
     formatted_delivery_date = DcTimePresenter.convert_and_format(delivery_date)
     expect(page).to have_content(
       "Estimated delivery date #{formatted_delivery_date}"

--- a/features/step_definitions/admin_views_needs_attention_auctions_steps.rb
+++ b/features/step_definitions/admin_views_needs_attention_auctions_steps.rb
@@ -3,3 +3,10 @@ Then(/^I should see the total number of auctions needing my attention next to th
 
   expect(page).to have_content("#{link} #{AuctionQuery.new.needs_attention_count}")
 end
+
+Then(/^I should see the no number next to the needs attention link$/) do
+  link = I18n.t('links_and_buttons.auctions.needs_attention')
+
+  expect(page).to have_content(link)
+  expect(page).to_not have_css('span.subnav-number-label')
+end

--- a/features/step_definitions/admin_views_needs_attention_auctions_steps.rb
+++ b/features/step_definitions/admin_views_needs_attention_auctions_steps.rb
@@ -1,0 +1,5 @@
+Then(/^I should see the total number of auctions needing my attention next to the needs attention link$/) do
+  link = I18n.t('links_and_buttons.auctions.needs_attention')
+
+  expect(page).to have_content("#{link} #{AuctionQuery.new.needs_attention_count}")
+end

--- a/features/step_definitions/auction_create_steps.rb
+++ b/features/step_definitions/auction_create_steps.rb
@@ -211,5 +211,5 @@ When(/^there is each type of auction that needs attention$/) do
   @needs_attention << FactoryGirl.create(:auction, :unpublished)
   @needs_attention << FactoryGirl.create(:auction, :payment_needed)
   @needs_attention << FactoryGirl.create(:auction, :pending_acceptance)
-  @needs_attention << FactoryGirl.create(:auction, :completed)
+  @needs_attention << FactoryGirl.create(:auction, :closed)
 end

--- a/features/step_definitions/auction_create_steps.rb
+++ b/features/step_definitions/auction_create_steps.rb
@@ -204,3 +204,12 @@ end
 When(/^there is another accepted auction$/) do
   FactoryGirl.create(:auction, :accepted, :with_bidders)
 end
+
+When(/^there is each type of auction that needs attention$/) do
+  # And there are auctions that are either in draft state, pending delivery, needs acceptance, or needs payment
+  @needs_attention = []
+  @needs_attention << FactoryGirl.create(:auction, :unpublished)
+  @needs_attention << FactoryGirl.create(:auction, :payment_needed)
+  @needs_attention << FactoryGirl.create(:auction, :pending_acceptance)
+  @needs_attention << FactoryGirl.create(:auction, :completed)
+end

--- a/spec/models/auction_query_spec.rb
+++ b/spec/models/auction_query_spec.rb
@@ -124,7 +124,7 @@ describe AuctionQuery do
     it 'returns the sum of unpublished, pending_delivery, pending_acceptance and payment_needed auctions' do
       _regular = create(:auction)
       _unpublished = create(:auction, :unpublished)
-      _pending_delivery = create(:auction, :completed)
+      _pending_delivery = create(:auction, :closed)
       _pending_acceptance = create(:auction, :evaluation_needed)
       _payment_needed = create(:auction, :payment_needed)
 

--- a/spec/models/auction_query_spec.rb
+++ b/spec/models/auction_query_spec.rb
@@ -120,6 +120,20 @@ describe AuctionQuery do
     end
   end
 
+  describe '#needs_attention_count' do
+    it 'returns the sum of unpublished, pending_delivery, pending_acceptance and payment_needed auctions' do
+      _regular = create(:auction)
+      _unpublished = create(:auction, :unpublished)
+      _pending_delivery = create(:auction, :completed)
+      _pending_acceptance = create(:auction, :evaluation_needed)
+      _payment_needed = create(:auction, :payment_needed)
+
+      query = AuctionQuery.new
+
+      expect(query.needs_attention_count).to eq(4)
+    end
+  end
+
   describe '#with_bid_from_user' do
     it 'returns auctions where the user has placed a bid' do
       auction = create(:auction, :with_bidders)


### PR DESCRIPTION
Fixes #1048

<img width="527" alt="localhost_3000_admin_auctions_needs_attention" src="https://cloud.githubusercontent.com/assets/2044/17916763/3d465a7e-6984-11e6-95e8-cdf7414f12b6.png">

This adds some functionality to display the number of auctions that need attention in the subnav of the admin interface for auctions. This needs some review of the CSS, etc.