### PR TITLE
Fix timezone-related failure

### DIFF
--- a/spec/controllers/api/v0/business_days_controller_spec.rb
+++ b/spec/controllers/api/v0/business_days_controller_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Api::V0::BusinessDaysController do
     end
 
     it 'should handle holidays correctly' do
+      BusinessTime::Config.holidays << Date.parse('2016-09-05')
       get :show, { date: '2016-09-01', time: '13:00', day_count: '5' }
       json = JSON.parse(response.body)
       expect(json['date']).to eq("September 09, 2016 01:00:00 PM EDT")


### PR DESCRIPTION
* Our holiday loading is only for future holidays so I need to forcibly
  load it in those places because that test is in the past
* Closes https://github.com/18F/micropurchase/issues/1169