### PR TITLE
Rename auction status field to delivery_status

### DIFF
--- a/app/controllers/admin/auction_rejections_controller.rb
+++ b/app/controllers/admin/auction_rejections_controller.rb
@@ -1,7 +1,7 @@
 class Admin::AuctionRejectionsController < Admin::BaseController
   def update
     auction = Auction.find(params[:id])
-    auction.update(status: :rejected, rejected_at: Time.current)
+    auction.update(delivery_status: :rejected, rejected_at: Time.current)
     WinningBidderMailer.auction_rejected(auction: auction).deliver_later
     redirect_to admin_auction_path(auction)
   end

--- a/app/models/admin_auction_status_presenter_factory.rb
+++ b/app/models/admin_auction_status_presenter_factory.rb
@@ -35,7 +35,7 @@ class AdminAuctionStatusPresenterFactory
     elsif auction.payment_confirmed?
       C2StatusPresenter::PaymentConfirmed
     elsif !auction.pending_delivery?
-      Object.const_get("AdminAuctionStatusPresenter::#{status}")
+      Object.const_get("AdminAuctionStatusPresenter::#{delivery_status}")
     else # auction.approved? && auction.pending_delivery?
       C2StatusPresenter::Approved
     end
@@ -49,7 +49,7 @@ class AdminAuctionStatusPresenterFactory
     elsif work_in_progress?
       AdminAuctionStatusPresenter::WorkInProgress
     elsif !auction.pending_delivery?
-      Object.const_get("AdminAuctionStatusPresenter::#{status}")
+      Object.const_get("AdminAuctionStatusPresenter::#{delivery_status}")
     else # available?
       AdminAuctionStatusPresenter::Available
     end
@@ -67,8 +67,8 @@ class AdminAuctionStatusPresenterFactory
     AuctionStatus.new(auction).work_in_progress?
   end
 
-  def status
-    auction.status.camelize
+  def delivery_status
+    auction.delivery_status.camelize
   end
 
   def c2_status

--- a/app/models/auction.rb
+++ b/app/models/auction.rb
@@ -21,7 +21,7 @@ class Auction < ActiveRecord::Base
     payment_confirmed: 5
   }
 
