### PR TITLE
Show information about bids for available auctions

### DIFF
--- a/app/models/admin_auction_status_presenter_factory.rb
+++ b/app/models/admin_auction_status_presenter_factory.rb
@@ -46,6 +46,8 @@ class AdminAuctionStatusPresenterFactory
       AdminAuctionStatusPresenter::Future
     elsif future? && auction.unpublished?
       AdminAuctionStatusPresenter::ReadyToPublish
+    elsif available?
+      AdminAuctionStatusPresenter::Available
     elsif work_in_progress?
       AdminAuctionStatusPresenter::WorkInProgress
     elsif !auction.pending_delivery?

--- a/app/models/admin_auction_status_presenter_factory.rb
+++ b/app/models/admin_auction_status_presenter_factory.rb
@@ -46,8 +46,6 @@ class AdminAuctionStatusPresenterFactory
       AdminAuctionStatusPresenter::Future
     elsif future? && auction.unpublished?
       AdminAuctionStatusPresenter::ReadyToPublish
-    elsif available?
-      AdminAuctionStatusPresenter::Available
     elsif work_in_progress?
       AdminAuctionStatusPresenter::WorkInProgress
     elsif !auction.pending_delivery?

--- a/app/models/bid_status_presenter_factory.rb
+++ b/app/models/bid_status_presenter_factory.rb
@@ -55,7 +55,7 @@ class BidStatusPresenterFactory
 
   def available_message
     if admin?
-      BidStatusPresenter::Available::Admin
+      AdminAuctionStatusPresenter::Available
     elsif guest?
       BidStatusPresenter::Available::Guest
     elsif ineligible?

--- a/app/presenters/admin_auction_status_presenter/available.rb
+++ b/app/presenters/admin_auction_status_presenter/available.rb
@@ -5,11 +5,12 @@ class AdminAuctionStatusPresenter::Available < AdminAuctionStatusPresenter::Base
 
   def body
     if total_bids > 0
-      I18n.t('statuses.bid_status_presenter.available.admin.has_bids',
-             end_date: end_date,
-             winner_url: winner_url,
-             total_bids: total_bids
-            )
+      I18n.t(
+        'statuses.bid_status_presenter.available.admin.has_bids',
+        end_date: end_date,
+        winner_url: winner_url,
+        total_bids: total_bids
+      )
     else
       I18n.t('statuses.bid_status_presenter.available.admin.body', end_date: end_date)
     end
@@ -25,8 +26,6 @@ class AdminAuctionStatusPresenter::Available < AdminAuctionStatusPresenter::Base
   def winner
     auction.lowest_bid.bidder
   end
-
-  private
 
   def end_date
     DcTimePresenter.convert_and_format(auction.ended_at)

--- a/app/presenters/admin_auction_status_presenter/available.rb
+++ b/app/presenters/admin_auction_status_presenter/available.rb
@@ -4,7 +4,26 @@ class AdminAuctionStatusPresenter::Available < AdminAuctionStatusPresenter::Base
   end
 
   def body
-    I18n.t('statuses.bid_status_presenter.available.admin.body', end_date: end_date)
+    if total_bids > 0
+      I18n.t('statuses.bid_status_presenter.available.admin.has_bids',
+             end_date: end_date,
+             winner_url: winner_url,
+             total_bids: total_bids
+            )
+    else
+      I18n.t('statuses.bid_status_presenter.available.admin.body', end_date: end_date)
+    end
+  end
+
+  private
+
+  def total_bids
+    auction.bids.count
+  end
+
+  # winning_bid is a NullBid when sealed-bid auctions are available
+  def winner
+    auction.lowest_bid.bidder
   end
 
   private

--- a/app/presenters/admin_auction_status_presenter/available.rb
+++ b/app/presenters/admin_auction_status_presenter/available.rb
@@ -22,9 +22,20 @@ class AdminAuctionStatusPresenter::Available < AdminAuctionStatusPresenter::Base
     auction.bids.count
   end
 
-  # winning_bid is a NullBid when sealed-bid auctions are available
-  def winner
-    auction.lowest_bid.bidder
+  def winner_url
+    Url.new(
+      link_text: winner_name,
+      path_name: 'admin_user',
+      params: { id: unmasked_winner_for_admin.id }
+    )
+  end
+
+  def winner_name
+    unmasked_winner_for_admin.name || unmasked_winner_for_admin.github_login
+  end
+
+  def unmasked_winner_for_admin
+    @_bidder ||= auction.lowest_bid.bidder
   end
 
   def end_date

--- a/app/presenters/bid_status_presenter/available/admin.rb
+++ b/app/presenters/bid_status_presenter/available/admin.rb
@@ -1,9 +1,0 @@
-class BidStatusPresenter::Available::Admin < BidStatusPresenter::Base
-  def header
-    I18n.t('statuses.bid_status_presenter.available.admin.header')
-  end
-
-  def body
-    I18n.t('statuses.bid_status_presenter.available.admin.body', end_date: end_date)
-  end
-end

