### PR TITLE
Use updated API endpoint for insights page

### DIFF
--- a/app/assets/javascripts/insights/insights.js
+++ b/app/assets/javascripts/insights/insights.js
@@ -3,7 +3,7 @@
 (function (window) {
   window.winners = {
     onReady: function(){
-      $.getJSON('auctions.json').success(function(data) {
+      $.getJSON('api/v0/auctions.json').success(function(data) {
         var auctions = _.sortBy(data.auctions, 'id');
         window.winners.charts = new Charts(auctions);
       })


### PR DESCRIPTION
* Closes https://rpm.newrelic.com/accounts/1345535/applications/18978233/traced_errors/ead4cf81-6ec7-11e6-a90b-b82a72d22a14_0_17367
* We removed API redirects from old endpoints to new a few days ago but forgot to update this