### PR TITLE
Admin can unpublish a future auction

### DIFF
--- a/app/models/admin_auction_status_presenter_factory.rb
+++ b/app/models/admin_auction_status_presenter_factory.rb
@@ -8,6 +8,8 @@ class AdminAuctionStatusPresenterFactory
   def create
     if auction.payment_confirmed? || auction.c2_paid?
       Object.const_get("C2StatusPresenter::#{c2_status}").new(auction: auction)
+    elsif future? && auction.published?
+      AdminAuctionStatusPresenter::FuturePublished.new(auction: auction)
     elsif !auction.pending_delivery?
       Object.const_get("AdminAuctionStatusPresenter::#{status}").new(auction: auction)
     else
@@ -16,6 +18,10 @@ class AdminAuctionStatusPresenterFactory
   end
 
   private
+
+  def future?
+    AuctionStatus.new(auction).future?
+  end
 
   def status
     auction.status.camelize

--- a/app/presenters/admin_auction_status_presenter/future_published.rb
+++ b/app/presenters/admin_auction_status_presenter/future_published.rb
@@ -1,0 +1,22 @@
+class AdminAuctionStatusPresenter::FuturePublished < AdminAuctionStatusPresenter::Base
+  def header
+    I18n.t('statuses.admin_auction_status_presenter.future_published.header')
+  end
+
+  def body
+    I18n.t(
+      'statuses.admin_auction_status_presenter.future_published.body',
+      start_date: start_date
+    )
+  end
+
+  def action_partial
+    'admin/auctions/unpublish'
+  end
+
+  private
+
+  def start_date
+    DcTimePresenter.convert_and_format(auction.started_at)
+  end
+end

--- a/app/views/admin/auctions/_unpublish.html.erb
+++ b/app/views/admin/auctions/_unpublish.html.erb
@@ -1,0 +1,4 @@
+<%= link_to I18n.t('statuses.admin_auction_status_presenter.future_published.actions.unpublish'),
+  admin_auction_published_path(status.auction),
+  method: :patch,
+  class: 'usa-button usa-button-outline action-button' %>

--- a/app/views/admin/auctions/needs_attention/_draft.html.erb
+++ b/app/views/admin/auctions/needs_attention/_draft.html.erb
@@ -1,4 +1,4 @@
-<table class="usa-table-borderless">
+<table class="usa-table-borderless" id="table-drafts">
   <thead>
     <tr>
       <th scope="col">Title</th>

--- a/config/locales/statuses/en.yml
+++ b/config/locales/statuses/en.yml
@@ -96,6 +96,15 @@ en:
               <a href=%{issue_url}>the issue associated with this auction</a>.
               Then enter the pull request URL, below, and click "start work."
     admin_auction_status_presenter:
+      future_published:
+        body: >
+          This auction is visible to the public but is not currently
+          accepting bids. It will open on %{start_date}. If you
+          need to take it down for whatever reason, press the
+          “unpublish” button, below.
+        header: Coming soon
+        actions:
+          unpublish: "Unpublish"
       pending_acceptance:
         body: >
           %{winner_url} made a <a href=%{delivery_url}>pull request</a> and marked this auction as

--- a/features/admin_unpublishes_future_auction.feature
+++ b/features/admin_unpublishes_future_auction.feature
@@ -1,0 +1,16 @@
+Feature: Admin views future unpublished auctions
+  As an an administrator
+  I should be able to view future auctions
+  So I can unpublish them if there any any problems
+
+  Scenario:
+    Given I am an administrator
+    And I sign in
+    And there is a future auction
+
+    When I visit the admin auction page for that auction
+    Then I should see the coming soon status box for admins
+
+    When I click on the unpublish button
+    Then I should be on the Needs Attention page
+    And I should see the auction as a draft auction

--- a/features/step_definitions/admin_views_drafts_steps.rb
+++ b/features/step_definitions/admin_views_drafts_steps.rb
@@ -1,6 +1,13 @@
 Then(/^I should see a table listing all draft auctions$/) do
-  table_xpath = '/html/body/div[2]/div/table'
+  table_xpath = '//table[@id="table-drafts"]'
   expect(page).to have_xpath(table_xpath)
+end
+
+Then(/^I should see the auction as a draft auction$/) do
+  table_xpath = '//table[@id="table-drafts"]'
+  within(:xpath, table_xpath) do
+    expect(page).to have_content(@auction.title)
+  end
 end
 
 Then(/^I should see the auction title$/) do

--- a/features/step_definitions/auction_status_steps.rb
+++ b/features/step_definitions/auction_status_steps.rb
@@ -67,6 +67,12 @@ Then(/^I should see the ready for work status box$/) do
   expect(find_field('auction_delivery_url')).not_to be_nil
 end
 
