### PR TITLE
Clarify presenter logic for admins

### DIFF
--- a/app/models/admin_auction_status_presenter_factory.rb
+++ b/app/models/admin_auction_status_presenter_factory.rb
@@ -16,18 +16,26 @@ class AdminAuctionStatusPresenterFactory
   private
 
   def default_purchase_card_presenter
-    if auction.payment_confirmed? || auction.c2_paid?
-      Object.const_get("C2StatusPresenter::#{c2_status}")
+    if auction.c2_status == 'not_requested'
+      C2StatusPresenter::NotRequested
+    elsif auction.c2_status == 'sent'
+      C2StatusPresenter::Sent
+    elsif auction.c2_status == 'pending_approval'
+      C2StatusPresenter::PendingApproval
     elsif future? && auction.published?
       AdminAuctionStatusPresenter::Future
     elsif future? && auction.unpublished?
       AdminAuctionStatusPresenter::ReadyToPublish
     elsif work_in_progress?
       AdminAuctionStatusPresenter::WorkInProgress
+    elsif auction.c2_paid?
+      C2StatusPresenter::C2Paid
+    elsif auction.payment_confirmed?
+      C2StatusPresenter::PaymentConfirmed
     elsif !auction.pending_delivery?
       Object.const_get("AdminAuctionStatusPresenter::#{status}")
-    else
-      Object.const_get("C2StatusPresenter::#{c2_status}")
+    else # auction.approved? && auction.pending_delivery?
+      C2StatusPresenter::Approved
     end
   end
 

--- a/app/presenters/admin_auction_status_presenter/future.rb
+++ b/app/presenters/admin_auction_status_presenter/future.rb
@@ -1,11 +1,11 @@
 class AdminAuctionStatusPresenter::Future < AdminAuctionStatusPresenter::Base
   def header
-    I18n.t('statuses.admin_auction_status_presenter.future.header')
+    I18n.t('statuses.admin_auction_status_presenter.future.published.header')
   end
 
   def body
     I18n.t(
-      'statuses.admin_auction_status_presenter.future.body',
+      'statuses.admin_auction_status_presenter.future.published.body',
       start_date: start_date
     )
   end

--- a/features/admin_views_future_auction.feature
+++ b/features/admin_views_future_auction.feature
@@ -9,7 +9,7 @@ Feature: Admin views future auction
     When I visit the auction page
     Then I should see a "Coming Soon" label
     And I should not see the bid form
-    And I should see the future auction message for admins
+    And I should see the future published auction message for admins
 
     When I click on the unpublish button
     Then I should see a success message confirming that the auction was unpublished
@@ -19,7 +19,7 @@ Feature: Admin views future auction
     And I sign in
     And there is a future auction
     When I visit the admin auction page for that auction
-    Then I should see the future auction message for admins
+    Then I should see the future published auction message for admins
 
     When I click on the unpublish button
     Then I should see a success message confirming that the auction was unpublished
@@ -31,7 +31,7 @@ Feature: Admin views future auction
     And there is a future auction
     And the auction is for a different purchase card
     When I visit the admin auction page for that auction
-    Then I should see the future auction message for admins
+    Then I should see the future published auction message for admins
 
     When I click on the unpublish button
     Then I should see a success message confirming that the auction was unpublished

--- a/features/step_definitions/auction_create_steps.rb
+++ b/features/step_definitions/auction_create_steps.rb
@@ -3,7 +3,7 @@ Given(/^there is an unpublished auction$/) do
 end
 
 Given(/^there is a future auction$/) do
-  @auction = FactoryGirl.create(:auction, :future)
+  @auction = FactoryGirl.create(:auction, :future, :published)
 end
 
 Given(/^there is a closed auction$/) do
@@ -41,7 +41,7 @@ Given(/^I am going to lose an auction$/) do
 end
 
 Given(/^there is an auction with work in progress$/) do
-  @auction = FactoryGirl.create(:auction, :closed, :with_bids, :delivery_url)
+  @auction = FactoryGirl.create(:auction, :c2_approved, :closed, :with_bids, :delivery_url)
 end
 
 When(/^the auction ends$/) do