-  enum status: {
+  enum delivery_status: {
     pending_delivery: 0,
     pending_acceptance: 3,
     accepted_pending_payment_url: 4,

--- a/app/models/bid_status_presenter_factory.rb
+++ b/app/models/bid_status_presenter_factory.rb
@@ -35,7 +35,7 @@ class BidStatusPresenterFactory
 
   def over_winning_bidder_message
     if !auction.pending_delivery?
-      Object.const_get("BidStatusPresenter::Over::Vendor::Winner::#{auction.status.camelize}")
+      Object.const_get("BidStatusPresenter::Over::Vendor::Winner::#{auction.delivery_status.camelize}")
     elsif work_in_progress?
       BidStatusPresenter::Over::Vendor::Winner::WorkInProgress
     elsif auction.payment_confirmed?

--- a/app/models/concerns/auction_scopes.rb
+++ b/app/models/concerns/auction_scopes.rb
@@ -2,20 +2,22 @@ module AuctionScopes
   extend ActiveSupport::Concern
 
   included do
-    scope :accepted, -> { where(status: statuses['accepted']) }
-    scope :accepted_pending_payment_url, -> { where(status: statuses['accepted_pending_payment_url']) }
+    scope :accepted, -> { where(delivery_status: delivery_statuses['accepted']) }
+    scope :accepted_pending_payment_url, lambda {
+      where(delivery_status: delivery_statuses['accepted_pending_payment_url'])
+    }
     scope :accepted_or_accepted_and_pending_payment_url, lambda {
-      where(status: [statuses['accepted'],
-                     statuses['accepted_pending_payment_url']])
+      where(delivery_status: [delivery_statuses['accepted'],
+                              delivery_statuses['accepted_pending_payment_url']])
     }
     scope :default_purchase_card, -> { where(purchase_card: 0) }
     scope :delivery_url, -> { where.not(delivery_url: [nil, '']) }
     scope :ended_at_in_future, -> { where('ended_at > ?', Time.current) }
     scope :ended, -> { where('ended_at < ?', Time.current) }
-    scope :evaluated, -> { where(status: [statuses['accepted'], statuses['rejected']]) }
+    scope :evaluated, -> { where(delivery_status: [delivery_statuses['accepted'], delivery_statuses['rejected']]) }
     scope :in_reverse_chron_order, -> { order('ended_at DESC') }
-    scope :pending_acceptance, -> { where(status: statuses['pending_acceptance']) }
-    scope :pending_delivery, -> { where(status: statuses['pending_delivery']) }
+    scope :pending_acceptance, -> { where(delivery_status: delivery_statuses['pending_acceptance']) }
+    scope :pending_delivery, -> { where(delivery_status: delivery_statuses['pending_delivery']) }
     scope :not_paid, -> { where(paid_at: nil) }
     scope :paid, -> { where.not(paid_at: nil) }
     scope :published, -> { where(published: publishes['published']) }

--- a/app/services/accept_auction.rb
+++ b/app/services/accept_auction.rb
@@ -21,10 +21,10 @@ class AcceptAuction
     auction.accepted_at = Time.current
 
     if payment_url.blank?
-      auction.status = :accepted_pending_payment_url
+      auction.delivery_status = :accepted_pending_payment_url
       send_winning_bidder_missing_payment_method_email
     else
-      auction.status = :accepted
+      auction.delivery_status = :accepted
       send_auction_accepted_emails
       update_purchase_request
     end

--- a/app/services/winning_vendor_update_auction.rb
+++ b/app/services/winning_vendor_update_auction.rb
@@ -9,7 +9,7 @@ class WinningVendorUpdateAuction
 
   def perform
     if user_is_winning_bidder? && status.present?
-      auction.update(status: :pending_acceptance)
+      auction.update(delivery_status: :pending_acceptance)
     elsif user_is_winning_bidder? && delivery_url.present?
       auction.update(delivery_url: delivery_url)
     else

--- a/app/view_models/admin/edit_auction_view_model.rb
+++ b/app/view_models/admin/edit_auction_view_model.rb
@@ -58,7 +58,7 @@ class Admin::EditAuctionViewModel < Admin::BaseViewModel
   end
 
   def paid_at_partial
-    if auction.purchase_card == "default" || auction.status != "accepted"
+    if auction.purchase_card == "default" || auction.delivery_status != "accepted"
       'components/null'
     elsif auction.paid_at.present?
       'admin/auctions/disabled_paid_at'

--- a/db/migrate/20160921135321_rename_status_field_in_auction.rb
+++ b/db/migrate/20160921135321_rename_status_field_in_auction.rb
@@ -1,0 +1,5 @@
+class RenameStatusFieldInAuction < ActiveRecord::Migration
+  def change
+    rename_column :auctions, :status, :delivery_status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160826013527) do
+ActiveRecord::Schema.define(version: 20160921135321) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,7 +31,7 @@ ActiveRecord::Schema.define(version: 20160826013527) do
     t.datetime "delivery_due_at",                null: false
     t.text     "notes",           default: ""
     t.string   "billable_to",     default: ""
-    t.integer  "status",          default: 0
+    t.integer  "delivery_status", default: 0
     t.integer  "type",            default: 0
     t.string   "delivery_url"
     t.string   "c2_proposal_url", default: ""
@@ -46,7 +46,7 @@ ActiveRecord::Schema.define(version: 20160826013527) do
   end
 
   add_index "auctions", ["customer_id"], name: "index_auctions_on_customer_id", using: :btree
-  add_index "auctions", ["status"], name: "index_auctions_on_status", using: :btree
+  add_index "auctions", ["delivery_status"], name: "index_auctions_on_delivery_status", using: :btree
   add_index "auctions", ["token"], name: "index_auctions_on_token", unique: true, using: :btree
   add_index "auctions", ["user_id"], name: "index_auctions_on_user_id", using: :btree
 

--- a/spec/factories/auctions.rb
+++ b/spec/factories/auctions.rb
@@ -4,7 +4,7 @@ FactoryGirl.define do
     billable_to "Project (billable)"
     started_at { quartile_minute(Time.now - 3.days) }
     ended_at { quartile_minute(Time.now + 3.days) }
-    status :pending_delivery
+    delivery_status :pending_delivery
     title { Faker::Company.catch_phrase }
     type :reverse
     published :published
@@ -18,7 +18,7 @@ FactoryGirl.define do
     end
 
     after(:create) do |auction, evaluator|
-      evaluator.bidders.each_with_index do |bidder, index|
+      evaluator.bidders.each do |bidder|
         auction.bids << create(:bid, bidder: bidder, auction: auction)
       end
     end
@@ -91,13 +91,13 @@ FactoryGirl.define do
 
     trait :pending_acceptance do
       closed
-      status :pending_acceptance
+      delivery_status :pending_acceptance
     end
 
     trait :accepted do
       closed
       c2_approved
-      status :accepted
+      delivery_status :accepted
       accepted_at { Time.now }
     end
 
@@ -105,13 +105,13 @@ FactoryGirl.define do
       accepted
       c2_approved
       with_bids
-      status :accepted_pending_payment_url
+      delivery_status :accepted_pending_payment_url
     end
 
     trait :rejected do
       closed
       c2_approved
-      status :rejected
+      delivery_status :rejected
       rejected_at { Time.now }
     end
 
@@ -141,12 +141,12 @@ FactoryGirl.define do
       end
     end
 
-   trait :pending_c2_approval do
-     future
-     c2_status :pending_approval
-     purchase_card :default
-     unpublished
-   end
+    trait :pending_c2_approval do
+      future
+      c2_status :pending_approval
+      purchase_card :default
+      unpublished
+    end
 
     trait :c2_approved do
       c2_proposal_url 'https://c2-dev.18f.gov/proposals/2486'

--- a/spec/models/admin_auction_status_presenter_factory_spec.rb
+++ b/spec/models/admin_auction_status_presenter_factory_spec.rb
@@ -21,7 +21,7 @@ describe AdminAuctionStatusPresenterFactory do
 
   context "when an auction has been accepted but doesn't have a payment URL yet" do
     it 'should return a AdminAuctionStatusPresenter::AcceptedPendingPaymentUrl' do
-      auction = create(:auction, :closed, :with_bids, :published, status: :accepted_pending_payment_url)
+      auction = create(:auction, :closed, :with_bids, :published, delivery_status: :accepted_pending_payment_url)
 
       expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
         .to be_a(AdminAuctionStatusPresenter::AcceptedPendingPaymentUrl)
@@ -75,7 +75,7 @@ describe AdminAuctionStatusPresenterFactory do
 
   context 'when auction is closed, pending delivery' do
     it 'should return the correct presenter' do
-      auction = create(:auction, :c2_approved, :closed, status: :pending_delivery)
+      auction = create(:auction, :c2_approved, :closed, delivery_status: :pending_delivery)
 
       expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
         .to be_a(C2StatusPresenter::Approved)

--- a/spec/models/auction_query_spec.rb
+++ b/spec/models/auction_query_spec.rb
@@ -7,7 +7,7 @@ describe AuctionQuery do
       create(:auction, :complete_and_successful)
     end
     let!(:available_auction) { create(:auction, :available) }
-    let!(:rejected_auction) { create(:auction, status: :rejected) }
+    let!(:rejected_auction) { create(:auction, delivery_status: :rejected) }
     let!(:unpaid_auction) do
       create(:auction, :not_paid)
     end
@@ -23,7 +23,7 @@ describe AuctionQuery do
     let!(:complete_and_successful) do
       create(:auction, :complete_and_successful)
     end
-    let!(:rejected_auction) { create(:auction, status: :rejected) }
+    let!(:rejected_auction) { create(:auction, delivery_status: :rejected) }
 
     it 'should only return unpublished auctions' do
       expect(query.rejected).to match_array([rejected_auction])
@@ -36,13 +36,13 @@ describe AuctionQuery do
       _payment_needed_other_pcard = create(
         :auction,
         purchase_card: :other,
-        status: :accepted,
+        delivery_status: :accepted,
         accepted_at: Time.current
       )
       c2_payment_needed = create(
         :auction,
         purchase_card: :default,
-        status: :accepted,
+        delivery_status: :accepted,
         accepted_at: Time.current
       )
 
@@ -56,13 +56,13 @@ describe AuctionQuery do
       payment_needed_other_pcard = create(
         :auction,
         purchase_card: :other,
-        status: :accepted,
+        delivery_status: :accepted,
         accepted_at: Time.current
       )
       c2_payment_needed = create(
         :auction,
         purchase_card: :default,
-        status: :accepted,
+        delivery_status: :accepted,
         accepted_at: Time.current
       )
 

--- a/spec/models/statistics/average_delivery_time_spec.rb
+++ b/spec/models/statistics/average_delivery_time_spec.rb
@@ -12,14 +12,14 @@ describe Statistics::AverageDeliveryTime do
       it 'returns average time between end date and accepted_at date' do
         _auction_accepted_after_6_days = create(
           :auction,
-          status: :accepted,
+          delivery_status: :accepted,
           ended_at: 6.days.ago,
           delivery_due_at: 3.days.ago,
           accepted_at: Time.current
         )
         _auction_accepted_after_2_days = create(
           :auction,
-          status: :accepted,
+          delivery_status: :accepted,
           ended_at: 4.days.ago,
           delivery_due_at: 1.day.ago,
           accepted_at: 2.days.ago

--- a/spec/services/accept_auction_spec.rb
+++ b/spec/services/accept_auction_spec.rb
@@ -57,7 +57,7 @@ describe AcceptAuction do
         expect(WinningBidderMailer).to have_received(:auction_accepted_missing_payment_method)
           .with(auction: auction)
         expect(mailer_double).to have_received(:deliver_later)
-        expect(auction.status).to eq 'accepted_pending_payment_url'
+        expect(auction.delivery_status).to eq 'accepted_pending_payment_url'
       end
     end
 

--- a/spec/services/update_user_spec.rb
+++ b/spec/services/update_user_spec.rb
@@ -73,7 +73,7 @@ describe UpdateUser do
   context 'payment_url is updated for winning vendor' do
     context 'payment_url set to valid value' do
       it 'calls AcceptAuction' do
-        auction = create(:auction, :with_bids, status: :accepted_pending_payment_url)
+        auction = create(:auction, :with_bids, delivery_status: :accepted_pending_payment_url)
         winning_bidder = WinningBid.new(auction).find.bidder
         winning_bidder.update(payment_url: '')
         accepter = double(perform: true)
@@ -93,7 +93,7 @@ describe UpdateUser do
 
     context 'payment_url set to invalid value' do
       it 'does not calls AcceptAuction' do
-        auction = create(:auction, :with_bids, status: :accepted_pending_payment_url)
+        auction = create(:auction, :with_bids, delivery_status: :accepted_pending_payment_url)
         winning_bidder = WinningBid.new(auction).find.bidder
         winning_bidder.update(payment_url: '')
         accepter = double(perform: true)


### PR DESCRIPTION
Fixes part of #1247

This is to make more clear how it is different from the bidding status (formerly known as AuctionStatus) and c2_status