### PR TITLE
Modify admin accepted text to link to C2 URL

### DIFF
--- a/app/presenters/admin_auction_status_presenter/accepted.rb
+++ b/app/presenters/admin_auction_status_presenter/accepted.rb
@@ -7,11 +7,16 @@ class AdminAuctionStatusPresenter::Accepted < AdminAuctionStatusPresenter::Base
     I18n.t(
       'statuses.admin_auction_status_presenter.accepted.body',
       accepted_at: accepted_at,
-      winner_url: winner_url
+      winner_url: winner_url,
+      c2_url: c2_url
     )
   end
 
   private
+
+  def c2_url
+    auction.c2_proposal_url
+  end
 
   def accepted_at
     DcTimePresenter.convert_and_format(auction.accepted_at)

--- a/config/locales/statuses/en.yml
+++ b/config/locales/statuses/en.yml
@@ -146,8 +146,11 @@ en:
           was accepted. However, this vendor cannot
           be paid until they’ve specified a valid payment URL.
       accepted:
-        header: "Accepted"
-        body: "%{winner_url}'s delivered code was accepted on %{accepted_at}."
+        header: Accepted
+        body: >
+          %{winner_url}'s delivered code was accepted on
+          %{accepted_at}. The p-card holder has been asked (via <a
+          href="%{c2_url}">C2</a>) to remit payment.
       rejected:
         header: "Rejected"
         body: "<a href=%{delivery_url}>%{winner_name}'s work</a> was rejected on %{rejected_at}."

--- a/features/step_definitions/auction_status_steps.rb
+++ b/features/step_definitions/auction_status_steps.rb
@@ -142,7 +142,8 @@ Then(/^I should see the admin status for an accepted auction$/) do
     I18n.t(
       'statuses.admin_auction_status_presenter.accepted.body',
       winner_url: winner_url,
-      accepted_at: accepted_date
+      accepted_at: accepted_date,
+      c2_url: @auction.c2_proposal_url
     )
   )
 end


### PR DESCRIPTION
Fixes #1197 

We decided to just edit the current message that admins see for accepted auctions to also include the C2 URL. Trying this

![localhost_3000_admin_auctions_12](https://cloud.githubusercontent.com/assets/2044/18771220/1026d30e-810b-11e6-95cb-256cfbbc2b78.jpg)
