### PR TITLE
Rename status presenters to bidding_status presenters

### DIFF
--- a/app/models/bidding_status_presenter_factory.rb
+++ b/app/models/bidding_status_presenter_factory.rb
@@ -1,4 +1,4 @@
-class StatusPresenterFactory
+class BiddingStatusPresenterFactory
   attr_reader :auction
 
   def initialize(auction)
@@ -6,7 +6,7 @@ class StatusPresenterFactory
   end
 
   def create
-    Object.const_get("StatusPresenter::#{status_name}").new(auction)
+    Object.const_get("BiddingStatusPresenter::#{status_name}").new(auction)
   end
 
   private

--- a/app/presenters/bidding_status_presenter/available.rb
+++ b/app/presenters/bidding_status_presenter/available.rb
@@ -1,4 +1,4 @@
-class StatusPresenter::Available < StatusPresenter::Base
+class BiddingStatusPresenter::Available < BiddingStatusPresenter::Base
   def start_label
     "Bid start time"
   end

--- a/app/presenters/bidding_status_presenter/base.rb
+++ b/app/presenters/bidding_status_presenter/base.rb
@@ -1,4 +1,4 @@
-class StatusPresenter::Base
+class BiddingStatusPresenter::Base
   attr_reader :auction
 
   def initialize(auction)

--- a/app/presenters/bidding_status_presenter/expiring.rb
+++ b/app/presenters/bidding_status_presenter/expiring.rb
@@ -1,4 +1,4 @@
-class StatusPresenter::Expiring < StatusPresenter::Available
+class BiddingStatusPresenter::Expiring < BiddingStatusPresenter::Available
   def label_class
     'auction-label-expiring'
   end

--- a/app/presenters/bidding_status_presenter/future.rb
+++ b/app/presenters/bidding_status_presenter/future.rb
@@ -1,4 +1,4 @@
-class StatusPresenter::Future < StatusPresenter::Base
+class BiddingStatusPresenter::Future < BiddingStatusPresenter::Base
   def start_label
     "Bid start time"
   end

--- a/app/presenters/bidding_status_presenter/over.rb
+++ b/app/presenters/bidding_status_presenter/over.rb
@@ -1,4 +1,4 @@
-class StatusPresenter::Over < StatusPresenter::Base
+class BiddingStatusPresenter::Over < BiddingStatusPresenter::Base
   def start_label
     "Auction started at"
   end

--- a/app/view_models/admin/auction_show_view_model.rb
+++ b/app/view_models/admin/auction_show_view_model.rb
@@ -26,8 +26,8 @@ class Admin::AuctionShowViewModel < Admin::BaseViewModel
     AdminAuctionStatusPresenterFactory.new(auction: auction).create
   end
 
-  def status_presenter
-    @_status_presenter ||= StatusPresenterFactory.new(auction).create
+  def bidding_status_presenter
+    @_status_presenter ||= BiddingStatusPresenterFactory.new(auction).create
   end
 
   def admin_data
@@ -60,7 +60,7 @@ class Admin::AuctionShowViewModel < Admin::BaseViewModel
   end
 
   def relative_time
-    status_presenter.relative_time
+    bidding_status_presenter.relative_time
   end
 
   def veiled_bids

--- a/app/view_models/admin/user_auction_view_model.rb
+++ b/app/view_models/admin/user_auction_view_model.rb
@@ -17,8 +17,8 @@ class Admin::UserAuctionViewModel
     auction.id
   end
 
-  def status
-    StatusPresenterFactory.new(auction).create.label
+  def bidding_status
+    BiddingStatusPresenterFactory.new(auction).create.label
   end
 
   def skills

--- a/app/view_models/auction_list_item.rb
+++ b/app/view_models/auction_list_item.rb
@@ -64,7 +64,7 @@ class AuctionListItem
   end
 
   def relative_time
-    status_presenter.relative_time
+    bidding_status_presenter.relative_time
   end
 
   def winning_bid_amount_as_currency
@@ -75,8 +75,8 @@ class AuctionListItem
     end
   end
 
-  def status_presenter
-    @_status_presenter ||= StatusPresenterFactory.new(auction).create
+  def bidding_status_presenter
+    @_status_presenter ||= BiddingStatusPresenterFactory.new(auction).create
   end
 
   private

