### PR TITLE
Removing the "Return to Top" link as part of design cleanup

### DIFF
--- a/app/views/components/_footer.html.erb
+++ b/app/views/components/_footer.html.erb
@@ -1,7 +1,4 @@
 <footer class="usa-footer usa-footer-slim" role="contentinfo">
-  <div class="usa-grid usa-footer-return-to-top">
-    <a href="#">Return to top</a>
-  </div>
 
   <div class="usa-footer-primary-section">
     <div class="usa-grid-full">


### PR DESCRIPTION
Removing the "return to top" link as this is not needed.