### PR TITLE
Test that the API documentation renders correctly

### DIFF
--- a/spec/controllers/docs_controller_spec.rb
+++ b/spec/controllers/docs_controller_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+describe DocsController do
+  render_views
+
+  describe '#index' do
+    it 'should render the Swagger docs' do
+      get :index
+      expect(assigns(:swagger)).to_not be_nil
+      expect(response).to render_template("index")
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1082 

The `render_views` declarations forcibly renders the views and I tested that it would fail if I broke the template.