### PR TITLE
Fix c2 status in drafts section of Needs Attention

### DIFF
--- a/app/presenters/admin_auction_status_presenter/base.rb
+++ b/app/presenters/admin_auction_status_presenter/base.rb
@@ -7,10 +7,6 @@ class AdminAuctionStatusPresenter::Base
     @bid_error = bid_error
   end
 
-  def status
-    ''
-  end
-
   def action_partial
     'components/null'
   end

--- a/app/view_models/admin/draft_list_item.rb
+++ b/app/view_models/admin/draft_list_item.rb
@@ -14,7 +14,11 @@ class Admin::DraftListItem < Admin::BaseViewModel
   end
 
   def c2_proposal_status
-    c2_proposal_status_presenter.status
+    if auction.purchase_card == 'default'
+      c2_proposal_status_presenter.status
+    else
+      'N/A'
+    end
   end
 
   def started_at
@@ -32,6 +36,6 @@ class Admin::DraftListItem < Admin::BaseViewModel
   private
 
   def c2_proposal_status_presenter
-    AdminAuctionStatusPresenterFactory.new(auction: auction).create
+    Object.const_get("C2StatusPresenter::#{auction.c2_status.camelize}").new(auction: auction)
   end
 end

--- a/app/view_models/admin/needs_attention_auction_list_item.rb
+++ b/app/view_models/admin/needs_attention_auction_list_item.rb
@@ -49,14 +49,6 @@ class Admin::NeedsAttentionAuctionListItem < Admin::BaseViewModel
     auction.delivery_url || 'N/A'
   end
 
-  def c2_proposal_url
-    if auction.purchase_card == 'default'
-      auction.c2_proposal_url
-    else
-      'N/A'
-    end
-  end
-
   def paid?
     auction.paid_at.present?
   end

--- a/spec/view_models/admin/draft_list_item_spec.rb
+++ b/spec/view_models/admin/draft_list_item_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+describe Admin::DraftListItem do
+  describe '#c2_proposal_url' do
+    context 'auction for default purchase card' do
+      it 'returns c2 proposal URL' do
+        auction = create(:auction, purchase_card: :default)
+
+        view_model = Admin::DraftListItem.new(auction)
+
+        expect(view_model.c2_proposal_status).to eq(
+          AdminAuctionStatusPresenterFactory.new(auction: auction).create.status
+        )
+      end
+    end
+
+    context 'auction for other purchase card' do
+      it 'returns n/a' do
+        auction = create(:auction, purchase_card: :other)
+
+        view_model = Admin::DraftListItem.new(auction)
+
+        expect(view_model.c2_proposal_status).to eq 'N/A'
+      end
+    end
+  end
+end

--- a/spec/view_models/admin/needs_attention_auction_list_item_spec.rb
+++ b/spec/view_models/admin/needs_attention_auction_list_item_spec.rb
@@ -1,28 +1,6 @@
 require 'rails_helper'
 
 describe Admin::NeedsAttentionAuctionListItem do
-  describe '#c2_proposal_url' do
-    context 'auction for default purchase card' do
-      it 'returns c2 proposal URL' do
-        auction = create(:auction, purchase_card: :default)
-
-        view_model = Admin::NeedsAttentionAuctionListItem.new(auction)
-
-        expect(view_model.c2_proposal_url).to eq auction.c2_proposal_url
-      end
-    end
-
-    context 'auction for other purchase card' do
-      it 'returns n/a' do
-        auction = create(:auction, purchase_card: :other)
-
-        view_model = Admin::NeedsAttentionAuctionListItem.new(auction)
-
-        expect(view_model.c2_proposal_url).to eq 'N/A'
-      end
-    end
-  end
-
   describe '#payment_status' do
     context 'winning bidder has a payment url' do
       it 'is pending' do


### PR DESCRIPTION
* Were were using `AdminAuctionStatusPresenterFactory` which returns
  various presenters
* We want to return the c2 status presenter status if default pcard
* Otherwise, return "N/A"

Before:

![screen shot 2016-09-16 at 2 11 17 pm](https://cloud.githubusercontent.com/assets/601515/18601366/4e0f96ea-7c17-11e6-9875-2ca2a0ce0b91.png)


After:
![screen shot 2016-09-16 at 2 09 47 pm](https://cloud.githubusercontent.com/assets/601515/18601357/3eebb220-7c17-11e6-95d8-21b28d71ca78.png)