--- a/config/locales/statuses/en.yml
+++ b/config/locales/statuses/en.yml
@@ -9,8 +9,12 @@ en:
             solicitation.
       available:
         admin:
-          header: "Accepting bids"
-          body: "This auction is accepting bids until %{end_date}."
+          header: Accepting bids
+          body: This auction is accepting bids until %{end_date}.
+          has_bids: >
+            There are %{total_bids} bids on this auction, and
+            %{winner_url} is currently winning. This auction is
+            accepting bids until %{end_date}.
         guest:
           body: >
             This auction is accepting bids until %{end_date}. %{sign_in_link} or

--- a/features/admin_views_auction.feature
+++ b/features/admin_views_auction.feature
@@ -6,7 +6,7 @@ Feature: Admin views public auction pages
   Scenario: Admin navigates to edit page from auction show page
     Given I am an administrator
     And I sign in
-    And there is a budget approved auction
+    And there is a budget approved auction with no bids
     And I visit the auction page
     Then I should see the "Edit" link for the auction
 

--- a/features/admin_views_available_auction.feature
+++ b/features/admin_views_available_auction.feature
@@ -6,7 +6,7 @@ Feature: Admin views available auction
   Scenario: The auction has no bids yet
     Given I am an administrator
     And I sign in
-    And there is a budget approved auction
+    And there is a budget approved auction with no bids
 
     When I visit the auction page
     Then I should see an admin status message that the auction is available with no bids

--- a/features/admin_views_available_auction.feature
+++ b/features/admin_views_available_auction.feature
@@ -1,0 +1,27 @@
+Feature: Admin views available auction
+  As an administrator
+  I want to see a sidebar status for available auctions
+  So I can see what the progress of them is
+
+  Scenario: The auction has no bids yet
+    Given I am an administrator
+    And I sign in
+    And there is a budget approved auction
+
+    When I visit the auction page
+    Then I should see an admin status message that the auction is available with no bids
+
+    When I visit the admin auction page for that auction
+    Then I should see an admin status message that the auction is available with no bids
+
+
+  Scenario: The auction has bids
+    Given I am an administrator
+    And I sign in
+    And there is a budget approved auction with bids
+
+    When I visit the auction page
+    Then I should see an admin status message that the auction is available with bids
+
+    When I visit the admin auction page for that auction
+    Then I should see an admin status message that the auction is available with bids

--- a/features/step_definitions/auction_create_steps.rb
+++ b/features/step_definitions/auction_create_steps.rb
@@ -92,7 +92,7 @@ Given(/^there is a budget approved auction with bids$/) do
   @auction = FactoryGirl.create(:auction, :c2_approved, :with_bids)
 end
 
-Given(/^there is a budget approved auction$/) do
+Given(/^there is a budget approved auction with no bids$/) do
   @auction = FactoryGirl.create(:auction, :c2_approved)
 end
 

--- a/features/step_definitions/auction_create_steps.rb
+++ b/features/step_definitions/auction_create_steps.rb
@@ -88,8 +88,12 @@ Given(/^there is an open auction with some skills$/) do
   @auction.skills << skills
 end
 
-Given(/^there is a budget approved auction$/) do
+Given(/^there is a budget approved auction with bids$/) do
   @auction = FactoryGirl.create(:auction, :c2_approved, :with_bids)
+end
+
+Given(/^there is a budget approved auction$/) do
+  @auction = FactoryGirl.create(:auction, :c2_approved)
 end
 
 Given(/^there is a sealed-bid auction$/) do

--- a/features/step_definitions/auction_status_steps.rb
+++ b/features/step_definitions/auction_status_steps.rb
@@ -203,3 +203,23 @@ Then(/^I should see an admin status message that the vendor needs to provide a p
     )
   )
 end
+
+Then(/^I should see an admin status message that the auction is available with no bids$/) do
+  expect(page).to have_content(
+    I18n.t(
+      'statuses.bid_status_presenter.available.admin.body',
+      end_date: end_date
+    )
+  )
+end
+
+Then(/^I should see an admin status message that the auction is available with bids$/) do
+  expect(page.html).to include(
+    I18n.t(
+      'statuses.bid_status_presenter.available.admin.has_bids',
+      end_date: end_date,
+      total_bids: @auction.bids.count,
+      winner_url: winner_url
+    )
+  )
+end


### PR DESCRIPTION
Fixes #1235 

![18f_micro-purchase_-_universal_explicit_throughput](https://cloud.githubusercontent.com/assets/2044/18686698/cee1938c-7f4a-11e6-8d50-17e59c6bd6ed.jpg)

This adds a box like this to available auctions for the both the `/auctions/:id` and `/admin/auctions/:id` when there are bids for an auction and the user is an admin. Note that this deprecates the `BidStatusPresenter::Available::Admin` presenter and I should delete that before this is merged if we think this is a right step.

Also, the message does not include the amount of the winning bid. Should it?