### PR TITLE
Update c2_status when auction is paid

### DIFF
--- a/app/services/check_payment.rb
+++ b/app/services/check_payment.rb
@@ -8,7 +8,7 @@ class CheckPayment < C2ApiWrapper
       paid_at = find_purchase_timestamp(proposal_json(auction))
 
       if paid_at
-        auction.update(paid_at: DateTime.parse(paid_at))
+        auction.update(c2_status: :c2_paid, paid_at: DateTime.parse(paid_at))
         AuctionMailer.auction_paid_winning_vendor_notification(auction: auction).deliver_later
       end
     end

--- a/spec/services/check_payment_spec.rb
+++ b/spec/services/check_payment_spec.rb
@@ -16,6 +16,7 @@ describe CheckPayment do
           CheckPayment.new.perform
 
           expect(auction.reload.paid_at).to be_nil
+          expect(auction.c2_paid?).to eq false
         end
       end
 
@@ -32,6 +33,7 @@ describe CheckPayment do
           CheckPayment.new.perform
 
           expect(auction.reload.paid_at).not_to be_nil
+          expect(auction.c2_paid?).to eq true
         end
 
         it 'sends an email to the vendor' do


### PR DESCRIPTION
* Previous we just updated `paid_at` timestamp
* This created a bug (closes https://github.com/18F/micropurchase/issues/1217)