### PR TITLE
Use tab subnav on auction#show

### DIFF
--- a/app/assets/javascripts/auctionToggle.js
+++ b/app/assets/javascripts/auctionToggle.js
@@ -1,7 +1,7 @@
 $(document).ready(function() {
-  $(".auction-header a").on("click", function(event) {
+  $(".auction-subnav a").on("click", function(event) {
     event.preventDefault();
     $('.js-auction-view').toggle();
-    $('.auction-header a').toggleClass('active');
+    $('.auction-subnav a').toggleClass('active');
   });
 });

--- a/app/assets/stylesheets/components/_auction-header.scss
+++ b/app/assets/stylesheets/components/_auction-header.scss
@@ -1,30 +1,31 @@
-.auction-header {
-  font-size: $base-font-size;
-  margin: 0 $negative-grid-margins;
-}
-
-.auction-header nav {
+.auction-header-wrapper {
   background: $color-gray-lightest;
   border-bottom: 1px solid $color-gray-light;
-  border-top: 1px solid $color-gray-light;
+}
+
+.auction-subnav {
   clear: both;
   display: block;
-  padding: 8px 16px;
-}
 
-.auction-header .active {
-  background: linear-gradient($color-gray-dark, $color-gray);
-  color: $color-white;
-}
+  .active {
+    background: $color-white;
+    border: 1px solid $color-gray-light;
+    border-bottom: none;
+    text-decoration: none;
+  }
 
-.auction-header nav a:hover {
-  background: $color-gray-light;
-}
+  a {
+    margin-top: 1rem;
+    margin-bottom: -1px;
+    border-bottom: 1px solid $color-gray-light;
+    padding: 1rem;
+    background: $color-gray-lightest;
+    display: inline-block;
+    line-height: $base-line-height;
+    vertical-align: middle;
+  }
 
-.auction-header nav a {
-  border-radius: $round-border-radius;
-  display: inline-block;
-  line-height: $base-line-height;
-  padding: 4px 12px;
-  vertical-align: middle;
+  a:focus {
+    box-shadow: none;
+  }
 }

--- a/app/assets/stylesheets/components/_auction-show.scss
+++ b/app/assets/stylesheets/components/_auction-show.scss
@@ -1,7 +1,4 @@
 .auction-show {
-  border: 1px solid $color-gray-neutral;
-  margin-top: $site-margins;
-
   .usa-alert {
     background-image: none;
   }

--- a/app/views/admin/admins/index.html.erb
+++ b/app/views/admin/admins/index.html.erb
@@ -1,22 +1,24 @@
-<%= render partial: 'admin/people_subnav', locals: { view_model: @view_model } %>
+<div class="usa-grid">
+  <%= render partial: 'admin/people_subnav', locals: { view_model: @view_model } %>
 
-<table class="usa-table-borderless" id="table-admins">
-  <thead>
-    <tr>
-      <th scope="col">Name</th>
-      <th scope="col">Email address</th>
-      <th scope="col">Contracting officer?</th>
-      <th scope="col">Actions</th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @view_model.admins.each do |user| %>
+  <table class="usa-table-borderless" id="table-admins">
+    <thead>
       <tr>
-        <td><%= link_to user.name, admin_user_path(user.id) %></td>
-        <td><%= user.email %></td>
-        <td><%= user.contracting_officer? %></td>
-        <td><%= link_to('Edit', edit_admin_user_path(user)) %></td>
+        <th scope="col">Name</th>
+        <th scope="col">Email address</th>
+        <th scope="col">Contracting officer?</th>
+        <th scope="col">Actions</th>
       </tr>
-    <% end %>
-  </tbody>
-</table>
+    </thead>
+    <tbody>
+      <% @view_model.admins.each do |user| %>
+        <tr>
+          <td><%= link_to user.name, admin_user_path(user.id) %></td>
+          <td><%= user.email %></td>
+          <td><%= user.contracting_officer? %></td>
+          <td><%= link_to('Edit', edit_admin_user_path(user)) %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/admin/auctions/closed/index.html.erb
+++ b/app/views/admin/auctions/closed/index.html.erb
@@ -1,9 +1,11 @@
-<%= render partial: 'admin/auctions_subnav', locals: { view_model: @view_model } %>
+<div class="usa-grid">
+  <%= render partial: 'admin/auctions_subnav', locals: { view_model: @view_model } %>
 
-<h2>Successfully Delivered</h2>
+  <h2>Successfully Delivered</h2>
 
-<%= render partial: @view_model.successful_partial, locals: { view_model: @view_model } %>
+  <%= render partial: @view_model.successful_partial, locals: { view_model: @view_model } %>
 
-<h2>Rejected Auctions</h2>
+  <h2>Rejected Auctions</h2>
 
-<%= render partial: @view_model.rejected_partial, locals: { view_model: @view_model } %>
+  <%= render partial: @view_model.rejected_partial, locals: { view_model: @view_model } %>
+</div>

--- a/app/views/admin/auctions/edit.html.erb
+++ b/app/views/admin/auctions/edit.html.erb
@@ -1,6 +1,8 @@
-<div class="auction-form usa-width-two-thirds">
-  <%= simple_form_for [:admin, @view_model.record] do |f| %>
-    <%= render partial: 'form', locals: { f: f, auction: @view_model } %>
-    <%= f.submit class: 'usa-button usa-button-outline' %>
-  <% end %>
+<div class="usa-grid">
+  <div class="auction-form usa-width-two-thirds">
+    <%= simple_form_for [:admin, @view_model.record] do |f| %>
+      <%= render partial: 'form', locals: { f: f, auction: @view_model } %>
+      <%= f.submit class: 'usa-button usa-button-outline' %>
+    <% end %>
+  </div>
 </div>

--- a/app/views/admin/auctions/index.html.erb
+++ b/app/views/admin/auctions/index.html.erb
@@ -1,12 +1,14 @@
-<%= render partial: 'admin/auctions_subnav', locals: { view_model: @view_model } %>
+<div class="usa-grid">
+  <%= render partial: 'admin/auctions_subnav', locals: { view_model: @view_model } %>
 
-<div class="admin-auction-wrapper auction-wrapper">
-  <% @auctions.each do |auction| %>
-    <%= render partial: 'auctions/list_item', locals: { auction: auction } %>
-  <% end %>
-</div>
+  <div class="admin-auction-wrapper auction-wrapper">
+    <% @auctions.each do |auction| %>
+      <%= render partial: 'auctions/list_item', locals: { auction: auction } %>
+    <% end %>
+  </div>
 
-<%= paginate @auctions %>
-<div class="pagination-details">
-  <%= page_entries_info @auctions, entry_name: 'auction' %>
+  <%= paginate @auctions %>
+  <div class="pagination-details">
+    <%= page_entries_info @auctions, entry_name: 'auction' %>
+  </div>
 </div>

--- a/app/views/admin/auctions/new.html.erb
+++ b/app/views/admin/auctions/new.html.erb
@@ -1,6 +1,8 @@
-<div class="auction-form usa-width-two-thirds">
-  <%= simple_form_for [:admin, @view_model.new_record] do |f| %>
-    <%= render partial: 'form', locals: { f: f, auction: @view_model } %>
-    <%= f.submit class: 'usa-button usa-button-outline' %>
-  <% end %>
+<div class="usa-grid">
+  <div class="auction-form usa-width-two-thirds">
+    <%= simple_form_for [:admin, @view_model.new_record] do |f| %>
+      <%= render partial: 'form', locals: { f: f, auction: @view_model } %>
+      <%= f.submit class: 'usa-button usa-button-outline' %>
+    <% end %>
+  </div>
 </div>

--- a/app/views/admin/auctions/show.html.erb
+++ b/app/views/admin/auctions/show.html.erb
@@ -1,43 +1,48 @@
-<div class="auction-show usa-grid issue-list-item">
-  <div class="auction-title">
-    <h1><%= @view_model.title %></h1>
-    <%= render partial: 'auctions/edit_auction_link', locals: { view_model: @view_model } %>
-     <%= render partial: @view_model.csv_report_partial,
-        locals: { auction: @view_model } %>
-    <div class="auction-subtitles">
-      <div class="auction-subtitle">
-        <div class="bidding-status">
-          <%= render partial: 'auctions/bidding_status_label',
-            locals: { status: @view_model.bidding_status_presenter } %>
+<div class="auction-show">
+  <div class="auction-header-wrapper">
+    <div class="usa-grid">
+      <div class="auction-title">
+        <h1><%= @view_model.title %></h1>
+        <%= render partial: 'auctions/edit_auction_link', locals: { view_model: @view_model } %>
+        <%= render partial: @view_model.csv_report_partial,
+          locals: { auction: @view_model } %>
+        <div class="auction-subtitles">
+          <div class="auction-subtitle">
+            <div class="bidding-status">
+              <%= render partial: 'auctions/bidding_status_label',
+                locals: { status: @view_model.bidding_status_presenter } %>
+            </div>
+          </div>
+          <div class="auction-subtitle">
+            <%= @view_model.relative_time %>
+          </div>
         </div>
       </div>
-      <div class="auction-subtitle">
-        <%= @view_model.relative_time %>
-      </div>
+
+      <%= render partial: 'auctions/subnav' %>
     </div>
   </div>
 
-  <%= render partial: 'auctions/header', locals: { auction: @view_model } %>
+  <div class="usa-grid">
+    <div class="usa-width-two-thirds">
+      <%= render partial: 'admin/auctions/auction', locals: { auction: @view_model } %>
+      <%= render partial: 'admin/auctions/bids', locals: { auction_bids: @view_model } %>
+    </div>
 
-  <div class="usa-width-two-thirds">
-    <%= render partial: 'admin/auctions/auction', locals: { auction: @view_model } %>
-    <%= render partial: 'admin/auctions/bids', locals: { auction_bids: @view_model } %>
-  </div>
+    <div class="usa-width-one-third">
+      <%= render partial: 'auctions/status',
+        locals: { status: @view_model.admin_auction_status_presenter  } %>
 
-  <div class="usa-width-one-third">
-    <%= render partial: 'auctions/status',
-      locals: { status: @view_model.admin_auction_status_presenter  } %>
+      <%= render partial: @view_model.admin_notes_partial,
+        locals: { auction: @view_model.auction  } %>
 
-    <%= render partial: @view_model.admin_notes_partial,
-      locals: { auction: @view_model.auction  } %>
-
-    <div class="auction-detail-panel">
-      <div class="auction-info">
-        <% @view_model.admin_data.each do |label, data| %>
-          <%= render partial: 'auctions/data',
-            locals: { label: label, data: data } %>
-        <% end %>
+      <div class="auction-detail-panel">
+        <div class="auction-info">
+          <% @view_model.admin_data.each do |label, data| %>
+            <%= render partial: 'auctions/data',
+              locals: { label: label, data: data } %>
+          <% end %>
+        </div>
       </div>
     </div>
   </div>
-</div>

--- a/app/views/admin/customers/edit.html.erb
+++ b/app/views/admin/customers/edit.html.erb
@@ -1,7 +1,9 @@
-<h2>Editing customer</h2>
+<div class="usa-grid">
+  <h2>Editing customer</h2>
 
-<div class="customer-form">
-  <%= simple_form_for [:admin, @view_model.record] do |f| %>
-    <%= render partial: 'form', locals: { f: f } %>
-  <% end %>
+  <div class="customer-form">
+    <%= simple_form_for [:admin, @view_model.record] do |f| %>
+      <%= render partial: 'form', locals: { f: f } %>
+    <% end %>
+  </div>
 </div>

--- a/app/views/admin/customers/index.html.erb
+++ b/app/views/admin/customers/index.html.erb
@@ -1,22 +1,24 @@
-<%= render partial: 'admin/settings_subnav', locals: { view_model: @view_model } %>
+<div class="usa-grid">
+  <%= render partial: 'admin/settings_subnav', locals: { view_model: @view_model } %>
 
-<table class="usa-table-borderless">
-  <thead>
-    <tr>
-      <th scope="col">Agency Name</th>
-      <th scope="col">Contact Name</th>
-      <th scope="col">Email</th>
-      <th scope="col"></th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @view_model.customers.each do |customer| %>
+  <table class="usa-table-borderless">
+    <thead>
       <tr>
-        <td><%= customer.agency_name %></td>
-        <td><%= customer.contact_name %></td>
-        <td><%= customer.email %></td>
-        <td><%= link_to('Edit', edit_admin_customer_path(customer)) %></td>
+        <th scope="col">Agency Name</th>
+        <th scope="col">Contact Name</th>
+        <th scope="col">Email</th>
+        <th scope="col"></th>
       </tr>
-    <% end %>
-  </tbody>
-</table>
+    </thead>
+    <tbody>
+      <% @view_model.customers.each do |customer| %>
+        <tr>
+          <td><%= customer.agency_name %></td>
+          <td><%= customer.contact_name %></td>
+          <td><%= customer.email %></td>
+          <td><%= link_to('Edit', edit_admin_customer_path(customer)) %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/admin/customers/new.html.erb
+++ b/app/views/admin/customers/new.html.erb
@@ -1,7 +1,9 @@
-<h2>New customer</h2>
+<div class="usa-grid">
+  <h2>New customer</h2>
 
-<div class="customer-form">
-  <%= simple_form_for [:admin, @view_model.new_record] do |f| %>
-    <%= render partial: 'form', locals: { f: f } %>
-  <% end %>
+  <div class="customer-form">
+    <%= simple_form_for [:admin, @view_model.new_record] do |f| %>
+      <%= render partial: 'form', locals: { f: f } %>
+    <% end %>
+  </div>
 </div>

--- a/app/views/admin/skills/edit.html.erb
+++ b/app/views/admin/skills/edit.html.erb
@@ -1,4 +1,6 @@
-<h2>New skill</h2>
-<%= simple_form_for [:admin, @view_model.record] do |f| %>
-  <%= render partial: 'form', locals: { f: f } %>
-<% end %>
+<div class="usa-grid">
+  <h2>New skill</h2>
+  <%= simple_form_for [:admin, @view_model.record] do |f| %>
+    <%= render partial: 'form', locals: { f: f } %>
+  <% end %>
+</div>

--- a/app/views/admin/skills/index.html.erb
+++ b/app/views/admin/skills/index.html.erb
@@ -1,18 +1,20 @@
-<%= render partial: 'admin/settings_subnav', locals: { view_model: @view_model } %>
+<div class="usa-grid">
+  <%= render partial: 'admin/settings_subnav', locals: { view_model: @view_model } %>
 
-<table class="usa-table-borderless">
-  <thead>
-    <tr>
-      <th scope="col">Skill name</th>
-      <th scope="col"></th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @view_model.skills.each do |skill| %>
+  <table class="usa-table-borderless">
+    <thead>
       <tr>
-        <td><%= skill.name %></td>
-        <td><%= link_to('Edit', edit_admin_skill_path(skill)) %></td>
+        <th scope="col">Skill name</th>
+        <th scope="col"></th>
       </tr>
-    <% end %>
-  </tbody>
-</table>
+    </thead>
+    <tbody>
+      <% @view_model.skills.each do |skill| %>
+        <tr>
+          <td><%= skill.name %></td>
+          <td><%= link_to('Edit', edit_admin_skill_path(skill)) %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/admin/skills/new.html.erb
+++ b/app/views/admin/skills/new.html.erb
@@ -1,4 +1,6 @@
-<h2>New skill</h2>
-<%= simple_form_for [:admin, @view_model.new_record] do |f| %>
-  <%= render partial: 'form', locals: { f: f } %>
-<% end %>
+<div class="usa-grid">
+  <h2>New skill</h2>
+  <%= simple_form_for [:admin, @view_model.new_record] do |f| %>
+    <%= render partial: 'form', locals: { f: f } %>
+  <% end %>
+</div>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,7 +1,9 @@
-<h2>Editing user</h2>
-<%= simple_form_for [:admin, @view_model.record] do |form| %>
-  <%= form.input :email, disabled: true %>
-  <%= form.input :name, disabled: true %>
-  <%= form.input :contracting_officer, as: :boolean %>
-  <%= form.submit %>
-<% end %>
+<div class="usa-grid">
+  <h2>Editing user</h2>
+  <%= simple_form_for [:admin, @view_model.record] do |form| %>
+    <%= form.input :email, disabled: true %>
+    <%= form.input :name, disabled: true %>
+    <%= form.input :contracting_officer, as: :boolean %>
+    <%= form.submit %>
+  <% end %>
+</div>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,12 +1,14 @@
-<h2><%= @view_model.name %></h2>
-<table class="striped-table">
-  <tbody>
-    <% @view_model.data.each do |row| %>
-      <%= render partial: 'attribute_row',
-        locals: { label: row[:label], data: row[:data] } %>
-    <% end %>
-  </tbody>
-</table>
+<div class="usa-grid">
+  <h2><%= @view_model.name %></h2>
+  <table class="striped-table">
+    <tbody>
+      <% @view_model.data.each do |row| %>
+        <%= render partial: 'attribute_row',
+          locals: { label: row[:label], data: row[:data] } %>
+      <% end %>
+    </tbody>
+  </table>
 
-<%= render partial: @view_model.bids_partial,
-  locals: { view_model: @view_model } %>
+  <%= render partial: @view_model.bids_partial,
+    locals: { view_model: @view_model } %>
+</div>

--- a/app/views/admin/vendors/index.html.erb
+++ b/app/views/admin/vendors/index.html.erb
@@ -1,26 +1,28 @@
-<%= render partial: 'admin/people_subnav', locals: { view_model: @view_model } %>
+<div class="usa-grid">
+  <%= render partial: 'admin/people_subnav', locals: { view_model: @view_model } %>
 
-<table class="usa-table-borderless" id="table-users">
-  <thead>
-    <tr>
-      <th scope="col">Name</th>
-      <th scope="col">Email address</th>
-      <th scope="col">DUNS #</th>
-      <th scope="col">Small business</th>
-      <th scope="col">SAM status</th>
-      <th scope="col"></th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @view_model.users.each do |user| %>
+  <table class="usa-table-borderless" id="table-users">
+    <thead>
       <tr>
-        <td><%= link_to user.name, admin_user_path(user.id) %></td>
-        <td><%= user.email %></td>
-        <td><%= user.duns_number %></td>
-        <td><%= user.small_business_label %></td>
-        <td><%= user.admin_sam_status %></td>
-        <td><%= render partial: user.masquerade_partial, locals: { user: user } %></td>
+        <th scope="col">Name</th>
+        <th scope="col">Email address</th>
+        <th scope="col">DUNS #</th>
+        <th scope="col">Small business</th>
+        <th scope="col">SAM status</th>
+        <th scope="col"></th>
       </tr>
-    <% end %>
-  </tbody>
-</table>
+    </thead>
+    <tbody>
+      <% @view_model.users.each do |user| %>
+        <tr>
+          <td><%= link_to user.name, admin_user_path(user.id) %></td>
+          <td><%= user.email %></td>
+          <td><%= user.duns_number %></td>
+          <td><%= user.small_business_label %></td>
+          <td><%= user.admin_sam_status %></td>
+          <td><%= render partial: user.masquerade_partial, locals: { user: user } %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/auctions/_header.html.erb
+++ b/app/views/auctions/_header.html.erb
@@ -1,6 +1,0 @@
-<div class="auction-header">
-  <nav>
-    <%= link_to 'Auction', '#', class: "nav-auction active" %>
-    <%= link_to 'Bids', '#', class: "nav-auction"%>
-  </nav>
-</div>

--- a/app/views/auctions/_subnav.html.erb
+++ b/app/views/auctions/_subnav.html.erb
@@ -1,0 +1,4 @@
+<div class="auction-subnav">
+  <%= link_to 'Auction', '#', class: "nav-auction active" %>
+  <%= link_to 'Bids', '#', class: "nav-auction"%>
+</div>

--- a/app/views/auctions/show.html.erb
+++ b/app/views/auctions/show.html.erb
@@ -7,67 +7,63 @@
   <%= render partial: @view_model.nofollow_partial %>
 <% end %>
 
-<div class="usa-grid">
-  <%= link_to(
-    "<icon class='fa fa-angle-double-left'></icon> Back to all auctions".html_safe,
-    root_path,
-    class: 'breadcrumb-link') %>
-</div>
-
-<div class="auction-show usa-grid">
-  <div class="auction-title">
-    <h1><%= @view_model.title %></h1>
-
-    <%= render partial: @view_model.admin_edit_auction_partial,
-      locals: { view_model: @view_model } %>
-
-    <div class="auction-subtitles">
-      <div class="auction-subtitle">
-        <div class="bidding-status">
-          <%= render partial: 'auctions/bidding_status_label',
-            locals: { status: @view_model.bidding_status_presenter } %>
+<div class="auction-show">
+  <div class="auction-header-wrapper">
+    <div class="usa-grid">
+      <div class="auction-title">
+        <h1><%= @view_model.title %></h1>
+        <%= render partial: @view_model.admin_edit_auction_partial,
+          locals: { view_model: @view_model } %>
+        <div class="auction-subtitles">
+          <div class="auction-subtitle">
+            <div class="bidding-status">
+              <%= render partial: 'auctions/bidding_status_label',
+                locals: { status: @view_model.bidding_status_presenter } %>
+            </div>
+          </div>
+          <div class="auction-subtitle">
+            <%= @view_model.relative_time %>
+          </div>
+          <div class="auction-subtitle">
+            <%= @view_model.bid_label %>
+          </div>
         </div>
       </div>
-      <div class="auction-subtitle">
-        <%= @view_model.relative_time %>
-      </div>
-      <div class="auction-subtitle">
-        <%= @view_model.bid_label %>
-      </div>
+
+      <%= render partial: 'auctions/subnav' %>
     </div>
   </div>
 
-  <%= render partial: 'auctions/header' %>
+  <div class="usa-grid">
+    <div class="usa-width-two-thirds">
+      <%= render partial: 'auctions/auction', locals: { auction: @view_model } %>
+      <%= render partial: 'auctions/bids', locals: { auction_bids: @view_model } %>
+    </div>
 
-  <div class="usa-width-two-thirds">
-    <%= render partial: 'auctions/auction', locals: { auction: @view_model } %>
-    <%= render partial: 'auctions/bids', locals: { auction_bids: @view_model } %>
-  </div>
+    <div class="usa-width-one-third">
+      <%= render partial: 'auctions/status', locals: { status: @view_model.bid_status_presenter } %>
 
-  <div class="usa-width-one-third">
-    <%= render partial: 'auctions/status', locals: { status: @view_model.bid_status_presenter } %>
+      <div class="auction-detail-panel">
+        <div class="auction-info">
+          <% @view_model.auction_data.each do |label, data| %>
+            <%= render partial: 'auctions/data',
+              locals: { label: label, data: data } %>
+          <% end %>
 
-    <div class="auction-detail-panel">
-      <div class="auction-info">
-        <% @view_model.auction_data.each do |label, data| %>
-          <%= render partial: 'auctions/data',
-            locals: { label: label, data: data } %>
-        <% end %>
-
-        <h6>Auction type:</h6>
-        <p class="auction-label-info">
-        <%= @view_model.capitalized_type %>
-        (<%= link_to 'rules', @view_model.rules_path %>)
-        </p>
-        <%= render partial: @view_model.paid_at_partial, locals: { auction: @view_model } %>
-        <%= render partial: @view_model.accepted_at_partial, locals: { auction: @view_model } %>
-        <p>
-        <i class="fa fa-github"></i>
-        <%= link_to 'View on GitHub <icon class="fa fa-angle-double-right"></icon>'.html_safe,
-          @view_model.issue_url,
-          target: '_blank' %>
-        </p>
+          <h6>Auction type:</h6>
+          <p class="auction-label-info">
+          <%= @view_model.capitalized_type %>
+          (<%= link_to 'rules', @view_model.rules_path %>)
+          </p>
+          <%= render partial: @view_model.paid_at_partial, locals: { auction: @view_model } %>
+          <%= render partial: @view_model.accepted_at_partial, locals: { auction: @view_model } %>
+          <p>
+          <i class="fa fa-github"></i>
+          <%= link_to 'View on GitHub <icon class="fa fa-angle-double-right"></icon>'.html_safe,
+            @view_model.issue_url,
+            target: '_blank' %>
+          </p>
+        </div>
       </div>
     </div>
   </div>
-</div>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -17,10 +17,8 @@
     title: "Micro-purchase (admin)" } %>
 
   <div class="site-content">
-    <div class="usa-grid">
-      <%= render "flashes" %>
-      <%= yield %>
-    </div>
+    <%= render "flashes" %>
+    <%= yield %>
   </div>
 
   <%= render "components/footer" %>


### PR DESCRIPTION
* Move from buttons to tabs
* This new layout requires that the header wrapper be outside of
  `usa-grid`, so had to move that outside of the layout and add to
  individual view templates
* Part of https://github.com/18F/micropurchase/issues/1032

## Before

![screen shot 2016-09-28 at 11 50 27 am](https://cloud.githubusercontent.com/assets/601515/18927632/88d007d4-8571-11e6-8c92-8d66201264b9.png)


## After
![screen shot 2016-09-28 at 11 49 31 am](https://cloud.githubusercontent.com/assets/601515/18927609/7972ba20-8571-11e6-9800-36921dc9cd9c.png)
