### PR TITLE
Put a sequence on the client_account name

### DIFF
--- a/spec/factories/client_accounts.rb
+++ b/spec/factories/client_accounts.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :client_account do
-    name { "#{Faker::Company.profession.capitalize} Pension Benefit Guaranty Corporation" }
+    sequence(:name) { |n| "Client Account #{n}" }
     billable true
     sequence(:tock_id) {|n| n}
   end


### PR DESCRIPTION
There was an issue where the tests were randomly using the same name for active and inactive client accounts leading to a false positive for some tests that was randomly triggered.