### PR TITLE
Wrap long links in auction sidebar

### DIFF
--- a/app/assets/stylesheets/components/_auction-sidebar.scss
+++ b/app/assets/stylesheets/components/_auction-sidebar.scss
@@ -65,6 +65,10 @@
   i {
     margin-right: 5px;
   }
+
+  a {
+    word-wrap: break-word;
+  }
 }
 
 .auction-label-info {


### PR DESCRIPTION
* Source: https://davidwalsh.name/fix-long-link-wrapping
* Closes https://github.com/18F/micropurchase/issues/1325

Before:

![screen shot 2016-09-30 at 1 53 39 pm](https://cloud.githubusercontent.com/assets/601515/19006578/160bebd2-8715-11e6-9ea3-ccf60e227414.png)


After:

![screen shot 2016-09-30 at 1 53 18 pm](https://cloud.githubusercontent.com/assets/601515/19006575/128f9bfc-8715-11e6-9d91-dc0cfebb75e1.png)
