### PR TITLE
Rename AuctionStatus to BiddingStatus

### DIFF
--- a/app/models/admin_auction_status_presenter_factory.rb
+++ b/app/models/admin_auction_status_presenter_factory.rb
@@ -64,7 +64,7 @@ class AdminAuctionStatusPresenterFactory
   end
 
   def work_in_progress?
-    bidding_status.work_in_progress?
+    auction.work_in_progress?
   end
 
   def bidding_status

--- a/app/models/admin_auction_status_presenter_factory.rb
+++ b/app/models/admin_auction_status_presenter_factory.rb
@@ -56,15 +56,19 @@ class AdminAuctionStatusPresenterFactory
   end
 
   def available?
-    AuctionStatus.new(auction).available?
+    bidding_status.available?
   end
 
   def future?
-    AuctionStatus.new(auction).future?
+    bidding_status.future?
   end
 
   def work_in_progress?
-    AuctionStatus.new(auction).work_in_progress?
+    bidding_status.work_in_progress?
+  end
+
+  def bidding_status
+    @_bidding_status ||= BiddingStatus.new(auction)
   end
 
   def status

--- a/app/models/auction.rb
+++ b/app/models/auction.rb
@@ -54,6 +54,10 @@ class Auction < ActiveRecord::Base
   )
   validate :publishing_auction, on: :update, if: :published_changed?
 
+  def work_in_progress?
+    delivery_url.present? && pending_delivery?
+  end
+
   def publishing_auction
     if published_was == 'unpublished' && purchase_card == 'default' && c2_status != 'approved'
       errors.add(:c2_status, " is not approved.")

--- a/app/models/bid_status_presenter_factory.rb
+++ b/app/models/bid_status_presenter_factory.rb
@@ -100,23 +100,23 @@ class BidStatusPresenterFactory
   end
 
   def work_in_progress?
-    auction_status.work_in_progress?
+    bidding_status.work_in_progress?
   end
 
   def over?
-    auction_status.over?
+    bidding_status.over?
   end
 
   def available?
-    auction_status.available?
+    bidding_status.available?
   end
 
   def future?
-    auction_status.future?
+    bidding_status.future?
   end
 
-  def auction_status
-    AuctionStatus.new(auction)
+  def bidding_status
+    BiddingStatus.new(auction)
   end
 
   def user_is_winning_bidder?

--- a/app/models/bid_status_presenter_factory.rb
+++ b/app/models/bid_status_presenter_factory.rb
@@ -100,7 +100,7 @@ class BidStatusPresenterFactory
   end
 
   def work_in_progress?
-    bidding_status.work_in_progress?
+    auction.work_in_progress?
   end
 
   def over?

--- a/app/models/bidding_status.rb
+++ b/app/models/bidding_status.rb
@@ -19,10 +19,6 @@ class BiddingStatus
     available? && auction.ended_at < (Time.current + 12.hours)
   end
 
-  def work_in_progress?
-    auction.delivery_url.present? && auction.pending_delivery?
-  end
-
   private
 
   attr_reader :auction

--- a/app/models/bidding_status.rb
+++ b/app/models/bidding_status.rb
@@ -1,4 +1,4 @@
-class AuctionStatus
+class BiddingStatus
   def initialize(auction)
     @auction = auction
   end

--- a/app/models/rules/base_rules.rb
+++ b/app/models/rules/base_rules.rb
@@ -22,7 +22,7 @@ class Rules::BaseRules
   end
 
   def auction_available?
-    AuctionStatus.new(auction).available?
+    BiddingStatus.new(auction).available?
   end
 
   def user_is_eligible_to_bid?(user)

--- a/app/models/status_presenter_factory.rb
+++ b/app/models/status_presenter_factory.rb
@@ -12,18 +12,18 @@ class StatusPresenterFactory
   private
 
   def status_name
-    if auction_status.expiring?
+    if bidding_status.expiring?
       'Expiring'
-    elsif auction_status.over?
+    elsif bidding_status.over?
       'Over'
