### PR TITLE
Run staging:prime on staging deploy

### DIFF
--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -1,9 +1,9 @@
-require "factory_girl"
-  require Rails.root.join('spec', 'support', 'helpers', 'factory_girl.rb')
+require 'factory_girl'
+require Rails.root.join('spec', 'support', 'helpers', 'factory_girl.rb')
 
 namespace :dev do
-  desc "Sample data for local development environment"
-  task prime: "db:setup" do
+  desc 'Sample data for local development environment'
+  task prime: 'db:setup' do
     include FactoryGirl::Syntax::Methods
 
     skills = [

--- a/lib/tasks/staging.rake
+++ b/lib/tasks/staging.rake
@@ -1,0 +1,35 @@
+require "factory_girl"
+  require Rails.root.join('spec', 'support', 'helpers', 'factory_girl.rb')
+
+namespace :staging do
+  desc "Sample data for staging environment"
+  task prime: :environment do
+    include FactoryGirl::Syntax::Methods
+
+    skills = [
+      Skill.find_or_create_by(name: 'rails'),
+      Skill.find_or_create_by(name: 'golang'),
+      Skill.find_or_create_by(name: 'react'),
+      Skill.find_or_create_by(name: 'rust'),
+      Skill.find_or_create_by(name: 'elm'),
+      Skill.find_or_create_by(name: 'a-language-you-never-heard-of')
+    ]
+
+    FactoryGirl.create(:auction, :reverse, :pending_c2_approval)
+    FactoryGirl.create(:auction, :reverse, :with_bids)
+    FactoryGirl.create(:auction, :reverse, :expiring, :with_bids)
+    future_reverse = FactoryGirl.create(:auction, :reverse, :future)
+    future_reverse.skills << skills
+    FactoryGirl.create(:auction, :reverse, :closed, :with_bids, purchase_card: :other)
+    FactoryGirl.create(:auction, :reverse, :closed, :with_bids, :c2_approved, :delivered)
+    FactoryGirl.create(:auction, :sealed_bid, :with_bids)
+    FactoryGirl.create(:auction, :sealed_bid, :expiring, :with_bids)
+    future_sealed = FactoryGirl.create(:auction, :sealed_bid, :future)
+    future_sealed.skills << skills
+    FactoryGirl.create(:auction, :complete_and_successful)
+    FactoryGirl.create(:auction, :payment_needed)
+    FactoryGirl.create(:auction, :evaluation_needed)
+    FactoryGirl.create(:auction, :unpublished)
+    FactoryGirl.create(:auction, :rejected, :with_bids)
+  end
+end

--- a/lib/tasks/staging.rake
+++ b/lib/tasks/staging.rake
@@ -1,9 +1,9 @@
-require "factory_girl"
-  require Rails.root.join('spec', 'support', 'helpers', 'factory_girl.rb')
+require 'factory_girl'
+require Rails.root.join('spec', 'support', 'helpers', 'factory_girl.rb')
 
 namespace :staging do
   desc "Sample data for staging environment"
-  task prime: :environment do
+  task prime: 'db:setup' do
     include FactoryGirl::Syntax::Methods
 
     skills = [

--- a/manifest-staging.yml
+++ b/manifest-staging.yml
@@ -13,7 +13,7 @@ applications:
     - micropurchase-staging-psql
     - micropurchase-smtp
     - new-relic
-  command: script/start
+  command: script/staging_start
   env:
     RAILS_ENV: production
     RACK_ENV: production

--- a/script/staging_start
+++ b/script/staging_start
@@ -7,8 +7,6 @@ set -x
 # http://stackoverflow.com/a/6859838/358804
 PORT=${PORT-3000}
 
-bin/rake cf:on_first_instance db:drop
-bin/rake cf:on_first_instance db:create
 bin/rake cf:on_first_instance db:migrate
 bin/rake staging:prime
 foreman start -p $PORT

--- a/script/staging_start
+++ b/script/staging_start
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -e
+set -x
+
+# default the port, for development
+# http://stackoverflow.com/a/6859838/358804
+PORT=${PORT-3000}
+
+bin/rake cf:on_first_instance db:drop
+bin/rake cf:on_first_instance db:create
+bin/rake cf:on_first_instance db:migrate
+bin/rake staging:prime
+foreman start -p $PORT


### PR DESCRIPTION
* This is to prep for https://github.com/18F/micropurchase/issues/1084
* In a world where we can view auctions as different people, we also
  want to be able to see auctions in many different states
* We can do this locally by running `bin/setup`
* On staging, we run this on each deploy via `staging:prime`
* Philosophical question: do we want to do this? Upside is we have more
  useful seed data on staging. Downside is that we are not running
  migrations on existing data like we do on prod, so there is less
  parity.