### PR TITLE
Validate auction dates when publishing

### DIFF
--- a/app/models/admin_auction_status_presenter_factory.rb
+++ b/app/models/admin_auction_status_presenter_factory.rb
@@ -26,7 +26,7 @@ class AdminAuctionStatusPresenterFactory
       C2StatusPresenter::PendingApproval
     elsif future? && auction.published?
       AdminAuctionStatusPresenter::Future
-    elsif future? && auction.unpublished?
+    elsif auction.unpublished?
       AdminAuctionStatusPresenter::ReadyToPublish
     elsif available?
       AdminAuctionStatusPresenter::Available

--- a/app/models/auction.rb
+++ b/app/models/auction.rb
@@ -78,20 +78,9 @@ class Auction < ActiveRecord::Base
     end
   end
 
-  def publishing_auction
-    if published_was == 'unpublished' && purchase_card == 'default' && c2_status != 'budget_approved'
-      errors.add(:c2_status, "is not budget approved.")
-    end
-
-    if published_was == 'unpubished' && (started_at < Time.current || started_at > ended_at)
-      errors.add(:started_at, "is invalid")
-    end
-  end
-
   def lowest_bids
     bids.select { |b| b.amount == lowest_amount }.sort_by(&:created_at)
   end
-
 
   def lowest_amount
     bids.sort_by(&:amount).first.try(:amount)

--- a/app/validators/published_auction_validator.rb
+++ b/app/validators/published_auction_validator.rb
@@ -1,6 +1,6 @@
 class PublishedAuctionValidator < ActiveModel::Validator
   def validate(auction)
-    if auction.published_was == 'unpublished'
+    if auction.published? && auction.published_was == 'unpublished'
       validate_budget_approval_for_default_pcard(auction)
       validate_start_date_before_end_date(auction)
       validate_start_date_in_future(auction)

--- a/app/validators/published_auction_validator.rb
+++ b/app/validators/published_auction_validator.rb
@@ -1,0 +1,35 @@
+class PublishedAuctionValidator < ActiveModel::Validator
+  def validate(auction)
+    if auction.published_was == 'unpublished'
+      validate_budget_approval_for_default_pcard(auction)
+      validate_start_date_before_end_date(auction)
+      validate_start_date_in_future(auction)
+    end
+  end
+
+  private
+
+  def validate_budget_approval_for_default_pcard(auction)
+    if auction.purchase_card == 'default' && auction.c2_status != 'budget_approved'
+      auction.errors.add(:c2_status, "is not budget approved")
+    end
+  end
+
+  def validate_start_date_before_end_date(auction)
+    if auction.started_at > auction.ended_at
+      auction.errors.add(
+        :base,
+        "You must specify an auction end date/time that comes after the auction start date/time."
+      )
+    end
+  end
+
+  def validate_start_date_in_future(auction)
+    if auction.started_at < Time.current
+      auction.errors.add(
+        :base,
+        "You must specify an auction start date/time that is after today."
+      )
+    end
+  end
+end

--- a/app/views/admin/auctions/_publish_auction_form.html.erb
+++ b/app/views/admin/auctions/_publish_auction_form.html.erb
@@ -1,0 +1,21 @@
+<%= simple_form_for [:admin, status.auction], url: admin_auction_publish_path, method: :patch do |f| %>
+<fieldset class="datetime">
+  <legend>Auction starts</legend>
+  <%= render partial: 'sidebar_datetime_fields',
+    locals: { field: 'started', auction: status } %>
+</fieldset>
+
+<fieldset class="datetime">
+  <legend>Auction ends</legend>
+  <%= render partial: 'sidebar_datetime_fields',
+    locals: { field: 'ended', auction: status } %>
+</fieldset>
+
+<fieldset class="datetime">
+  <legend>Delivery deadline</legend>
+  <%= render partial: 'sidebar_datetime_fields',
+    locals: { field: 'delivery_due', auction: status } %>
+</fieldset>
+
+  <%= f.submit t('links_and_buttons.auctions.publish'), class: 'usa-button usa-button-outline' %>
+<% end %>

--- a/spec/models/auction_spec.rb
+++ b/spec/models/auction_spec.rb
@@ -44,6 +44,18 @@ describe Auction do
       end
     end
 
+    context 'when set to archived' do
+      it 'does not run date validations' do
+        start_date = DefaultDateTime.new(2.days.from_now).convert
+        end_date = DefaultDateTime.new(Time.current).convert
+        auction = create(:auction, :unpublished, started_at: start_date, ended_at: end_date)
+
+        auction.published = :archived
+
+        expect(auction).to be_valid
+      end
+    end
+
     context 'when set to published' do
       it 'validates presence of summary' do
         auction = create(:auction, published: :unpublished)


### PR DESCRIPTION
* Start date is in future
* End date is after start date
* Also updated presenter factory to show "ready to publish" message for
  any unpublished auction because I realized that sometimes an auction
  is no longer in the future because it's been a draft for a while, but
  we still want to show the "ready to publish" message in that case.
* Closes https://github.com/18F/micropurchase/issues/1168