### PR TITLE
Admin auction status for pending payment URL

### DIFF
--- a/app/models/admin_auction_status_presenter_factory.rb
+++ b/app/models/admin_auction_status_presenter_factory.rb
@@ -12,6 +12,8 @@ class AdminAuctionStatusPresenterFactory
       AdminAuctionStatusPresenter::Future.new(auction: auction)
     elsif work_in_progress?
       AdminAuctionStatusPresenter::WorkInProgress.new(auction: auction)
+    elsif auction.accepted? && auction.accepted_at.nil?
+      AdminAuctionStatusPresenter::PendingPaymentUrl.new(auction: auction)
     elsif !auction.pending_delivery?
       Object.const_get("AdminAuctionStatusPresenter::#{status}").new(auction: auction)
     else # if auction.purchase_card == 'default'

--- a/app/presenters/admin_auction_status_presenter/base.rb
+++ b/app/presenters/admin_auction_status_presenter/base.rb
@@ -17,6 +17,14 @@ class AdminAuctionStatusPresenter::Base
 
   protected
 
+  def winner_url
+    Url.new(
+      link_text: winner.email,
+      path_name: 'admin_user',
+      params: { id: winner.id }
+    )
+  end
+
   def winner
     WinningBid.new(auction).find.bidder
   end

--- a/app/presenters/admin_auction_status_presenter/pending_payment_url.rb
+++ b/app/presenters/admin_auction_status_presenter/pending_payment_url.rb
@@ -1,0 +1,13 @@
+class AdminAuctionStatusPresenter::PendingPaymentUrl < AdminAuctionStatusPresenter::Base
+  def header
+    I18n.t('statuses.admin_auction_status_presenter.pending_payment_url.header')
+  end
+
+  def body
+    I18n.t(
+      'statuses.admin_auction_status_presenter.pending_payment_url.body',
+      winner_url: winner_url,
+      delivery_url: auction.delivery_url
+    )
+  end
+end

--- a/app/presenters/admin_auction_status_presenter/work_in_progress.rb
+++ b/app/presenters/admin_auction_status_presenter/work_in_progress.rb
@@ -14,14 +14,6 @@ class AdminAuctionStatusPresenter::WorkInProgress < AdminAuctionStatusPresenter:
 
   private
 
-  def winner_url
-    Url.new(
-      link_text: winner.email,
-      path_name: 'admin_user',
-      params: { id: winner.id }
-    )
-  end
-
   def delivery_deadline
     DcTimePresenter.convert_and_format(auction.delivery_due_at)
   end

--- a/config/locales/statuses/en.yml
+++ b/config/locales/statuses/en.yml
@@ -130,6 +130,12 @@ en:
         actions:
           accept: "Accept"
           reject: "Reject"
+      pending_payment_url:
+        header: Payment URL needed
+        body: >
+          The <a href=%{delivery_url}>pull request</a> from %{winner_url}
+          was accepted. However, this vendor cannot
+          be paid until they’ve specified a valid payment URL.
       accepted:
         header: "Accepted"
         body: "%{winner_email}'s delivered code was accepted on %{accepted_at}."

--- a/features/admin_views_missing_payment_url.feature
+++ b/features/admin_views_missing_payment_url.feature
@@ -1,0 +1,12 @@
+Feature: Admin views missing Payment URL
+  As an administrator
+  I should be able to see if an auction is missing a payment URL
+  So I can ask the vendor to provide one
+
+  Scenario: Admin sees message in status box for auction that payment URL is needed before payment can be made
+    Given I am an administrator
+    And I sign in
+    And there is an accepted auction where the winning vendor is missing a payment method
+    When I visit the admin auction page for that auction
+    Then I should see an admin status message that the vendor needs to provide a payment URL
+    And I should see a link to the delivery URL

--- a/features/step_definitions/auction_create_steps.rb
+++ b/features/step_definitions/auction_create_steps.rb
@@ -204,6 +204,7 @@ Given(/^there is an accepted auction where the winning vendor is missing a payme
     :with_bids,
     :closed,
     :published,
+    :delivery_url,
     status: :accepted,
     accepted_at: nil,
     c2_proposal_url: 'https://c2-dev.18f.gov/proposals/2486'

--- a/features/step_definitions/auction_status_steps.rb
+++ b/features/step_definitions/auction_status_steps.rb
@@ -200,6 +200,14 @@ Then(/^I should see the payment confirmed message$/) do
   )
 end
 
+Then(/^I should see an admin status message that the vendor needs to provide a payment URL$/) do
+  expect(page).to have_content(
+    I18n.t(
+      'statuses.admin_auction_status_presenter.pending_payment_url.header'
+    )
+  )
+end
+
 def end_date
   DcTimePresenter.convert_and_format(@auction.ended_at)
 end

--- a/features/step_definitions/link_and_button_steps.rb
+++ b/features/step_definitions/link_and_button_steps.rb
@@ -125,3 +125,7 @@ end
 Then(/^I should not see an "Edit" link for the auction$/) do
   within('.auction-title') { expect(page).not_to have_selector(:link, "Edit") }
 end
+
+Then(/^I should see a link to the delivery URL$/) do
+  expect(page).to have_link('pull request', href: @auction.delivery_url)
+end

--- a/spec/models/admin_auction_status_presenter_factory_spec.rb
+++ b/spec/models/admin_auction_status_presenter_factory_spec.rb
@@ -11,11 +11,20 @@ describe AdminAuctionStatusPresenterFactory do
   end
 
   context "when the auction has been published but hasn't started yet" do
-    it 'should return a AdminAuctionStatusPresenter::FuturePublished' do
+    it 'should return a AdminAuctionStatusPresenter::Future' do
       auction = create(:auction, :future, :published)
 
       expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
         .to be_a(AdminAuctionStatusPresenter::Future)
+    end
+  end
+
+  context "when an auction has been accepted but doesn't have a payment URL yet" do
+    it 'should return a AdminAuctionStatusPresenter::PendingPaymentUrl' do
+      auction = create(:auction, :closed, :with_bids, :published, :accepted, accepted_at: nil)
+
+      expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
+        .to be_a(AdminAuctionStatusPresenter::PendingPaymentUrl)
     end
   end
 


### PR DESCRIPTION
Addresses one part of #1153 

Note that the original issue includes the `approver_name` and `approved_at` time but the first is not recorded and the second is not set if the payment_url is nil

Note that this will need to be revised when #1222 is implemented. At that time, we could also add `accepted_at` to the status message