### PR TITLE
Auctions pending payment URL need attention

### DIFF
--- a/app/models/auction_query.rb
+++ b/app/models/auction_query.rb
@@ -63,7 +63,7 @@ class AuctionQuery
 
   def payment_needed
     relation
-      .accepted_and_pending
+      .accepted_or_accepted_and_pending_payment_url
       .not_paid
   end
 

--- a/app/models/auction_query.rb
+++ b/app/models/auction_query.rb
@@ -63,7 +63,7 @@ class AuctionQuery
 
   def payment_needed
     relation
-      .accepted
+      .accepted_and_pending
       .not_paid
   end
 

--- a/app/models/concerns/auction_scopes.rb
+++ b/app/models/concerns/auction_scopes.rb
@@ -4,7 +4,7 @@ module AuctionScopes
   included do
     scope :accepted, -> { where(status: statuses['accepted']) }
     scope :accepted_pending_payment_url, -> { where(status: statuses['accepted_pending_payment_url']) }
-    scope :accepted_and_pending, lambda {
+    scope :accepted_or_accepted_and_pending_payment_url, lambda {
       where(status: [statuses['accepted'],
                      statuses['accepted_pending_payment_url']])
     }

--- a/app/models/concerns/auction_scopes.rb
+++ b/app/models/concerns/auction_scopes.rb
@@ -4,6 +4,10 @@ module AuctionScopes
   included do
     scope :accepted, -> { where(status: statuses['accepted']) }
     scope :accepted_pending_payment_url, -> { where(status: statuses['accepted_pending_payment_url']) }
+    scope :accepted_and_pending, lambda {
+      where(status: [statuses['accepted'],
+                     statuses['accepted_pending_payment_url']])
+    }
     scope :default_purchase_card, -> { where(purchase_card: 0) }
     scope :delivery_url, -> { where.not(delivery_url: [nil, '']) }
     scope :ended_at_in_future, -> { where('ended_at > ?', Time.current) }

--- a/app/views/admin/auctions/needs_attention/_draft.html.erb
+++ b/app/views/admin/auctions/needs_attention/_draft.html.erb
@@ -1,4 +1,4 @@
-<table class="usa-table-borderless" id="table-drafts">
+<table class="usa-table-borderless">
   <thead>
     <tr>
       <th scope="col">Title</th>

--- a/app/views/admin/auctions/needs_attention/_payment_needed.html.erb
+++ b/app/views/admin/auctions/needs_attention/_payment_needed.html.erb
@@ -1,4 +1,4 @@
-<table class="usa-table-borderless" id="table-payment">
+<table class="usa-table-borderless">
   <thead>
     <tr>
       <th scope="col">Title</th>

--- a/app/views/admin/auctions/needs_attention/_payment_needed.html.erb
+++ b/app/views/admin/auctions/needs_attention/_payment_needed.html.erb
@@ -1,4 +1,4 @@
-<table class="usa-table-borderless">
+<table class="usa-table-borderless" id="table-payment">
   <thead>
     <tr>
       <th scope="col">Title</th>

--- a/features/admin_views_missing_payment_url.feature
+++ b/features/admin_views_missing_payment_url.feature
@@ -10,3 +10,12 @@ Feature: Admin views missing Payment URL
     When I visit the admin auction page for that auction
     Then I should see an admin status message that the vendor needs to provide a payment URL
     And I should see a link to the delivery URL
+
+  Scenario: Admin sees status in the "Needs Payment" section of needs attention page that a payment URL is needed
+    Given I am an administrator
+    And I sign in
+    And there is an accepted auction where the winning vendor is missing a payment method
+    And I visit the Needs Attention page
+    Then I should see a table listing all payment needed auctions
+    And I should see the auction as a payment needed auction
+    And I should see "Needs Credit Card URL"

--- a/features/admin_views_needs_attention_auctions.feature
+++ b/features/admin_views_needs_attention_auctions.feature
@@ -25,7 +25,7 @@ Feature: Admin view needs attention auctions
     Given there is an unpublished auction
     When I visit the admin needs attention auctions page
     Then I should see a table listing all draft auctions
-    And I should see the auction title
+    And I should see the auction as a draft auction
 
   Scenario: Admin sees data for needs evaluation auctions
     Given there is an auction that needs evaluation

--- a/features/step_definitions/admin_views_drafts_steps.rb
+++ b/features/step_definitions/admin_views_drafts_steps.rb
@@ -1,6 +1,5 @@
 Then(/^I should see a table listing all draft auctions$/) do
-  table_xpath = '//table[@id="table-drafts"]'
-  expect(page).to have_xpath(table_xpath)
+  expect(page).to have_xpath(needs_attention_table_xpath('drafts'))
 end
 
 Then(/^I should see the auction as an unpublished auction that is ready to be published$/) do
@@ -9,13 +8,20 @@ Then(/^I should see the auction as an unpublished auction that is ready to be pu
   )
 end
 
+Then(/^I should see the auction as a draft auction$/) do
+  table_xpath = needs_attention_table_xpath('drafts')
+
+  within(:xpath, table_xpath) do
+    expect(page).to have_content(@auction.title)
+  end
+end
+
 Then(/^I should see a table listing all payment needed auctions$/) do
-  table_xpath = '//table[@id="table-payment"]'
-  expect(page).to have_xpath(table_xpath)
+  expect(page).to have_xpath(needs_attention_table_xpath('payment_needed'))
 end
 
 Then(/^I should see the auction as a payment needed auction$/) do
-  table_xpath = '//table[@id="table-payment"]'
+  table_xpath = needs_attention_table_xpath('payment_needed')
   within(:xpath, table_xpath) do
     expect(page).to have_content(@auction.title)
   end

--- a/features/step_definitions/admin_views_drafts_steps.rb
+++ b/features/step_definitions/admin_views_drafts_steps.rb
@@ -9,6 +9,18 @@ Then(/^I should see the auction as an unpublished auction that is ready to be pu
   )
 end
 
+Then(/^I should see a table listing all payment needed auctions$/) do
+  table_xpath = '//table[@id="table-payment"]'
+  expect(page).to have_xpath(table_xpath)
+end
+
+Then(/^I should see the auction as a payment needed auction$/) do
+  table_xpath = '//table[@id="table-payment"]'
+  within(:xpath, table_xpath) do
+    expect(page).to have_content(@auction.title)
+  end
+end
+
 Then(/^I should see the auction title$/) do
   expect(page).to have_content(@auction.title)
 end

--- a/features/support/needs_attention.rb
+++ b/features/support/needs_attention.rb
@@ -1,0 +1,4 @@
+def needs_attention_table_xpath(section)
+  table_title = I18n.t("needs_attention.index.#{section}")
+  "//h2[text()='#{table_title}']/following-sibling::table[1]"
+end

--- a/spec/factories/auctions.rb
+++ b/spec/factories/auctions.rb
@@ -96,6 +96,11 @@ FactoryGirl.define do
       accepted_at { Time.now }
     end
 
+    trait :accepted_pending_payment_url do
+      status :accepted_pending_payment_url
+      accepted_at { Time.now }
+    end
+
     trait :rejected do
       status :rejected
       rejected_at { Time.now }

--- a/spec/models/auction_query_spec.rb
+++ b/spec/models/auction_query_spec.rb
@@ -136,10 +136,11 @@ describe AuctionQuery do
       _pending_delivery = create(:auction, :closed)
       _pending_acceptance = create(:auction, :evaluation_needed)
       _payment_needed = create(:auction, :payment_needed)
+      _pending_url = create(:auction, :closed, :accepted_pending_payment_url)
 
       query = AuctionQuery.new
 
-      expect(query.needs_attention_count).to eq(4)
+      expect(query.needs_attention_count).to eq(5)
     end
   end
 


### PR DESCRIPTION
Fixes #1153 

Make sure that auctions that are accepted but missing the payment URL show up in the needs_attention column