### PR TITLE
Remove `running` trait from factories

### DIFF
--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -19,7 +19,7 @@ admin](../config/admins.yml).
 Being an admin means you can:
 * create/edit auctions
 * read users
-* view bids when auctions are running (this info is veiled/sealed when the
+* view bids when auctions are available (this info is veiled/sealed when the
 auctions are running)
 
 Don't forget to submit a pull request! See

--- a/features/step_definitions/auction_create_steps.rb
+++ b/features/step_definitions/auction_create_steps.rb
@@ -83,7 +83,11 @@ Given(/^there is a budget approved auction$/) do
 end
 
 Given(/^there is a sealed-bid auction$/) do
-  @auction = FactoryGirl.create(:auction, :running, :sealed_bid)
+  @auction = FactoryGirl.create(:auction, :available, :sealed_bid)
+end
+
+Given(/^there is a sealed-bid auction with bids$/) do
+  @auction = FactoryGirl.create(:auction, :available, :sealed_bid, :with_bidders)
 end
 
 Given(/^there is a closed sealed-bid auction$/) do
@@ -112,7 +116,7 @@ end
 
 Given(/^there are many different auctions$/) do
   FactoryGirl.create(:auction, :closed, title: Faker::Commerce.product_name)
-  FactoryGirl.create(:auction, :running, title: Faker::Commerce.product_name)
+  FactoryGirl.create(:auction, :available, title: Faker::Commerce.product_name)
   FactoryGirl.create(:auction, :future)
 end
 

--- a/features/vendor_bids_sealed_auction.feature
+++ b/features/vendor_bids_sealed_auction.feature
@@ -12,7 +12,7 @@ Feature: Vendor bids on a sealed-bid auction
     Then I should see the rules for Sealed-bid auctions
 
   Scenario: bidding on a sealed-bid auction
-    Given there is a sealed-bid auction
+    Given there is a sealed-bid auction with bids
     And I am an authenticated vendor
     When I visit the home page
     Then I should not see "Current bid:"

--- a/public/api/v0/swagger.json
+++ b/public/api/v0/swagger.json
@@ -24,7 +24,7 @@
     "/auctions": {
       "get": {
         "summary": "List auctions",
-        "description": "Returns a list of all auctions (upcoming, running, and ended). Each auction contains bids and each bid contains one bidder. If an auction is still running, `bid['bidder_id']` and all keys in `bidder` will be `null`. This request does not require authentication, but if you are authenticated, your bids will not be redacted. This is consistent with the behavior of the web UI.",
+        "description": "Returns a list of all auctions (future, available, and closed). Each auction contains bids and each bid contains one bidder. If an auction is still running, `bid['bidder_id']` and all keys in `bidder` will be `null`. This request does not require authentication, but if you are authenticated, your bids will not be redacted. This is consistent with the behavior of the web UI.",
         "security": [
           {
             "api_key": []

--- a/spec/factories/auctions.rb
+++ b/spec/factories/auctions.rb
@@ -98,10 +98,6 @@ FactoryGirl.define do
       paid_at { Time.current }
     end
 
-    trait :running do
-      with_bidders
-    end
-
     trait :expiring do
       ended_at { quartile_minute(Time.now + 3.hours) }
     end

--- a/spec/models/auction_query_spec.rb
+++ b/spec/models/auction_query_spec.rb
@@ -6,7 +6,7 @@ describe AuctionQuery do
     let(:complete_and_successful) do
       create(:auction, :complete_and_successful)
     end
-    let!(:running_auction) { create(:auction, :running) }
+    let!(:available_auction) { create(:auction, :available) }
     let!(:rejected_auction) { create(:auction, status: :rejected) }
     let!(:unpaid_auction) do
       create(:auction, :not_paid)

--- a/spec/requests/api/v0/bids_spec.rb
+++ b/spec/requests/api/v0/bids_spec.rb
@@ -8,7 +8,7 @@ describe 'API bid requests' do
       github_response_for_user(user)
     end
   end
-  let(:user) { FactoryGirl.create(:user, sam_status: :sam_accepted) }
+  let(:user) { create(:user, sam_status: :sam_accepted) }
   let(:headers) do
     {
       'HTTP_ACCEPT' => 'text/x-json',
@@ -37,7 +37,7 @@ describe 'API bid requests' do
 
     context 'when the API key is missing' do
       let(:api_key) { nil }
-      let(:auction) { FactoryGirl.create(:auction, :running) }
+      let(:auction) { create(:auction, :with_bidders) }
       let(:current_auction_price) do
         auction.bids.sort_by(&:amount).first.amount
       end
@@ -57,7 +57,7 @@ describe 'API bid requests' do
 
     context 'when the API key is invalid' do
       let(:api_key) { FakeGitHubApi::INVALID_API_KEY }
-      let(:auction) { FactoryGirl.create(:auction, :running) }
+      let(:auction) { create(:auction, :with_bidders) }
       let(:current_auction_price) do
         auction.bids.sort_by(&:amount).first.amount
       end
@@ -77,7 +77,7 @@ describe 'API bid requests' do
 
     context 'when the auction has ended' do
       let(:api_key) { FakeGitHubApi::VALID_API_KEY }
-      let(:auction) { FactoryGirl.create(:auction, :closed, :with_bidders) }
+      let(:auction) { create(:auction, :closed, :with_bidders) }
       let(:current_auction_price) do
         auction.bids.sort_by(&:amount).first.amount
       end
@@ -99,7 +99,7 @@ describe 'API bid requests' do
 
     context 'when the auction has not yet started' do
       let(:api_key) { FakeGitHubApi::VALID_API_KEY }
-      let(:auction) { FactoryGirl.create(:auction, :future, :with_bidders) }
+      let(:auction) { create(:auction, :future, :with_bidders) }
       let(:current_auction_price) do
         auction.bids.sort_by(&:amount).first.amount
       end
@@ -119,9 +119,9 @@ describe 'API bid requests' do
       end
     end
 
-    context 'when the auction is running' do
+    context 'when the auction has bids' do
       let(:api_key) { FakeGitHubApi::VALID_API_KEY }
-      let(:auction) { FactoryGirl.create(:auction, :running) }
+      let(:auction) { create(:auction, :with_bidders) }
       let(:current_auction_price) do
         auction.bids.sort_by(&:amount).first.amount
       end
@@ -154,7 +154,7 @@ describe 'API bid requests' do
       end
 
       context 'when the auction start price is between the micropurchase and SAT threshold' do
-        let(:auction) { create(:auction, :between_micropurchase_and_sat_threshold, :running) }
+        let(:auction) { create(:auction, :between_micropurchase_and_sat_threshold, :with_bidders) }
         let(:bid_amount) { current_auction_price - 10 }
 
         context 'and the vendor is not small business' do
@@ -179,7 +179,7 @@ describe 'API bid requests' do
       end
 
       context 'when the auction is reverse' do
-        let(:auction) { FactoryGirl.create(:auction, :running, :reverse) }
+        let(:auction) { create(:auction, :reverse, :with_bidders) }
 
         context 'and the bid amount is not the lowest' do
           let(:bid_amount) { current_auction_price + 10 }
@@ -203,7 +203,7 @@ describe 'API bid requests' do
       end
 
       context 'when the auction is sealed-bid' do
-        let(:auction) { FactoryGirl.create(:auction, :running, :sealed_bid) }
+        let(:auction) { create(:auction, :with_bidders, :sealed_bid) }
 
         context 'and the bid amount is not the lowest' do
           let(:amount) { current_auction_price + 10 }
@@ -265,7 +265,7 @@ describe 'API bid requests' do
       end
 
       context 'and the user has a rejected #sam_status' do
-        let(:user) { FactoryGirl.create(:user, sam_status: :sam_rejected) }
+        let(:user) { create(:user, sam_status: :sam_rejected) }
         let(:bid_amount) { current_auction_price - 10 }
 
         it 'returns a json error' do
@@ -288,7 +288,7 @@ describe 'API bid requests' do
       end
 
       context 'and the user has a pending #sam_status' do
-        let(:user) { FactoryGirl.create(:user, sam_status: :sam_pending) }
+        let(:user) { create(:user, sam_status: :sam_pending) }
         let(:bid_amount) { current_auction_price - 10 }
 
         it 'returns a json error' do

--- a/spec/requests/api/v0/get_auction_spec.rb
+++ b/spec/requests/api/v0/get_auction_spec.rb
@@ -17,10 +17,10 @@ describe Api::V0::AuctionsController do
     end
 
     context 'when the auction is sealed-bid' do
-      context 'and the auction is running' do
+      context 'and the auction is available, has bids' do
         it 'veils all bids' do
           login
-          auction = create(:auction, :running, :sealed_bid, :with_bidders)
+          auction = create(:auction, :available, :sealed_bid, :with_bidders)
 
           get api_v0_auction_path(auction), nil, headers
 
@@ -31,7 +31,7 @@ describe Api::V0::AuctionsController do
           it 'does not veil the bids from the authenticated user' do
             user = create(:user)
             login(user)
-            auction = create(:auction, :running, :sealed_bid, :with_bidders)
+            auction = create(:auction, :available, :sealed_bid, :with_bidders)
             create(:bid, auction: auction, bidder: user)
 
             get api_v0_auction_path(auction), nil, headers
@@ -50,7 +50,7 @@ describe Api::V0::AuctionsController do
           it 'veils the bids not created by the authenticated user' do
             user = create(:user)
             login(user)
-            auction = create(:auction, :running, :sealed_bid, :with_bidders)
+            auction = create(:auction, :available, :sealed_bid, :with_bidders)
             create(:bid, auction: auction, bidder: user)
 
             get api_v0_auction_path(auction), nil, headers
@@ -84,10 +84,10 @@ describe Api::V0::AuctionsController do
     end
 
     context 'when the auction is mult-bid' do
-      context 'and the auction is running' do
+      context 'and the auction is available' do
         it 'veils all bidder information' do
           login
-          auction = create(:auction, :running, :with_bidders)
+          auction = create(:auction, :available, :with_bidders)
 
           get api_v0_auction_path(auction), nil, headers
 
@@ -108,7 +108,7 @@ describe Api::V0::AuctionsController do
           it 'does not veil the bids from the authenticated user' do
             user = create(:user)
             login(user)
-            auction = create(:auction, :running, bidder_ids: [user.id])
+            auction = create(:auction, :available, bidders: [user])
 
             get api_v0_auction_path(auction), nil, headers
 
@@ -127,7 +127,7 @@ describe Api::V0::AuctionsController do
           it 'veils the bids not created by the authenticated user' do
             user = create(:user)
             login(user)
-            auction = create(:auction, :running, bidder_ids: [user.id])
+            auction = create(:auction, :available, bidder_ids: [user.id])
 
             get api_v0_auction_path(auction), nil, headers
 

--- a/spec/requests/api/v0/get_auctions_spec.rb
+++ b/spec/requests/api/v0/get_auctions_spec.rb
@@ -17,10 +17,10 @@ describe Api::V0::Admin::AuctionsController do
     end
 
     context 'when the auction is reverse' do
-      context 'and the auction is running' do
+      context 'and the auction is available, has bidders' do
         it 'veils all bidder information' do
           login
-          create(:auction, :running, :reverse, :with_bidders)
+          create(:auction, :available, :reverse, :with_bidders)
 
           get api_v0_auctions_path(format: :json), nil, headers
 
@@ -61,10 +61,10 @@ describe Api::V0::Admin::AuctionsController do
     end
 
     context 'when the auction is sealed-bid' do
-      context 'and the auction is running' do
+      context 'and the auction is available, has bidders' do
         it 'veils all bids' do
           login
-          create(:auction, :running, :sealed_bid, :with_bidders)
+          create(:auction, :available, :sealed_bid, :with_bidders)
           get '/api/v0/auctions', nil, headers
           expect(json_bids).to be_empty
         end

--- a/spec/requests/api/v0/swagger_spec.rb
+++ b/spec/requests/api/v0/swagger_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe 'Swagger spec', type: :apivore, order: :defined do
 
     context 'when the API key is missing' do
       let(:api_key) { nil }
-      let(:auction) { create(:auction, :running) }
+      let(:auction) { create(:auction, :available, :with_bidders) }
       let(:current_auction_price) do
         auction.bids.sort_by(&:amount).first.amount
       end
@@ -175,7 +175,7 @@ RSpec.describe 'Swagger spec', type: :apivore, order: :defined do
 
     context 'when the API key is invalid' do
       let(:api_key) { FakeGitHubApi::INVALID_API_KEY }
-      let(:auction) { create(:auction, :running) }
+      let(:auction) { create(:auction, :available, :with_bidders) }
       let(:current_auction_price) do
         auction.bids.sort_by(&:amount).first.amount
       end
@@ -255,7 +255,7 @@ RSpec.describe 'Swagger spec', type: :apivore, order: :defined do
 
     context 'when the user places a successful bid' do
       let(:api_key) { FakeGitHubApi::VALID_API_KEY }
-      let(:auction) { create(:auction, :running) }
+      let(:auction) { create(:auction, :available, :with_bidders) }
       let(:current_auction_price) do
         auction.bids.sort_by(&:amount).first.amount
       end

--- a/spec/view_models/admin/user_auction_view_model_spec.rb
+++ b/spec/view_models/admin/user_auction_view_model_spec.rb
@@ -33,7 +33,7 @@ describe Admin::UserAuctionViewModel do
   describe '#user_won_label' do
     context 'when the auction is not over yet' do
       it 'should return "-"' do
-        auction = create(:auction, :running, :with_bidders)
+        auction = create(:auction, :available, :with_bidders)
         user = WinningBid.new(auction).find.bidder
 
         expect(Admin::UserAuctionViewModel.new(auction, user).user_won_label).to eq('-')


### PR DESCRIPTION
* was just adding bids to the auction, which was not obvious based on the name
* we usually use the terms "future" "available" and "closed" to describe the temporal state of an auction