### PR TITLE
Add an archived status to auction model

### DIFF
--- a/app/assets/javascripts/admin/archiveConfirm.js
+++ b/app/assets/javascripts/admin/archiveConfirm.js
@@ -1,0 +1,5 @@
+$(document).ready(function() {
+  $('#archive-auction-link').click(function() {
+    return confirm("Are you sure you want to archive this auction?");
+  })
+});

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -6,3 +6,4 @@
 //= require selectize
 //= require selectizer
 //= require bidConfirm.js
+//= require admin/archiveConfirm.js

--- a/app/assets/stylesheets/components/_auction-form.scss
+++ b/app/assets/stylesheets/components/_auction-form.scss
@@ -22,6 +22,10 @@
   label {
     clear: both;
   }
+
+  input[type="submit"] {
+    display: inline-block;
+  }
 }
 
 .auction_summary textarea {

--- a/app/controllers/admin/auctions_controller.rb
+++ b/app/controllers/admin/auctions_controller.rb
@@ -32,7 +32,12 @@ class Admin::AuctionsController < Admin::BaseController
 
   def update
     auction = Auction.find(params[:id])
-    update_auction = UpdateAuction.new(auction: auction, params: params, current_user: current_user)
+
+    update_auction = if ArchiveAuction.archive_submit?(params)
+                       ArchiveAuction.new(auction: auction)
+                     else
+                       UpdateAuction.new(auction: auction, params: params, current_user: current_user)
+                     end
 
     if update_auction.perform
       flash[:success] = I18n.t('controllers.admin.auctions.update.success')

--- a/app/models/admin_auction_status_presenter_factory.rb
+++ b/app/models/admin_auction_status_presenter_factory.rb
@@ -16,7 +16,9 @@ class AdminAuctionStatusPresenterFactory
   private
 
   def default_purchase_card_presenter
-    if auction.c2_status == 'not_requested'
+    if auction.archived?
+      AdminAuctionStatusPresenter::Archived
+    elsif auction.c2_status == 'not_requested'
       C2StatusPresenter::NotRequested
     elsif auction.c2_status == 'sent'
       C2StatusPresenter::Sent
@@ -48,7 +50,9 @@ class AdminAuctionStatusPresenterFactory
   end
 
   def other_purchase_card_presenter
-    if future? && auction.published?
+    if auction.archived?
+      AdminAuctionStatusPresenter::Archived
+    elsif future? && auction.published?
       AdminAuctionStatusPresenter::Future
     elsif future? && auction.unpublished?
       AdminAuctionStatusPresenter::ReadyToPublish

--- a/app/models/auction.rb
+++ b/app/models/auction.rb
@@ -30,7 +30,7 @@ class Auction < ActiveRecord::Base
     rejected: 2
   }
 
-  enum published: { unpublished: 0, published: 1 }
+  enum published: { unpublished: 0, published: 1, archived: 2 }
   enum purchase_card: { default: 0, other: 1 }
   enum type: { sealed_bid: 0, reverse: 1 }
 
@@ -56,6 +56,7 @@ class Auction < ActiveRecord::Base
   validate :publishing_auction, on: :update, if: :published_changed?
 
   def publishing_auction
+    return if archived?
     if published_was == 'unpublished' && purchase_card == 'default' && c2_status != 'budget_approved'
       errors.add(:c2_status, " is not budget approved.")
     end

--- a/app/models/concerns/auction_scopes.rb
+++ b/app/models/concerns/auction_scopes.rb
@@ -20,10 +20,8 @@ module AuctionScopes
     scope :pending_delivery, -> { where(delivery_status: delivery_statuses['pending_delivery']) }
     scope :not_paid, -> { where(paid_at: nil) }
     scope :paid, -> { where.not(paid_at: nil) }
-    scope :published, -> { where(published: publishes['published']) }
     scope :started_at_in_future, -> { where('started_at > ?', Time.current) }
     scope :started_at_in_past, -> { where('started_at < ?', Time.current) }
-    scope :unpublished, -> { where(published: [nil, '', publisheds['unpublished']]) }
     scope :with_bids, -> { includes(:bids) }
     scope :with_bids_and_bidders, -> { includes(:bids, :bidders) }
 