-    elsif auction_status.future?
+    elsif bidding_status.future?
       'Future'
     else
       'Available'
     end
   end
 
-  def auction_status
-    AuctionStatus.new(auction)
+  def bidding_status
+    @_bidding_status ||= BiddingStatus.new(auction)
   end
 end

--- a/app/serializers/auction_serializer.rb
+++ b/app/serializers/auction_serializer.rb
@@ -55,7 +55,7 @@ class AuctionSerializer < ActiveModel::Serializer
   private
 
   def veiled_bids
-    if object.type == 'sealed_bid' && auction_status.available?
+    if object.type == 'sealed_bid' && bidding_status.available?
       object.bids.where(bidder: scope)
     else
       object.bids
@@ -63,7 +63,7 @@ class AuctionSerializer < ActiveModel::Serializer
   end
 
   def find_winning_bid
-    if auction_status.available?
+    if bidding_status.available?
       NullBid.new
     else
       WinningBid.new(object).find
@@ -74,7 +74,7 @@ class AuctionSerializer < ActiveModel::Serializer
     object.customer || NullCustomer.new
   end
 
-  def auction_status
-    @_auction_status ||= AuctionStatus.new(object)
+  def bidding_status
+    @_bidding_status ||= BiddingStatus.new(object)
   end
 end

--- a/app/serializers/bid_serializer.rb
+++ b/app/serializers/bid_serializer.rb
@@ -45,6 +45,6 @@ class BidSerializer < ActiveModel::Serializer
   end
 
   def auction_available?
-    AuctionStatus.new(object.auction).available?
+    BiddingStatus.new(object.auction).available?
   end
 end

--- a/app/services/create_auction_ended_job.rb
+++ b/app/services/create_auction_ended_job.rb
@@ -23,6 +23,6 @@ class CreateAuctionEndedJob
   end
 
   def auction_not_over?
-    !AuctionStatus.new(auction).over?
+    !BiddingStatus.new(auction).over?
   end
 end

--- a/app/view_models/admin/auction_show_view_model.rb
+++ b/app/view_models/admin/auction_show_view_model.rb
@@ -7,7 +7,7 @@ class Admin::AuctionShowViewModel < Admin::BaseViewModel
   end
 
   def csv_report_partial
-    if auction_status.over?
+    if bidding_status.over?
       'admin/auctions/csv_report'
     else
       'components/null'
@@ -108,8 +108,8 @@ class Admin::AuctionShowViewModel < Admin::BaseViewModel
     end
   end
 
-  def auction_status
-    AuctionStatus.new(auction)
+  def bidding_status
+    BiddingStatus.new(auction)
   end
 
   def customer

--- a/app/view_models/admin/bid_list_item.rb
+++ b/app/view_models/admin/bid_list_item.rb
@@ -37,7 +37,7 @@ class Admin::BidListItem
   end
 
   def auction_available?
-    AuctionStatus.new(bid.auction).available?
+    BiddingStatus.new(bid.auction).available?
   end
 
   def bidder_not_user?

--- a/app/view_models/admin/edit_auction_view_model.rb
+++ b/app/view_models/admin/edit_auction_view_model.rb
@@ -86,7 +86,7 @@ class Admin::EditAuctionViewModel < Admin::BaseViewModel
   end
 
   def closed?
-    AuctionStatus.new(auction).over?
+    BiddingStatus.new(auction).over?
   end
 
   def publishable?

--- a/app/view_models/admin/user_auction_view_model.rb
+++ b/app/view_models/admin/user_auction_view_model.rb
@@ -56,7 +56,7 @@ class Admin::UserAuctionViewModel
   end
 
   def auction_over?
-    AuctionStatus.new(auction).over?
+    BiddingStatus.new(auction).over?
   end
 
   def auction_accepted?

--- a/app/view_models/auction_list_item.rb
+++ b/app/view_models/auction_list_item.rb
@@ -86,14 +86,14 @@ class AuctionListItem
   end
 
   def available?
-    auction_status.available?
+    bidding_status.available?
   end
 
   def over?
-    auction_status.over?
+    bidding_status.over?
   end
 
