### PR TITLE
Incremental auction status refactor

### DIFF
--- a/app/assets/javascripts/publishedToggle.js
+++ b/app/assets/javascripts/publishedToggle.js
@@ -6,7 +6,7 @@ $(document).ready(function() {
     published_option = "<option value='published'>published</option>"
     unpublished_option = "<option value='unpublished'>unpublished</option>"
 
-    if(this.value === "default" && c2_status !== "approved") {
+    if(this.value === "default" && c2_status !== "budget_approved") {
       published_select_element.empty().append(unpublished_option)
     } else {
       published_select_element.empty().append(unpublished_option, published_option)

--- a/app/models/admin_auction_status_presenter_factory.rb
+++ b/app/models/admin_auction_status_presenter_factory.rb
@@ -28,16 +28,22 @@ class AdminAuctionStatusPresenterFactory
       AdminAuctionStatusPresenter::ReadyToPublish
     elsif available?
       AdminAuctionStatusPresenter::Available
-    elsif work_in_progress?
+    elsif auction.budget_approved? && auction.pending_delivery?
+      C2StatusPresenter::Approved
+    elsif auction.work_in_progress?
       AdminAuctionStatusPresenter::WorkInProgress
+    elsif auction.pending_acceptance?
+      AdminAuctionStatusPresenter::PendingAcceptance
+    elsif auction.accepted_pending_payment_url?
+      AdminAuctionStatusPresenter::AcceptedPendingPaymentUrl
+    elsif auction.accepted? && !(auction.c2_paid? || auction.payment_confirmed?)
+      AdminAuctionStatusPresenter::Accepted
+    elsif auction.rejected?
+      AdminAuctionStatusPresenter::Rejected
     elsif auction.c2_paid?
       C2StatusPresenter::C2Paid
-    elsif auction.payment_confirmed?
+    else # auction.payment_confirmed?
       C2StatusPresenter::PaymentConfirmed
-    elsif !auction.pending_delivery?
-      Object.const_get("AdminAuctionStatusPresenter::#{delivery_status}")
-    else # auction.approved? && auction.pending_delivery?
-      C2StatusPresenter::Approved
     end
   end
 
@@ -46,12 +52,18 @@ class AdminAuctionStatusPresenterFactory
       AdminAuctionStatusPresenter::Future
     elsif future? && auction.unpublished?
       AdminAuctionStatusPresenter::ReadyToPublish
-    elsif work_in_progress?
-      AdminAuctionStatusPresenter::WorkInProgress
-    elsif !auction.pending_delivery?
-      Object.const_get("AdminAuctionStatusPresenter::#{delivery_status}")
-    else # available?
+    elsif available?
       AdminAuctionStatusPresenter::Available
+    elsif auction.work_in_progress?
+      AdminAuctionStatusPresenter::WorkInProgress
+    elsif auction.pending_acceptance?
+      AdminAuctionStatusPresenter::PendingAcceptance
+    elsif auction.accepted_pending_payment_url?
+      AdminAuctionStatusPresenter::AcceptedPendingPaymentUrl
+    elsif auction.accepted?
+      AdminAuctionStatusPresenter::Accepted
+    else # auction.rejected?
+      AdminAuctionStatusPresenter::Rejected
     end
   end
 
@@ -61,10 +73,6 @@ class AdminAuctionStatusPresenterFactory
 
   def future?
     bidding_status.future?
-  end
-
-  def work_in_progress?
-    auction.work_in_progress?
   end
 
   def bidding_status

--- a/app/models/auction.rb
+++ b/app/models/auction.rb
@@ -16,7 +16,7 @@ class Auction < ActiveRecord::Base
     not_requested: 0,
     sent: 2,
     pending_approval: 1,
-    approved: 3,
+    budget_approved: 3,
     c2_paid: 4,
     payment_confirmed: 5
   }
@@ -56,8 +56,8 @@ class Auction < ActiveRecord::Base
   validate :publishing_auction, on: :update, if: :published_changed?
 
   def publishing_auction
-    if published_was == 'unpublished' && purchase_card == 'default' && c2_status != 'approved'
-      errors.add(:c2_status, " is not approved.")
+    if published_was == 'unpublished' && purchase_card == 'default' && c2_status != 'budget_approved'
+      errors.add(:c2_status, " is not budget approved.")
     end
   end
 

--- a/app/services/check_approval.rb
+++ b/app/services/check_approval.rb
@@ -6,10 +6,10 @@ class CheckApproval < C2ApiWrapper
   def perform
     auctions.each do |auction|
       next if auction.c2_proposal_url.blank? || auction.invalid?
-      approved_at = find_approval_timestamp(proposal_json(auction))
+      budget_approved_at = find_approval_timestamp(proposal_json(auction))
 
-      if approved_at
-        auction.update(c2_status: :approved)
+      if budget_approved_at
+        auction.update(c2_status: :budget_approved)
       end
     end
   end

--- a/app/services/update_auction.rb
+++ b/app/services/update_auction.rb
@@ -8,7 +8,7 @@ class UpdateAuction
   def perform
     assign_attributes
     update_auction_ended_job
-    perform_approved_auction_tasks
+    perform_budget_approved_auction_tasks
     perform_rejected_auction_tasks
     auction.save
   end
@@ -47,7 +47,7 @@ class UpdateAuction
     parsed_attributes.key?(:ended_at)
   end
 
-  def perform_approved_auction_tasks
+  def perform_budget_approved_auction_tasks
     if auction.accepted? && auction.accepted_at.nil? && auction.bids.any?
       AcceptAuction.new(
         auction: auction,

--- a/app/view_models/admin/edit_auction_view_model.rb
+++ b/app/view_models/admin/edit_auction_view_model.rb
@@ -91,6 +91,6 @@ class Admin::EditAuctionViewModel < Admin::BaseViewModel
 
   def publishable?
     closed? || auction.purchase_card == 'other' ||
-      auction.c2_status == 'approved'
+      auction.c2_status == 'budget_approved'
   end
 end

--- a/features/admin_accepts_auction.feature
+++ b/features/admin_accepts_auction.feature
@@ -1,6 +1,6 @@
 Feature: Admin accepts delivery of a project
   As an admin
-  I want to set an auction status to be approved
+  I want to set an auction status to be budget approved
   So the vendor can get paid
 
   Scenario: Marking an auction as accepted successfully

--- a/features/admin_publishes_auction.feature
+++ b/features/admin_publishes_auction.feature
@@ -2,21 +2,21 @@ Feature: Admin publishes auction in the admin panel
   As an admin
   I should be able to publish auctions
 
-  Scenario: Auction is C2 approved and uses default purchase card
+  Scenario: Auction is C2 budget approved and uses default purchase card
     Given I am an administrator
     And I sign in
     And there is an unpublished auction
     And the auction is for the default purchase card
-    And the c2 proposal for the auction is approved
+    And the c2 proposal for the auction is budget approved
     When I visit the admin form for that auction
     Then I should be able to set the auction to published
 
-  Scenario: Auction is not C2 approved and uses default purchase card
+  Scenario: Auction is not C2 budget approved and uses default purchase card
     Given I am an administrator
     And I sign in
     And there is an unpublished auction
     And the auction is for the default purchase card
-    And the c2 proposal for the auction is not approved
+    And the c2 proposal for the auction is not budget approved
     When I visit the admin form for that auction
     Then I should not be able to set the auction to published
 

--- a/features/step_definitions/auction_create_steps.rb
+++ b/features/step_definitions/auction_create_steps.rb
@@ -41,7 +41,7 @@ Given(/^I am going to lose an auction$/) do
 end
 
 Given(/^there is an auction with work in progress$/) do
-  @auction = FactoryGirl.create(:auction, :c2_approved, :work_in_progress)
+  @auction = FactoryGirl.create(:auction, :c2_budget_approved, :work_in_progress)
 end
 
 When(/^the auction ends$/) do
@@ -79,7 +79,7 @@ Given(/^there is an open bidless auction$/) do
 end
 
 Given(/^there is an open auction$/) do
-  @auction = FactoryGirl.create(:auction, :with_bids, :available, :c2_approved)
+  @auction = FactoryGirl.create(:auction, :with_bids, :available, :c2_budget_approved)
 end
 
 Given(/^there is an open auction with some skills$/) do
@@ -89,11 +89,11 @@ Given(/^there is an open auction with some skills$/) do
 end
 
 Given(/^there is a budget approved auction with bids$/) do
-  @auction = FactoryGirl.create(:auction, :c2_approved, :with_bids)
+  @auction = FactoryGirl.create(:auction, :c2_budget_approved, :with_bids)
 end
 
 Given(/^there is a budget approved auction with no bids$/) do
-  @auction = FactoryGirl.create(:auction, :c2_approved)
+  @auction = FactoryGirl.create(:auction, :c2_budget_approved)
 end
 
 Given(/^there is a sealed-bid auction$/) do
@@ -109,7 +109,7 @@ Given(/^there is a closed sealed-bid auction$/) do
 end
 
 Given(/^there is an auction that needs evaluation$/) do
-   @auction = FactoryGirl.create(:auction, :with_bids, :evaluation_needed, :c2_approved)
+   @auction = FactoryGirl.create(:auction, :with_bids, :evaluation_needed, :c2_budget_approved)
 end
 
 Given(/^there is an auction within the simplified acquisition threshold$/) do
@@ -157,7 +157,7 @@ end
 Given(/^there is an auction where the winning vendor is not eligible to be paid$/) do
   @auction = FactoryGirl.create(
     :auction,
-    :c2_approved,
+    :c2_budget_approved,
     :pending_acceptance,
     :between_micropurchase_and_sat_threshold,
     :winning_vendor_is_non_small_business
@@ -176,11 +176,11 @@ Given(/^the auction is for a different purchase card$/) do
   @auction.update(purchase_card: :other)
 end
 
-Given(/^the c2 proposal for the auction is approved$/) do
-  @auction.update(c2_status: :approved)
+Given(/^the c2 proposal for the auction is budget approved$/) do
+  @auction.update(c2_status: :budget_approved)
 end
 
-Given(/^the c2 proposal for the auction is not approved$/) do
+Given(/^the c2 proposal for the auction is not budget approved$/) do
   @auction.update(c2_status: :not_requested)
 end
 

--- a/spec/factories/auctions.rb
+++ b/spec/factories/auctions.rb
@@ -36,7 +36,7 @@ FactoryGirl.define do
     end
 
     trait :published do
-      c2_approved
+      c2_budget_approved
       published :published
     end
 
@@ -96,14 +96,14 @@ FactoryGirl.define do
 
     trait :accepted do
       closed
-      c2_approved
+      c2_budget_approved
       delivery_status :accepted
       accepted_at { Time.now }
     end
 
     trait :accepted_pending_payment_url do
       accepted
-      c2_approved
+      c2_budget_approved
       with_bids
       delivery_status :accepted_pending_payment_url
     end
@@ -117,7 +117,7 @@ FactoryGirl.define do
 
     trait :rejected do
       closed
-      c2_approved
+      c2_budget_approved
       delivery_status :rejected
       rejected_at { Time.now }
     end
@@ -155,14 +155,14 @@ FactoryGirl.define do
       unpublished
     end
 
-    trait :c2_approved do
+    trait :c2_budget_approved do
       c2_proposal_url 'https://c2-dev.18f.gov/proposals/2486'
-      c2_status :approved
+      c2_status :budget_approved
     end
 
     trait :evaluation_needed do
       closed
-      c2_approved
+      c2_budget_approved
       with_bids
       delivery_url
       pending_acceptance

--- a/spec/models/admin_auction_status_presenter_factory_spec.rb
+++ b/spec/models/admin_auction_status_presenter_factory_spec.rb
@@ -66,7 +66,7 @@ describe AdminAuctionStatusPresenterFactory do
 
   context 'when auction is available' do
     it 'should return the correct presenter' do
-      auction = create(:auction, :c2_approved, :available)
+      auction = create(:auction, :c2_budget_approved, :available)
 
       expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
         .to be_a(AdminAuctionStatusPresenter::Available)
@@ -75,7 +75,7 @@ describe AdminAuctionStatusPresenterFactory do
 
   context 'when auction is closed, pending delivery' do
     it 'should return the correct presenter' do
-      auction = create(:auction, :c2_approved, :closed, delivery_status: :pending_delivery)
+      auction = create(:auction, :c2_budget_approved, :closed, delivery_status: :pending_delivery)
 
       expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
         .to be_a(C2StatusPresenter::Approved)

--- a/spec/models/auction_spec.rb
+++ b/spec/models/auction_spec.rb
@@ -78,7 +78,7 @@ describe Auction do
           auction.published = :published
 
           expect(auction).to be_invalid
-          expect(auction.errors.messages).to eq(c2_status: [" is not approved."])
+          expect(auction.errors.messages).to eq(c2_status: [" is not budget approved."])
         end
       end
 

--- a/spec/services/check_approval_spec.rb
+++ b/spec/services/check_approval_spec.rb
@@ -19,8 +19,8 @@ describe CheckApproval do
       end
 
       context 'auction is not published' do
-        context 'c2 proposal is approved' do
-          it 'updates the c2_approved_at field' do
+        context 'c2 proposal is budget_approved' do
+          it 'updates the c2_status field' do
             c2_path = "proposals/#{FakeC2Api::PURCHASED_PROPOSAL_ID}"
             auction = create(
               :auction,
@@ -30,12 +30,12 @@ describe CheckApproval do
 
             CheckApproval.new.perform
 
-            expect(auction.reload.c2_status).to eq 'approved'
+            expect(auction.reload.c2_status).to eq 'budget_approved'
           end
         end
 
-        context 'c2 proposal is not approved' do
-          it 'does not update the c2_approved_at field' do
+        context 'c2 proposal is not budget_approved' do
+          it 'does not update the c2_budget_approved_at field' do
             c2_path = 'proposals/1234'
             auction = create(
               :auction,

--- a/spec/view_models/admin/auction_show_view_model_spec.rb
+++ b/spec/view_models/admin/auction_show_view_model_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe Admin::AuctionShowViewModel do
   context 'auction for default purchase card' do
-    it 'returns c2 proposal URL and approved at fields' do
+    it 'returns c2 proposal URL and c2 status and receipt fields' do
       auction = create(:auction, purchase_card: :default)
       user = create(:user)
 
@@ -16,7 +16,7 @@ describe Admin::AuctionShowViewModel do
   end
 
   context 'auction for other purchase card' do
-    it 'does not return c2 proposal URL or approved at fields' do
+    it 'does not return c2 proposal URL or c2 status or receipt URL fields' do
       auction = create(:auction, purchase_card: :other)
       user = create(:user)
 
@@ -24,7 +24,7 @@ describe Admin::AuctionShowViewModel do
       data = view_model.admin_data
 
       expect(data).not_to have_key('C2 proposal URL')
-      expect(data).not_to have_key('C2 approved at')
+      expect(data).not_to have_key('C2 approval status')
       expect(data).not_to have_key('Receipt URL')
     end
   end

--- a/spec/view_models/admin/edit_auction_view_model_spec.rb
+++ b/spec/view_models/admin/edit_auction_view_model_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe Admin::EditAuctionViewModel do
   describe '#published_options' do
-    context 'auction does not have c2 approval' do
+    context 'auction does not have c2 budget approval' do
       context 'auction is closed' do
         it 'returns all options' do
           auction = create(:auction, :closed, c2_status: :not_requested)
@@ -24,9 +24,9 @@ describe Admin::EditAuctionViewModel do
       end
     end
 
-    context 'auction does have c2_approved_at' do
+    context 'auction has c2 budget approval' do
       it 'returns all options' do
-        auction = create(:auction, c2_status: :approved)
+        auction = create(:auction, c2_status: :budget_approved)
 
         view_model = Admin::EditAuctionViewModel.new(auction)
 


### PR DESCRIPTION
* Put auction statuses in timeline order in Factory model
* Rename c2_status `approved` to `budget_approved` for clarity
* This is an incremental step toward clarifying our logic, but is ready
  to be reviewed and merged