--- a/app/presenters/admin_auction_status_presenter/archived.rb
+++ b/app/presenters/admin_auction_status_presenter/archived.rb
@@ -1,0 +1,11 @@
+class AdminAuctionStatusPresenter::Archived < AdminAuctionStatusPresenter::Base
+  def header
+    I18n.t('statuses.admin_auction_status_presenter.archived.header')
+  end
+
+  def body
+    I18n.t(
+      'statuses.admin_auction_status_presenter.archived.body'
+    )
+  end
+end

--- a/app/services/archive_auction.rb
+++ b/app/services/archive_auction.rb
@@ -1,0 +1,20 @@
+class ArchiveAuction
+  attr_reader :auction
+
+  def initialize(auction:)
+    @auction = auction
+  end
+
+  def perform
+    if auction.unpublished?
+      auction.published = :archived
+      auction.save
+    else
+      false
+    end
+  end
+
+  def self.archive_submit?(params)
+    params.key?(:archive_auction)
+  end
+end

--- a/app/view_models/admin/edit_auction_view_model.rb
+++ b/app/view_models/admin/edit_auction_view_model.rb
@@ -45,6 +45,14 @@ class Admin::EditAuctionViewModel < Admin::BaseViewModel
     end
   end
 
+  def archive_auction_partial
+    if auction.unpublished?
+      'admin/auctions/archive_auction'
+    else
+      'components/null'
+    end
+  end
+
   def paid_at_partial
     if auction.purchase_card == "default" || auction.delivery_status != "accepted"
       'components/null'

--- a/app/views/admin/auctions/_archive_auction.html.erb
+++ b/app/views/admin/auctions/_archive_auction.html.erb
@@ -1,0 +1,3 @@
+<%= f.submit t('links_and_buttons.auctions.archive'),
+    name: 'archive_auction',
+    class: 'usa-button usa-button-secondary', id: 'archive-auction-link' %>

--- a/app/views/admin/auctions/_publish_auction.html.erb
+++ b/app/views/admin/auctions/_publish_auction.html.erb
@@ -20,4 +20,6 @@
   <%= f.hidden_field :published, value: 'published', hidden: true %>
   <%= f.submit t('links_and_buttons.auctions.publish'),
     class: 'usa-button usa-button-outline action-button' %>
+
+  <%= f.submit t('links_and_buttons.auctions.publish'), class: 'usa-button usa-button-outline' %>
 <% end %>

--- a/app/views/admin/auctions/edit.html.erb
+++ b/app/views/admin/auctions/edit.html.erb
@@ -3,6 +3,7 @@
     <%= simple_form_for [:admin, @view_model.record] do |f| %>
       <%= render partial: 'form', locals: { f: f, auction: @view_model } %>
       <%= f.submit class: 'usa-button usa-button-outline' %>
+      <%= render partial: @view_model.archive_auction_partial, locals: {auction: @view_model.auction, f: f} %>
     <% end %>
   </div>
 </div>

--- a/config/locales/links_and_buttons/en.yml
+++ b/config/locales/links_and_buttons/en.yml
@@ -7,6 +7,7 @@ en:
       closed: 'Closed'
       add: 'Add auction'
       publish: 'Publish'
+      archive: 'Archive'
     customers:
       add: 'Add customer'
     skills:

--- a/config/locales/statuses/en.yml
+++ b/config/locales/statuses/en.yml
@@ -111,6 +111,9 @@ en:
               <a href=%{issue_url}>the issue associated with this auction</a>.
               Then enter the pull request URL, below, and click "start work."
     admin_auction_status_presenter:
+      archived:
+        header: Archived
+        body: This auction was archived.
       future:
         published:
           body: >