-  def auction_status
-    AuctionStatus.new(auction)
+  def bidding_status
+    BiddingStatus.new(auction)
   end
 end

--- a/app/view_models/auction_show_view_model.rb
+++ b/app/view_models/auction_show_view_model.rb
@@ -164,15 +164,15 @@ class AuctionShowViewModel
   end
 
   def over?
-    auction_status.over?
+    bidding_status.over?
   end
 
   def available?
-    auction_status.available?
+    bidding_status.available?
   end
 
-  def auction_status
-    AuctionStatus.new(auction)
+  def bidding_status
+    @_bidding_status ||= BiddingStatus.new(auction)
   end
 
   def rules

--- a/app/view_models/bid_list_item.rb
+++ b/app/view_models/bid_list_item.rb
@@ -41,7 +41,7 @@ class BidListItem
   end
 
   def auction_available?
-    AuctionStatus.new(bid.auction).available?
+    BiddingStatus.new(bid.auction).available?
   end
 
   def bidder_not_user?

--- a/app/view_models/my_bid_list_item.rb
+++ b/app/view_models/my_bid_list_item.rb
@@ -54,7 +54,7 @@ class MyBidListItem
   private
 
   def available?
-    AuctionStatus.new(auction).available?
+    BiddingStatus.new(auction).available?
   end
 
   def winning_bid

--- a/docs/technical_debt.md
+++ b/docs/technical_debt.md
@@ -132,7 +132,7 @@ the various classes relate:
 7. The `AuctionListItem` class also delegates to methods from an internal
    object. So, a call to `AuctionListItem#available?` within a view
    will actually call an internal variable instance of the
-   [AuctionStatus](../app/models/auction_status.rb) with that
+   [BiddingStatus](../app/models/bidding_status.rb) with that
    method. This approach lets us collect related functions like _all
    the methods for querying the availability of an auction_ in a single
    focused place unlike having them be scattered among many methods in

--- a/spec/models/bidding_status_spec.rb
+++ b/spec/models/bidding_status_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
-describe AuctionStatus do
+describe BiddingStatus do
   describe '#available?' do
     context 'start datetime in past, end datetime in future' do
       it 'is true' do
         auction = FactoryGirl.build(:auction, :available)
-        status = AuctionStatus.new(auction)
+        status = BiddingStatus.new(auction)
         expect(status).to be_available
       end
     end
@@ -13,7 +13,7 @@ describe AuctionStatus do
     context 'start datetime in past, end datetime in past' do
       it 'is false' do
         auction = FactoryGirl.build(:auction, :closed)
-        status = AuctionStatus.new(auction)
+        status = BiddingStatus.new(auction)
         expect(status).not_to be_available
       end
     end
@@ -21,7 +21,7 @@ describe AuctionStatus do
     context 'start datetime in future, end datetime in future' do
       it 'is false' do
         auction = FactoryGirl.build(:auction, :future)
-        status = AuctionStatus.new(auction)
+        status = BiddingStatus.new(auction)
         expect(status).not_to be_available
       end
     end
@@ -29,7 +29,7 @@ describe AuctionStatus do
     context 'the auction is not published' do
       it 'is false' do
         auction = FactoryGirl.build(:auction, :available, published: false)
-        status = AuctionStatus.new(auction)
+        status = BiddingStatus.new(auction)
         expect(status).to_not be_available
       end
     end
@@ -39,7 +39,7 @@ describe AuctionStatus do
     context 'end datetime is in past' do
       it 'is true' do
         auction = FactoryGirl.build(:auction, :closed)
-        status = AuctionStatus.new(auction)
+        status = BiddingStatus.new(auction)
         expect(status).to be_over
       end
     end
@@ -47,7 +47,7 @@ describe AuctionStatus do
     context 'end datetime is in future' do
       it 'is false' do
         auction = FactoryGirl.build(:auction, :future)
-        status = AuctionStatus.new(auction)
+        status = BiddingStatus.new(auction)
         expect(status).not_to be_over
       end
     end
