### PR TITLE
Add "ready to publish" status

### DIFF
--- a/app/controllers/admin/auction_published_controller.rb
+++ b/app/controllers/admin/auction_published_controller.rb
@@ -7,7 +7,7 @@ class Admin::AuctionPublishedController < Admin::BaseController
         'controllers.admin.auctions.unpublish.success',
         title: auction.title
       )
-      redirect_to admin_auctions_needs_attention_path
+      redirect_to admin_auction_path(auction)
     end
   end
 end

--- a/app/presenters/admin_auction_status_presenter/base.rb
+++ b/app/presenters/admin_auction_status_presenter/base.rb
@@ -7,6 +7,10 @@ class AdminAuctionStatusPresenter::Base
     @bid_error = bid_error
   end
 
+  def status
+    ''
+  end
+
   def action_partial
     'components/null'
   end

--- a/app/presenters/admin_auction_status_presenter/ready_to_publish.rb
+++ b/app/presenters/admin_auction_status_presenter/ready_to_publish.rb
@@ -1,0 +1,9 @@
+class AdminAuctionStatusPresenter::ReadyToPublish < AdminAuctionStatusPresenter::Base
+  def header
+    I18n.t('statuses.admin_auction_status_presenter.future.unpublished.header')
+  end
+
+  def body
+    I18n.t('statuses.admin_auction_status_presenter.future.unpublished.body')
+  end
+end

--- a/config/locales/statuses/en.yml
+++ b/config/locales/statuses/en.yml
@@ -107,14 +107,18 @@ en:
               Then enter the pull request URL, below, and click "start work."
     admin_auction_status_presenter:
       future:
-        body: >
-          This auction is visible to the public but is not currently
-          accepting bids. It will open on %{start_date}. If you
-          need to take it down for whatever reason, press the
-          "unpublish" button, below.
-        header: Coming soon
-        actions:
-          unpublish: "Unpublish"
+        published:
+          body: >
+            This auction is visible to the public but is not currently
+            accepting bids. It will open on %{start_date}. If you
+            need to take it down for whatever reason, press the
+            "unpublish" button, below.
+          header: Coming soon
+          actions:
+            unpublish: "Unpublish"
+        unpublished:
+          body: "This auction is ready to publish!"
+          header: "Ready to publish"
       work_in_progress:
         header: Work in progress
         body: >

--- a/features/admin_views_closed_auction.feature
+++ b/features/admin_views_closed_auction.feature
@@ -12,7 +12,7 @@ Feature: Admin views closed auction
   Scenario: Auction is paid, winning vendor has not yet confirmed payment
     Given I am an administrator
     And I sign in
-    And there is an auction pending acceptance
+    And there is an accepted auction
     And the auction was marked as paid in C2
     When I visit the admin auction page for that auction
     Then I should see the C2 status for an auction pending payment confirmation

--- a/features/admin_views_future_auction.feature
+++ b/features/admin_views_future_auction.feature
@@ -12,8 +12,7 @@ Feature: Admin views future auction
     And I should see the future auction message for admins
 
     When I click on the unpublish button
-    Then I should be on the admin needs attention auctions page
-    And I should see a success message confirming that the auction was unpublished
+    Then I should see a success message confirming that the auction was unpublished
 
   Scenario: Viewing the admin auction page
     Given I am an administrator
@@ -23,11 +22,10 @@ Feature: Admin views future auction
     Then I should see the future auction message for admins
 
     When I click on the unpublish button
-    Then I should be on the admin needs attention auctions page
-    And I should see a success message confirming that the auction was unpublished
-    And I should see the auction as a draft auction
+    Then I should see a success message confirming that the auction was unpublished
+    And I should see the auction as an unpublished auction that is ready to be published
 
-  Scenario: Viewing the admin auction page for an aucton that uses a non-default purchase card
+  Scenario: Viewing the admin auction page for an auction that uses a non-default purchase card
     Given I am an administrator
     And I sign in
     And there is a future auction
@@ -36,6 +34,5 @@ Feature: Admin views future auction
     Then I should see the future auction message for admins
 
     When I click on the unpublish button
-    Then I should be on the admin needs attention auctions page
-    And I should see a success message confirming that the auction was unpublished
-    And I should see the auction as a draft auction
+    Then I should see a success message confirming that the auction was unpublished
+    And I should see the auction as an unpublished auction that is ready to be published

--- a/features/step_definitions/admin_views_drafts_steps.rb
+++ b/features/step_definitions/admin_views_drafts_steps.rb
@@ -3,11 +3,10 @@ Then(/^I should see a table listing all draft auctions$/) do
   expect(page).to have_xpath(table_xpath)
 end
 
-Then(/^I should see the auction as a draft auction$/) do
-  table_xpath = '//table[@id="table-drafts"]'
-  within(:xpath, table_xpath) do
-    expect(page).to have_content(@auction.title)
-  end
+Then(/^I should see the auction as an unpublished auction that is ready to be published$/) do
+  expect(page).to have_content(
+    I18n.t('statuses.admin_auction_status_presenter.future.unpublished.header')
+  )
 end
 
 Then(/^I should see the auction title$/) do


### PR DESCRIPTION
* When default pcard, this happens when c2 request is approved
* Otherwise, it is for any future auction that is unpublished.
* Closes https://github.com/18F/micropurchase/issues/931

![screen shot 2016-09-15 at 4 17 24 pm](https://cloud.githubusercontent.com/assets/601515/18570902/e2a536d0-7b62-11e6-90eb-4665f00bb794.png)
