### PR TITLE
Fix fonts for asset pipeline

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -4,6 +4,7 @@
 @import 'c3.min';
 @import 'selectize.bootstrap3';
 
+@import 'core/fonts';
 @import 'core/variables';
 @import 'core/mixins';
 @import 'core/elements';

--- a/app/assets/stylesheets/core/_fonts.scss
+++ b/app/assets/stylesheets/core/_fonts.scss
@@ -1,0 +1,35 @@
+@include font-face(
+  'Source Sans Pro',
+  '#{$font-path}/sourcesanspro-light-webfont',
+  300,
+  normal,
+  $asset-pipeline: true,
+  $file-formats: eot woff2 woff ttf
+);
+
+@include font-face(
+  'Source Sans Pro',
+  '#{$font-path}/sourcesanspro-regular-webfont',
+  400,
+  normal,
+  $asset-pipeline: true,
+  $file-formats: eot woff2 woff ttf
+);
+
+@include font-face(
+  'Source Sans Pro',
+  '#{$font-path}/sourcesanspro-italic-webfont',
+  400,
+  italic,
+  $asset-pipeline: true,
+  $file-formats: eot woff2 woff ttf
+);
+
+@include font-face(
+  'Source Sans Pro',
+  '#{$font-path}/sourcesanspro-bold-webfont',
+  700,
+  normal,
+  $asset-pipeline: true,
+  $file-formats: eot woff2 woff ttf
+);


### PR DESCRIPTION
* Fonts not loading properly on prod because they didn't have digest
* We thought that declaring $asset-pipeline: true` in defaults would
  do this but we were wrong
* Will fix in the gem next and then update back here