@@ -199,15 +199,7 @@ Given(/^there is an auction where the winning vendor is missing a payment method
 end
 
 Given(/^there is an accepted auction where the winning vendor is missing a payment method$/) do
-  @auction = FactoryGirl.create(
-    :auction,
-    :with_bids,
-    :closed,
-    :published,
-    :delivery_url,
-    status: :accepted_pending_payment_url,
-    c2_proposal_url: 'https://c2-dev.18f.gov/proposals/2486'
-  )
+  @auction = FactoryGirl.create(:auction, :accepted_pending_payment_url)
   @winning_bidder = WinningBid.new(@auction).find.bidder
   @winning_bidder.update(payment_url: '')
 end

--- a/features/step_definitions/auction_status_steps.rb
+++ b/features/step_definitions/auction_status_steps.rb
@@ -38,9 +38,9 @@ Then(/^I should see the future auction message for vendors$/) do
   )
 end
 
-Then(/^I should see the future auction message for admins$/) do
+Then(/^I should see the future published auction message for admins$/) do
   expect(page).to have_content(
-    I18n.t('statuses.admin_auction_status_presenter.future.header')
+    I18n.t('statuses.admin_auction_status_presenter.future.published.header')
   )
 end
 

--- a/spec/factories/auctions.rb
+++ b/spec/factories/auctions.rb
@@ -36,10 +36,12 @@ FactoryGirl.define do
     end
 
     trait :published do
+      c2_approved
       published :published
     end
 
     trait :unpublished do
+      future
       published :unpublished
     end
 
@@ -88,25 +90,33 @@ FactoryGirl.define do
     end
 
     trait :pending_acceptance do
+      closed
       status :pending_acceptance
     end
 
     trait :accepted do
+      closed
+      c2_approved
       status :accepted
       accepted_at { Time.now }
     end
 
     trait :accepted_pending_payment_url do
+      accepted
+      c2_approved
+      with_bids
       status :accepted_pending_payment_url
-      accepted_at { Time.now }
     end
 
     trait :rejected do
+      closed
+      c2_approved
       status :rejected
       rejected_at { Time.now }
     end
 
     trait :paid do
+      closed
       paid_at { Time.current }
     end
 
@@ -115,6 +125,7 @@ FactoryGirl.define do
     end
 
     trait :payment_confirmed do
+      closed
       c2_status :payment_confirmed
     end
 
@@ -131,6 +142,7 @@ FactoryGirl.define do
     end
 
    trait :pending_c2_approval do
+     future
      c2_status :pending_approval
      purchase_card :default
      unpublished
@@ -142,12 +154,15 @@ FactoryGirl.define do
     end
 
     trait :evaluation_needed do
+      closed
+      c2_approved
       with_bids
       delivery_url
       pending_acceptance
     end
 
     trait :payment_needed do
+      closed
       with_bids
       delivery_url
       accepted
@@ -155,6 +170,7 @@ FactoryGirl.define do
     end
 
     trait :complete_and_successful do
+      closed
       with_bids
       delivery_url
       accepted

--- a/spec/models/admin_auction_status_presenter_factory_spec.rb
+++ b/spec/models/admin_auction_status_presenter_factory_spec.rb
@@ -28,9 +28,9 @@ describe AdminAuctionStatusPresenterFactory do
     end
   end
 
-  context 'when the auction has been approved' do
+  context 'when the auction has been accepted' do
     it 'should return a AdminAuctionStatusPresenter::Accepted' do
-      auction = create(:auction, :closed, :with_bids, :delivery_url, :accepted)
+      auction = create(:auction, :accepted)
 
       expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
         .to be_a(AdminAuctionStatusPresenter::Accepted)
@@ -39,7 +39,7 @@ describe AdminAuctionStatusPresenterFactory do
 
   context 'when the auction has been rejected' do
     it 'should return a AdminAuctionStatusPresenter::Rejected' do
-      auction = create(:auction, :closed, :with_bids, :delivery_url, :rejected)
+      auction = create(:auction, :rejected)
 
       expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
         .to be_a(AdminAuctionStatusPresenter::Rejected)
@@ -66,7 +66,7 @@ describe AdminAuctionStatusPresenterFactory do
 
   context 'when auction is approved' do
     it 'should return a C2StatusPresenter::Approved' do
-      auction = create(:auction, c2_status: :approved)
+      auction = create(:auction, :available, c2_status: :approved)
 
       expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
         .to be_a(C2StatusPresenter::Approved)


### PR DESCRIPTION
* Move away from `Obj.const_get`
* Make sure our traits have realistic attributes (eg: unpublished
  auctions should be future by default)
* Fixes https://github.com/18F/micropurchase/issues/1248