@@ -55,7 +55,7 @@ describe AuctionStatus do
     context 'end datetime is nil' do
       it 'is false' do
         auction = FactoryGirl.build(:auction, ended_at: nil)
-        status = AuctionStatus.new(auction)
+        status = BiddingStatus.new(auction)
         expect(status).not_to be_over
       end
     end
@@ -65,7 +65,7 @@ describe AuctionStatus do
     context 'start datetime is in future' do
       it 'is true' do
         auction = FactoryGirl.build(:auction, :future)
-        status = AuctionStatus.new(auction)
+        status = BiddingStatus.new(auction)
         expect(status).to be_future
       end
     end
@@ -73,7 +73,7 @@ describe AuctionStatus do
     context 'start datetime is in past' do
       it 'is false' do
         auction = FactoryGirl.build(:auction, :available)
-        status = AuctionStatus.new(auction)
+        status = BiddingStatus.new(auction)
         expect(status).not_to be_future
       end
     end
@@ -81,7 +81,7 @@ describe AuctionStatus do
     context 'start datetime is nil' do
       it 'is true' do
         auction = FactoryGirl.build(:auction, started_at: nil)
-        status = AuctionStatus.new(auction)
+        status = BiddingStatus.new(auction)
         expect(status).to be_future
       end
     end
@@ -91,7 +91,7 @@ describe AuctionStatus do
     context 'auction in progress and expiring in less than 12 hours' do
       it 'is true' do
         auction = FactoryGirl.build(:auction, :expiring)
-        status = AuctionStatus.new(auction)
+        status = BiddingStatus.new(auction)
         expect(status).to be_expiring
       end
     end
@@ -99,7 +99,7 @@ describe AuctionStatus do
     context 'auction not started and expiring in less than 12 hours' do
       it 'is false' do
         auction = FactoryGirl.build(:auction, :future)
-        status = AuctionStatus.new(auction)
+        status = BiddingStatus.new(auction)
         expect(status).not_to be_expiring
       end
     end
@@ -107,7 +107,7 @@ describe AuctionStatus do
     context 'auction in progress and expiring in more than 12 hours' do
       it 'is false' do
         auction = FactoryGirl.build(:auction, :available)
-        status = AuctionStatus.new(auction)
+        status = BiddingStatus.new(auction)
         expect(status).not_to be_expiring
       end
     end

--- a/spec/models/rules/sealed_bid_auction_spec.rb
+++ b/spec/models/rules/sealed_bid_auction_spec.rb
@@ -82,7 +82,7 @@ describe Rules::SealedBidAuction do
     it 'should return true if the auction is closed' do
       auction = create(:auction, :sealed_bid)
       rules = Rules::SealedBidAuction.new(auction, eligibility)
-      expect(rules.show_bids?).to eq(!AuctionStatus.new(auction).available?)
+      expect(rules.show_bids?).to eq(!BiddingStatus.new(auction).available?)
     end
   end
 

--- a/spec/serializers/auction_serializer_spec.rb
+++ b/spec/serializers/auction_serializer_spec.rb
@@ -17,7 +17,7 @@ describe AuctionSerializer do
     context 'auction is available' do
       it 'returns null attributes' do
         auction = create(:auction)
-        allow(AuctionStatus).to receive(:new).with(auction).and_return(double(available?: true))
+        allow(BiddingStatus).to receive(:new).with(auction).and_return(double(available?: true))
 
         serializer = AuctionSerializer.new(auction)
 
@@ -30,7 +30,7 @@ describe AuctionSerializer do
         it 'returns winning bid' do
           auction = create(:auction)
           bid = create(:bid, auction: auction)
-          allow(AuctionStatus).to receive(:new).with(auction).and_return(double(available?: false))
+          allow(BiddingStatus).to receive(:new).with(auction).and_return(double(available?: false))
 
           serializer = AuctionSerializer.new(auction)
 


### PR DESCRIPTION
Fixes part of #1247

This PR renames the AuctionStatus class to BiddingStatus. I still have to rename the StatusPresenter classes, but that should be a different PR