### PR TITLE
Add regression test: rejected auction has no winning bidder

### DIFF
--- a/app/presenters/admin_auction_status_presenter/base.rb
+++ b/app/presenters/admin_auction_status_presenter/base.rb
@@ -30,6 +30,6 @@ class AdminAuctionStatusPresenter::Base
   end
 
   def winner
-    WinningBid.new(auction).find.bidder
+    WinningBid.new(auction).find.bidder || NullBidder.new
   end
 end

--- a/spec/models/admin_auction_status_presenter_factory_spec.rb
+++ b/spec/models/admin_auction_status_presenter_factory_spec.rb
@@ -44,6 +44,23 @@ describe AdminAuctionStatusPresenterFactory do
       expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
         .to be_a(AdminAuctionStatusPresenter::Rejected)
     end
+
+    context 'rejected auction has no winner' do
+      it 'should return a AdminAuctionStatusPresenter::Rejected' do
+        auction = create(:auction, :rejected)
+
+        expect(
+          AdminAuctionStatusPresenterFactory.new(auction: auction).create.body
+        ).to eq(
+          I18n.t(
+            'statuses.admin_auction_status_presenter.rejected.body',
+            delivery_url: auction.delivery_url,
+            rejected_at: DcTimePresenter.convert_and_format(auction.rejected_at),
+            winner_name: 'N/A'
+          )
+        )
+      end
+    end
   end
 
   context 'when the auction approval request is sent' do


### PR DESCRIPTION
* We have an auction on staging like this
* Shouldn't happen in real life too much, but better to return this than
  to have the page error when an auction is in this state