### PR TITLE
fixing local docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,5 @@ RUN bundle install
 RUN gem install foreman
 RUN curl https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh > /usr/local/bin/wait-for-it
 RUN chmod +x /usr/local/bin/wait-for-it
-CMD wait-for-it db:5432 && bundle exec rake dev:prime \
+CMD wait-for-it db:5432 && bundle exec rake dev:prime && \
   foreman start


### PR DESCRIPTION
previously `foreman` was being (incorrectly) run as a rake command. this PR adds an `&&` to pull it out of rake and into its own command.