--- a/features/admin_archives_auction.feature
+++ b/features/admin_archives_auction.feature
@@ -1,0 +1,41 @@
+Feature: Admin archives auction
+  As an admin
+  I should be able to archive unpublished auctions
+  So they will not be listed anymore
+
+  Scenario: Admin can archive unpublished auction that is not yet approved
+    Given I am an administrator
+    And I sign in
+    And there is an unpublished auction
+    And the auction is for the default purchase card
+    And the c2 proposal for the auction is not budget approved
+    When I visit the admin form for that auction
+    Then I should see the Archive button
+
+  Scenario: Admin can archive unpublished auction that is approved
+    Given I am an administrator
+    And I sign in
+    And there is an unpublished auction
+    And the auction is for the default purchase card
+    When I visit the admin form for that auction
+    Then I should see the Archive button
+
+  Scenario: Admin can not archive published auction
+    Given I am an administrator
+    And I sign in
+    And there is an open auction
+    And the auction is for the default purchase card
+    When I visit the admin form for that auction
+    Then I should not see the Archive button
+
+  @javascript
+  Scenario: When the user clicks the link
+    Given I am an administrator
+    And I sign in
+    And there is an unpublished auction
+    And the auction is for the default purchase card
+    When I visit the admin form for that auction
+
+    When I click on the Archive button
+    When I click OK on the javascript confirm dialog to archive the auction
+    Then I should see the admin status message for an archived auction

--- a/features/step_definitions/auction_status_steps.rb
+++ b/features/step_definitions/auction_status_steps.rb
@@ -247,3 +247,12 @@ Then(/^I should see an admin status message that the auction was paid with anoth
     )
   )
 end
+
+Then(/^I should see the admin status message for an archived auction$/) do
+  @auction.reload
+  expect(page.html).to have_content(
+    I18n.t(
+      'statuses.admin_auction_status_presenter.archived.body'
+    )
+  )
+end

--- a/features/step_definitions/js_dialog_steps.rb
+++ b/features/step_definitions/js_dialog_steps.rb
@@ -2,3 +2,8 @@ When(/^I click OK on the javascript confirm dialog for a bid amount of (.+)$/) d
   text = "Are you sure you want to place a bid for #{amount}?"
   page.accept_alert(text)
 end
+
+When(/^I click OK on the javascript confirm dialog to archive the auction$/) do
+  text = 'Are you sure you want to archive this auction?'
+  page.accept_alert(text)
+end

--- a/features/step_definitions/link_and_button_steps.rb
+++ b/features/step_definitions/link_and_button_steps.rb
@@ -42,6 +42,21 @@ When(/^I click on the Publish button$/) do
   step("I click on the \"#{button}\" button")
 end
 
+Then(/^I should see the Archive button$/) do
+  button = I18n.t('links_and_buttons.auctions.archive')
+  step("I should see a \"#{button}\" button")
+end
+
+Then(/^I should not see the Archive button$/) do
+  button = I18n.t('links_and_buttons.auctions.archive')
+  step("I should not see a \"#{button}\" button")
+end
+
+When(/^I click on the Archive button$/) do
+  button = I18n.t('links_and_buttons.auctions.archive')
+  step("I click on the \"#{button}\" button")
+end
+
 When(/^I click on the unpublish button$/) do
   unpublish_button = I18n.t('statuses.admin_auction_status_presenter.future.published.actions.unpublish')
   step("I click on the \"#{unpublish_button}\" button")

--- a/spec/factories/auctions.rb
+++ b/spec/factories/auctions.rb
@@ -40,6 +40,10 @@ FactoryGirl.define do
       published :published
     end
 
+    trait :archived do
+      published :archived
+    end
+
     trait :unpublished do
       future
       published :unpublished

--- a/spec/services/archive_auction_spec.rb
+++ b/spec/services/archive_auction_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe ArchiveAuction do
+  it 'should set the delivery_status to be archived' do
+    auction = FactoryGirl.create(:auction, :unpublished)
+    ArchiveAuction.new(auction: auction).perform
+
+    expect(auction).to be_archived
+    expect(auction.published).to eq("archived")
+  end
+
+  it 'should not be applied if the auction is published' do
+    auction = FactoryGirl.create(:auction, :published)
+    out = ArchiveAuction.new(auction: auction).perform
+
+    expect(out).to be_falsey
+    expect(auction).to_not be_archived
+  end
+end


### PR DESCRIPTION
Fixes #1276

![localhost_3000_admin_auctions_1_edit](https://cloud.githubusercontent.com/assets/2044/18996019/c024ab54-86fc-11e6-8215-ae5208290bda.jpg)

Note: this does not implement a few tweaks to the admin display for archived auctions or data insights that are specified in later issues. Also, not sure how you want that styled