+Then(/^I should see the coming soon status box for admins$/) do
+  expect(page).to have_content(
+    I18n.t('statuses.admin_auction_status_presenter.future_published.header')
+  )
+end
+
 Then(/^I should see the work in progress status box$/) do
   expect(page).to have_content(
     I18n.t('statuses.bid_status_presenter.over.winner.work_in_progress.header')

--- a/features/step_definitions/link_and_button_steps.rb
+++ b/features/step_definitions/link_and_button_steps.rb
@@ -37,6 +37,11 @@ When(/^I click on the update button$/) do
   step("I click on the \"#{update_button}\" button")
 end
 
+When(/^I click on the unpublish button$/) do
+  unpublish_button = I18n.t('statuses.admin_auction_status_presenter.future_published.actions.unpublish')
+  step("I click on the \"#{unpublish_button}\" button")
+end
+
 When(/^I click on the I'm done button$/) do
   button = I18n.t('statuses.bid_status_presenter.over.winner.work_in_progress.action')
   step("I click on the \"#{button}\" button")

--- a/spec/models/admin_auction_status_presenter_factory_spec.rb
+++ b/spec/models/admin_auction_status_presenter_factory_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe AdminAuctionStatusPresenterFactory do
   context 'when the auction approval is not requested' do
-    it 'should return a AdminAuctionStatusPresenter::NotRequested' do
+    it 'should return a C2StatusPresenter::NotRequested' do
       auction = create(:auction, c2_status: :not_requested)
 
       expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
@@ -10,17 +10,35 @@ describe AdminAuctionStatusPresenterFactory do
     end
   end
 
-  context 'when the auction approval request is sent' do
-      it 'should return a AdminAuctionStatusPresenter::Sent' do
-        auction = create(:auction, c2_status: :sent)
+  context 'when the auction has been approved' do
+    it 'should return a AdminAuctionStatusPresenter::Accepted' do
+      auction = create(:auction, :closed, :with_bids, :delivered, :accepted)
 
-        expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
-          .to be_a(C2StatusPresenter::Sent)
+      expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
+        .to be_a(AdminAuctionStatusPresenter::Accepted)
+    end
+  end
+
+  context 'when the auction has been rejected' do
+    it 'should return a AdminAuctionStatusPresenter::Rejected' do
+      auction = create(:auction, :closed, :with_bids, :delivered, :rejected)
+
+      expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
+        .to be_a(AdminAuctionStatusPresenter::Rejected)
+    end
+  end
+
+  context 'when the auction approval request is sent' do
+    it 'should return a C2StatusPresenter::Sent' do
+      auction = create(:auction, c2_status: :sent)
+
+      expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
+        .to be_a(C2StatusPresenter::Sent)
     end
   end
 
   context 'when the auction approval request is pending' do
-    it 'should return a AdminAuctionStatusPresenter::PendingApproval' do
+    it 'should return a C2StatusPresenter::PendingApproval' do
       auction = create(:auction, c2_status: :pending_approval)
 
       expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
@@ -29,7 +47,7 @@ describe AdminAuctionStatusPresenterFactory do
   end
 
   context 'when auction is approved' do
-    it 'should return a AdminAuctionStatusPresenter::Approved' do
+    it 'should return a C2StatusPresenter::Approved' do
       auction = create(:auction, c2_status: :approved)
 
       expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)

--- a/spec/models/admin_auction_status_presenter_factory_spec.rb
+++ b/spec/models/admin_auction_status_presenter_factory_spec.rb
@@ -10,6 +10,15 @@ describe AdminAuctionStatusPresenterFactory do
     end
   end
 
+  context "when the auction has been published but hasn't started yet" do
+    it 'should return a AdminAuctionStatusPresenter::FuturePublished' do
+      auction = create(:auction, :future, :published)
+
+      expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
+        .to be_a(AdminAuctionStatusPresenter::FuturePublished)
+    end
+  end
+
   context 'when the auction has been approved' do
     it 'should return a AdminAuctionStatusPresenter::Accepted' do
       auction = create(:auction, :closed, :with_bids, :delivered, :accepted)


### PR DESCRIPTION
Fixes #1133 

<img width="1018" alt="localhost_3000_admin_auctions_9" src="https://cloud.githubusercontent.com/assets/2044/18216721/9e0356ec-7126-11e6-8853-0e2b876a60dd.png">

This allows admins to unpublish future auctions before they go live. A few additional notes:

1. I added a few missing tests for the AdminAuctionPresenterFactory class.
2. I really don't like cucumber features that look for the presence of a table by seeing if it's in the second div from the top. I added an id to the `drafts` table on the page because it seems less brittle than some approach that would break in an unclear fashion if we reordered the page.