--- a/app/view_models/auction_show_view_model.rb
+++ b/app/view_models/auction_show_view_model.rb
@@ -33,8 +33,8 @@ class AuctionShowViewModel
 
   def auction_data
     {
-      status_presenter.start_label => formatted_date(auction.started_at),
-      status_presenter.deadline_label => formatted_ended_at,
+      bidding_status_presenter.start_label => formatted_date(auction.started_at),
+      bidding_status_presenter.deadline_label => formatted_ended_at,
       'Delivery deadline' => formatted_date(auction.delivery_due_at),
       'Eligible vendors' => eligibility_label,
       'Customer' => customer.agency_name
@@ -53,8 +53,8 @@ class AuctionShowViewModel
     auction.type.dasherize.capitalize
   end
 
-  def status_presenter
-    @_status_presenter ||= StatusPresenterFactory.new(auction).create
+  def bidding_status_presenter
+    @_status_presenter ||= BiddingStatusPresenterFactory.new(auction).create
   end
 
   def bid_status_presenter
@@ -105,15 +105,15 @@ class AuctionShowViewModel
   end
 
   def tag_data_value_status
-    status_presenter.tag_data_value_status
+    bidding_status_presenter.tag_data_value_status
   end
 
   def tag_data_label_2
-    status_presenter.tag_data_label_2
+    bidding_status_presenter.tag_data_label_2
   end
 
   def tag_data_value_2
-    status_presenter.tag_data_value_2
+    bidding_status_presenter.tag_data_value_2
   end
 
   def highlighted_bid_amount_as_currency
@@ -125,7 +125,7 @@ class AuctionShowViewModel
   end
 
   def relative_time
-    status_presenter.relative_time
+    bidding_status_presenter.relative_time
   end
 
   def sealed_bids_partial

--- a/app/views/admin/auctions/show.html.erb
+++ b/app/views/admin/auctions/show.html.erb
@@ -3,7 +3,7 @@
     <div class='usa-width-one-whole issue-label'>
       <h3 class='issue-title'>
         <div class="issue-ribbon">
-          <%= render partial: 'auctions/status_ribbon', locals: { status: @view_model.status_presenter } %>
+          <%= render partial: 'auctions/status_ribbon', locals: { status: @view_model.bidding_status_presenter } %>
         </div>
       </h3>
     </div>

--- a/app/views/admin/users/_bid_history.html.erb
+++ b/app/views/admin/users/_bid_history.html.erb
@@ -15,7 +15,7 @@
     <% view_model.user_auctions.each do |auction| %>
       <tr>
         <td><%= link_to auction.title, admin_auction_path(auction.id) %></td>
-        <td><%= auction.status %></td>
+        <td><%= auction.bidding_status %></td>
         <td><%= auction.skills %></td>
         <td><%= auction.user_bid_count %></td>
         <td><%= auction.user_won_label %></td>

--- a/app/views/auctions/_list_item.html.erb
+++ b/app/views/auctions/_list_item.html.erb
@@ -5,7 +5,7 @@
 
       <div class="issue-vitals">
         <div class="issue-bid-deadline">
-          <%= render partial: 'auctions/status_ribbon', locals: { status: auction.status_presenter } %>
+          <%= render partial: 'auctions/status_ribbon', locals: { status: auction.bidding_status_presenter } %>
           <%= auction.relative_time %>
         </div>
         <div class="winning-bid-detail">

--- a/app/views/auctions/show.html.erb
+++ b/app/views/auctions/show.html.erb
@@ -19,7 +19,7 @@
     <div class="usa-width-one-whole issue-label">
       <h3 class="issue-title">
         <div class="issue-ribbon">
-          <%= render partial: 'auctions/status_ribbon', locals: { status: @view_model.status_presenter } %>
+          <%= render partial: 'auctions/status_ribbon', locals: { status: @view_model.bidding_status_presenter } %>
         </div>
       </h3>
     </div>

--- a/features/step_definitions/admin_views_user_steps.rb
+++ b/features/step_definitions/admin_views_user_steps.rb
@@ -27,7 +27,7 @@ Then(/^in that section I should see a table of the user's bids$/) do
 
   values = [
     view_model.title,
-    view_model.status,
+    view_model.bidding_status,
     view_model.skills,
     view_model.user_bid_count,
     view_model.user_won_label,

--- a/spec/presenters/bidding_status_presenter/available_spec.rb
+++ b/spec/presenters/bidding_status_presenter/available_spec.rb
@@ -1,30 +1,30 @@
 require 'rails_helper'
 
-describe StatusPresenter::Available do
+describe BiddingStatusPresenter::Available do
   describe '#tag_data_value_status' do
     it "has a twitter status data value with human readable time expression" do
-      presenter = StatusPresenter::Available.new(auction)
+      presenter = BiddingStatusPresenter::Available.new(auction)
       expect(presenter.tag_data_value_status).to eq("2 days left")
     end
   end
 
   describe '#tag_data_label_2' do
     it "has a twitter second label that indicates bidding is open" do
-      presenter = StatusPresenter::Available.new(auction)
+      presenter = BiddingStatusPresenter::Available.new(auction)
       expect(presenter.tag_data_label_2).to eq("Bidding")
     end
   end
 
   describe '#tag_data_value_2' do
     it "has some weird value associated with the bidding label" do
-      presenter = StatusPresenter::Available.new(auction)
+      presenter = BiddingStatusPresenter::Available.new(auction)
       expect(presenter.tag_data_value_2).to eq("$3,000.00 - 1 bids")
     end
   end
 
   describe '#relative_time' do
     it 'returns time remaining' do
-      presenter = StatusPresenter::Available.new(auction)
+      presenter = BiddingStatusPresenter::Available.new(auction)
       expect(presenter.relative_time).to eq("Ending in 2 days")
     end
   end

--- a/spec/presenters/bidding_status_presenter/expiring_spec.rb
+++ b/spec/presenters/bidding_status_presenter/expiring_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
-describe StatusPresenter::Expiring do
+describe BiddingStatusPresenter::Expiring do
   describe '#label_class' do
     it 'returns the correct label class' do
       auction = build(:auction)
 
-      presenter = StatusPresenter::Expiring.new(auction)
+      presenter = BiddingStatusPresenter::Expiring.new(auction)
 
       expect(presenter.label_class).to eq 'auction-label-expiring'
     end
@@ -15,7 +15,7 @@ describe StatusPresenter::Expiring do
     it 'returns the correct label' do
       auction = build(:auction)
 
-      presenter = StatusPresenter::Expiring.new(auction)
+      presenter = BiddingStatusPresenter::Expiring.new(auction)
 
       expect(presenter.label).to eq 'Expiring'
     end

--- a/spec/presenters/bidding_status_presenter/future_spec.rb
+++ b/spec/presenters/bidding_status_presenter/future_spec.rb
@@ -1,23 +1,23 @@
 require 'rails_helper'
 
-describe StatusPresenter::Future do
+describe BiddingStatusPresenter::Future do
   describe '#tag_data_value_status' do
     it "returns human readable time" do
-      presenter = StatusPresenter::Future.new(auction)
+      presenter = BiddingStatusPresenter::Future.new(auction)
       expect(presenter.tag_data_value_status).to eq("in 3 days")
     end
   end
 
   describe '#tag_data_label_2' do
     it "returns starting bid" do
-      presenter = StatusPresenter::Future.new(auction)
+      presenter = BiddingStatusPresenter::Future.new(auction)
       expect(presenter.tag_data_label_2).to eq("Starting bid")
     end
   end
 
   describe '#tag_data_value_2' do
     it "returns start price" do
-      presenter = StatusPresenter::Future.new(auction)
+      presenter = BiddingStatusPresenter::Future.new(auction)
       expect(presenter.tag_data_value_2).to eq("$3,500.00")
     end
   end
@@ -28,7 +28,7 @@ describe StatusPresenter::Future do
         time = Time.current + 1.day
         auction = create(:auction, :future, started_at: time)
 
-        presenter = StatusPresenter::Future.new(auction)
+        presenter = BiddingStatusPresenter::Future.new(auction)
 
         expect(presenter.relative_time).to eq 'Starting in 1 day'
       end

--- a/spec/presenters/bidding_status_presenter/over_spec.rb
+++ b/spec/presenters/bidding_status_presenter/over_spec.rb
@@ -1,23 +1,23 @@
 require 'rails_helper'
 
-describe StatusPresenter::Over do
+describe BiddingStatusPresenter::Over do
   describe '#tag_data_value_status' do
     it 'is closed' do
-      presenter = StatusPresenter::Over.new(auction)
+      presenter = BiddingStatusPresenter::Over.new(auction)
       expect(presenter.tag_data_value_status).to eq('Closed')
     end
   end
 
   describe '#tag_data_label_2' do
     it 'has a label about the winning bid amount' do
-      presenter = StatusPresenter::Over.new(auction)
+      presenter = BiddingStatusPresenter::Over.new(auction)
       expect(presenter.tag_data_label_2).to eq('Winning Bid')
     end
   end
 
   describe '#tag_data_value_2' do
     it 'returns winning bid amount' do
-      presenter = StatusPresenter::Over.new(auction)
+      presenter = BiddingStatusPresenter::Over.new(auction)
       expect(presenter.tag_data_value_2).to eq('$3,000.00')
     end
   end
@@ -27,7 +27,7 @@ describe StatusPresenter::Over do
       time = Time.local(2008, 9, 1)
       auction = create(:auction, :closed, ended_at: time)
 
-      presenter = StatusPresenter::Over.new(auction)
+      presenter = BiddingStatusPresenter::Over.new(auction)
 
       expect(presenter.relative_time).to eq 'Ended on: 09/01/2008'
     end

--- a/spec/view_models/admin/user_auction_view_model_spec.rb
+++ b/spec/view_models/admin/user_auction_view_model_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
 describe Admin::UserAuctionViewModel do
-  describe '#status' do
-    it 'should return the auction status' do
+  describe '#bidding_status' do
+    it 'should return the auction bidding status' do
       auction = create(:auction, :available)
 
-      expect(Admin::UserAuctionViewModel.new(auction, user).status).to eq('Open')
+      expect(Admin::UserAuctionViewModel.new(auction, user).bidding_status).to eq('Open')
     end
   end
 


### PR DESCRIPTION
**Merge after #1271**

This renames the StatusPresenter classes to be BiddingStatusPresenter (unfortunately, we now also have BidStatusPresenter too) as a followup to #1271.

Fixes #1247 