### PR TITLE
Clarify status confirmation for sealed-bid auction

### DIFF
--- a/app/presenters/bid_status_presenter/available/vendor/sealed_auction_bidder.rb
+++ b/app/presenters/bid_status_presenter/available/vendor/sealed_auction_bidder.rb
@@ -11,6 +11,10 @@ class BidStatusPresenter::Available::Vendor::SealedAuctionBidder < BidStatusPres
     )
   end
 
+  def alert_css_class
+    'usa-alert-success'
+  end
+
   private
 
   def bid_amount

--- a/config/locales/statuses/en.yml
+++ b/config/locales/statuses/en.yml
@@ -33,7 +33,7 @@ en:
             body: "You've been outbid! The maximum you can bid is %{max_allowed_bid_as_currency}."
           sealed_auction_bidder:
             header: 'Bid placed'
-            body: "You bid %{bid_amount} on %{bid_date}."
+            body: You placed a bid of %{bid_amount} on %{bid_date}.
           winning_bidder:
             header: 'Bid placed'
             body: "You are currently the low bidder, with a bid of %{winning_amount}"

--- a/features/step_definitions/auction_status_steps.rb
+++ b/features/step_definitions/auction_status_steps.rb
@@ -53,8 +53,10 @@ Then(/^I should the open auction message for admins$/) do
   )
 end
 
-Then(/^I should see the time I placed my bid$/) do
+Then(/^I should see a status confirmation for my sealed bid$/) do
   bid = @auction.bids.last
+  expect(bid.amount).to eq(@bid_amount.to_i)
+  expect(bid.bidder).to eq(@user)
 
   expect(page).to have_content(
     I18n.t(

--- a/features/step_definitions/auction_status_steps.rb
+++ b/features/step_definitions/auction_status_steps.rb
@@ -53,7 +53,7 @@ Then(/^I should the open auction message for admins$/) do
   )
 end
 
-Then(/^I should see a status confirmation for my sealed bid$/) do
+Then(/^I should see a status message that confirms I placed a sealed bid$/) do
   bid = @auction.bids.last
   expect(bid.amount).to eq(@bid_amount.to_i)
   expect(bid.bidder).to eq(@user)

--- a/features/step_definitions/bidding_steps.rb
+++ b/features/step_definitions/bidding_steps.rb
@@ -63,6 +63,7 @@ Then(/^I should see the winning bid for the auction$/) do
 end
 
 When(/^I submit a bid for \$(.+)$/) do |amount|
+  @bid_amount = amount
   fill_in("Your bid", with: amount)
   step('I click on the "Place bid" button')
 end

--- a/features/vendor_bids_sealed_auction.feature
+++ b/features/vendor_bids_sealed_auction.feature
@@ -27,12 +27,12 @@ Feature: Vendor bids on a sealed-bid auction
 
     When I submit a bid for $3493
     And I click OK on the javascript confirm dialog for a bid amount of $3,493.00
-    Then I should see "Your bid: $3,493.00"
+    Then I should see a status confirmation for my sealed bid
 
     When I visit the auction page
     Then I should not see the bid form
     And I should see "Your bid: $3,493.00"
-    And I should see the time I placed my bid
+    And I should see a status confirmation for my sealed bid
 
   @javascript
   Scenario: viewing your own bid

--- a/features/vendor_bids_sealed_auction.feature
+++ b/features/vendor_bids_sealed_auction.feature
@@ -27,12 +27,12 @@ Feature: Vendor bids on a sealed-bid auction
 
     When I submit a bid for $3493
     And I click OK on the javascript confirm dialog for a bid amount of $3,493.00
-    Then I should see a status confirmation for my sealed bid
+    Then I should see a status message that confirms I placed a sealed bid
 
     When I visit the auction page
     Then I should not see the bid form
     And I should see "Your bid: $3,493.00"
-    And I should see a status confirmation for my sealed bid
+    Then I should see a status message that confirms I placed a sealed bid
 
   @javascript
   Scenario: viewing your own bid


### PR DESCRIPTION
Fixes #985

This is the last checkbox on there. But it seems like it already is implemented. So I just renamed a few steps