### PR TITLE
Vendor messaging - Payment URL needed - Auction Show Page

### DIFF
--- a/app/models/bid_status_presenter_factory.rb
+++ b/app/models/bid_status_presenter_factory.rb
@@ -34,7 +34,9 @@ class BidStatusPresenterFactory
   end
 
   def over_winning_bidder_message
-    if auction.pending_acceptance?
+    if auction.accepted? && auction.accepted_at.nil?
+      BidStatusPresenter::Over::Vendor::Winner::PendingPaymentUrl
+    elsif auction.pending_acceptance?
       BidStatusPresenter::Over::Vendor::Winner::PendingAcceptance
     elsif auction.accepted?
       BidStatusPresenter::Over::Vendor::Winner::PendingPayment

--- a/app/presenters/bid_status_presenter/over/vendor/winner/pending_payment_url.rb
+++ b/app/presenters/bid_status_presenter/over/vendor/winner/pending_payment_url.rb
@@ -1,0 +1,12 @@
+class BidStatusPresenter::Over::Vendor::Winner::PendingPaymentUrl < BidStatusPresenter::Base
+  def header
+    I18n.t('statuses.bid_status_presenter.over.winner.pending_payment_url.header')
+  end
+
+  def body
+    I18n.t(
+      'statuses.bid_status_presenter.over.winner.pending_payment_url.body',
+      delivery_url: auction.delivery_url,
+    )
+  end
+end

--- a/config/locales/statuses/en.yml
+++ b/config/locales/statuses/en.yml
@@ -54,6 +54,14 @@ en:
           header: 'Bidding closed'
           body: "Bidding for this auction closed on %{end_date}."
         winner:
+          pending_payment_url:
+            header: "Payment URL needed"
+            body: >
+              Your <a href=%{delivery_url}>pull request</a> was accepted, but we
+              cannot issue payment until you have specified a valid payment URL. Please update
+              the payment URL field on <a href="/profile">your profile</a>, or contact us at
+              micropurchase@gsa.gov with other instructions on how to pay you via credit card
+              for this auction.
           pending_payment_confirmation:
             header: "Payment confirmation needed"
             body: >

--- a/features/step_definitions/auction_create_steps.rb
+++ b/features/step_definitions/auction_create_steps.rb
@@ -202,6 +202,7 @@ Given(/^there is an accepted auction where the winning vendor is missing a payme
   @auction = FactoryGirl.create(
     :auction,
     :with_bids,
+    :closed,
     :published,
     status: :accepted,
     accepted_at: nil,

--- a/features/step_definitions/auction_status_steps.rb
+++ b/features/step_definitions/auction_status_steps.rb
@@ -65,6 +65,12 @@ Then(/^I should see the time I placed my bid$/) do
   )
 end
 
+Then(/^I should see the auction missing payment method status box$/) do
+  expect(page).to have_content(
+    I18n.t('statuses.bid_status_presenter.over.winner.pending_payment_url.header')
+  )
+end
+
 Then(/^I should see the ready for work status box$/) do
   expect(page).to have_content(
     I18n.t('statuses.bid_status_presenter.over.winner.work_not_started.header')

--- a/features/vendor_provides_payment_url.feature
+++ b/features/vendor_provides_payment_url.feature
@@ -45,7 +45,8 @@ Feature: Vendor updates Payment URL
     And I am the winning bidder
     And I sign in
     When I visit the auction page
-    Then I should see that the auction was not accepted
+    Then I should see the auction missing payment method status box
+
     When I visit my profile page
     And I fill in the Payment URL field on my profile page
     And I click on the "Update" button


### PR DESCRIPTION
* if an auction is accepted and the winning vendor does not have a payment url,
  they receive an email asking them to update their profile.
* when they view the auction, they will now also see this

![screen shot 2016-09-13 at 8 30 12 pm](https://cloud.githubusercontent.com/assets/601515/18499174/6717ff74-79f1-11e6-8909-1cc15c4b877e.png)


* Closes https://github.com/18F/micropurchase/issues/1099