### PR TITLE
Add start price to bid_label for future auctions

### DIFF
--- a/app/view_models/admin/auction_show_view_model.rb
+++ b/app/view_models/admin/auction_show_view_model.rb
@@ -103,10 +103,6 @@ class Admin::AuctionShowViewModel < Admin::BaseViewModel
     bidding_status.over?
   end
 
-  def available?
-    bidding_status.available?
-  end
-
   def future?
     bidding_status.future?
   end

--- a/app/view_models/admin/auction_show_view_model.rb
+++ b/app/view_models/admin/auction_show_view_model.rb
@@ -77,7 +77,47 @@ class Admin::AuctionShowViewModel < Admin::BaseViewModel
     MarkdownRender.new(auction.summary).to_s
   end
 
+  def bid_label
+    if over? && auction.bids.any?
+      "Winning bid (#{lowest_bidder_name}): #{highlighted_bid_amount_as_currency}"
+    elsif auction.bids.any?
+      "Current bid: #{highlighted_bid_amount_as_currency}"
+    elsif future?
+      "Starting price: #{Currency.new(auction.start_price)}"
+    else
+      ""
+    end
+  end
+
   private
+
+  def lowest_bidder_name
+    auction.lowest_bid.bidder_name
+  end
+
+  def highlighted_bid_amount_as_currency
+    Currency.new(rules.highlighted_bid(current_user).amount).to_s
+  end
+
+  def over?
+    bidding_status.over?
+  end
+
+  def available?
+    bidding_status.available?
+  end
+
+  def future?
+    bidding_status.future?
+  end
+
+  def bidding_status
+    @_bidding_status ||= BiddingStatus.new(auction)
+  end
+
+  def rules
+    @_rules ||= RulesFactory.new(auction).create
+  end
 
   def eligibility_label
     EligibilityFactory.new(auction).create.label

--- a/app/view_models/auction_show_view_model.rb
+++ b/app/view_models/auction_show_view_model.rb
@@ -71,6 +71,8 @@ class AuctionShowViewModel
       "Your bid: #{Currency.new(lowest_user_bid_amount)}"
     elsif auction.bids.any?
       "Current bid: #{highlighted_bid_amount_as_currency}"
+    elsif future?
+      "Starting price: #{Currency.new(auction.start_price)}"
     else
       ""
     end
@@ -169,6 +171,10 @@ class AuctionShowViewModel
 
   def available?
     bidding_status.available?
+  end
+
+  def future?
+    bidding_status.future?
   end
 
   def bidding_status

--- a/app/views/admin/auctions/show.html.erb
+++ b/app/views/admin/auctions/show.html.erb
@@ -20,6 +20,9 @@
           <div class="auction-subtitle">
             <%= @view_model.relative_time %>
           </div>
+          <div class="auction-subtitle">
+            <%= @view_model.bid_label %>
+          </div>
         </div>
       </div>
 

--- a/features/admin_views_future_auction.feature
+++ b/features/admin_views_future_auction.feature
@@ -10,6 +10,7 @@ Feature: Admin views future auction
     Then I should see a "Coming soon" label
     And I should not see the bid form
     And I should see the future published auction message for admins
+    And I should see the starting price
 
     When I click on the unpublish button
     Then I should see a success message confirming that the auction was updated
@@ -20,6 +21,7 @@ Feature: Admin views future auction
     And there is a future auction
     When I visit the admin auction page for that auction
     Then I should see the future published auction message for admins
+    And I should see the starting price
 
     When I click on the unpublish button
     Then I should see a success message confirming that the auction was updated
@@ -32,6 +34,7 @@ Feature: Admin views future auction
     And the auction is for a different purchase card
     When I visit the admin auction page for that auction
     Then I should see the future published auction message for admins
+    And I should see the starting price
 
     When I click on the unpublish button
     Then I should see a success message confirming that the auction was updated

--- a/features/step_definitions/page_content_steps.rb
+++ b/features/step_definitions/page_content_steps.rb
@@ -17,6 +17,10 @@ Then(/^I should see a current bid amount( of \$([\d\.]+))?$/) do |_, amount|
   expect(page).to have_content(amount) unless amount.nil?
 end
 
+Then(/^I should see the starting price$/) do
+  expect(page).to have_content("Starting price: #{Currency.new(@auction.start_price).to_s}")
+end
+
 Then(/^I should see a winning bid amount( of \$([\d\.]+))?$/) do |_, amount|
   expect(page).to have_content(/Winning bid \([^\)]+\): \$[\d,\.]+/)
   expect(page).to have_content(amount) unless amount.nil?

--- a/features/vendor_views_future_auction.feature
+++ b/features/vendor_views_future_auction.feature
@@ -10,3 +10,4 @@ Feature: Vendor views future auction
     Then I should see a "Coming soon" label
     And I should not see the bid form
     And I should see the future auction message for vendors
+    And I should see the starting price

--- a/spec/view_models/admin/auction_show_view_model_spec.rb
+++ b/spec/view_models/admin/auction_show_view_model_spec.rb
@@ -1,31 +1,71 @@
 require 'rails_helper'
 
 describe Admin::AuctionShowViewModel do
-  context 'auction for default purchase card' do
-    it 'returns c2 proposal URL and c2 status and receipt fields' do
-      auction = create(:auction, purchase_card: :default)
-      user = create(:user)
+  describe '#admin_data' do
+    context 'auction for default purchase card' do
+      it 'returns c2 proposal URL and c2 status and receipt fields' do
+        auction = create(:auction, purchase_card: :default)
+        user = create(:user)
 
-      view_model = Admin::AuctionShowViewModel.new(auction: auction, current_user: user)
-      data = view_model.admin_data
+        view_model = Admin::AuctionShowViewModel.new(auction: auction, current_user: user)
+        data = view_model.admin_data
 
-      expect(data).to have_key('C2 proposal URL')
-      expect(data).to have_key('C2 approval status')
-      expect(data).to have_key('Receipt URL')
+        expect(data).to have_key('C2 proposal URL')
+        expect(data).to have_key('C2 approval status')
+        expect(data).to have_key('Receipt URL')
+      end
+    end
+
+    context 'auction for other purchase card' do
+      it 'does not return c2 proposal URL or c2 status or receipt URL fields' do
+        auction = create(:auction, purchase_card: :other)
+        user = create(:user)
+
+        view_model = Admin::AuctionShowViewModel.new(auction: auction, current_user: user)
+        data = view_model.admin_data
+
+        expect(data).not_to have_key('C2 proposal URL')
+        expect(data).not_to have_key('C2 approval status')
+        expect(data).not_to have_key('Receipt URL')
+      end
     end
   end
 
-  context 'auction for other purchase card' do
-    it 'does not return c2 proposal URL or c2 status or receipt URL fields' do
-      auction = create(:auction, purchase_card: :other)
+  describe '#bid_label' do
+    it 'should show the winning bid amount and user when the auction has a winner' do
+      auction = create(:auction, :closed, :with_bids)
+      bid = WinningBid.new(auction).find
+      name = bid.bidder.name
       user = create(:user)
 
       view_model = Admin::AuctionShowViewModel.new(auction: auction, current_user: user)
-      data = view_model.admin_data
 
-      expect(data).not_to have_key('C2 proposal URL')
-      expect(data).not_to have_key('C2 approval status')
-      expect(data).not_to have_key('Receipt URL')
+      expect(view_model.bid_label).to eq("Winning bid (#{name}): #{Currency.new(bid.amount)}")
+    end
+
+    it 'should show the current bid when the auction has any bids' do
+      auction = create(:auction, :with_bids)
+      bid = WinningBid.new(auction).find
+      user = create(:user)
+      view_model = Admin::AuctionShowViewModel.new(auction: auction, current_user: user)
+
+      expect(view_model.bid_label).to eq("Current bid: #{Currency.new(bid.amount)}")
+    end
+
+    it "should show the starting price when auction hasn't started yet" do
+      auction = create(:auction, :future, start_price: 1000)
+      user = create(:user)
+      view_model = Admin::AuctionShowViewModel.new(auction: auction, current_user: user)
+
+      expect(view_model.bid_label).to eq("Starting price: $1,000.00")
+    end
+
+    it 'should be blank if auction had no bids' do
+      auction = create(:auction, :closed)
+      user = create(:user)
+      view_model = Admin::AuctionShowViewModel.new(auction: auction, current_user: user)
+
+      expect(view_model.bid_label).to be_blank
     end
   end
 end

--- a/spec/view_models/auction_show_view_model_spec.rb
+++ b/spec/view_models/auction_show_view_model_spec.rb
@@ -24,4 +24,51 @@ describe AuctionShowViewModel do
       end
     end
   end
+
+  describe '#bid_label' do
+    it 'should show the winning bid amount and user when the auction has a winner' do
+      auction = create(:auction, :closed, :with_bids)
+      bid = WinningBid.new(auction).find
+      name = bid.bidder.name
+      user = create(:user)
+
+      view_model = AuctionShowViewModel.new(auction: auction, current_user: user)
+
+      expect(view_model.bid_label).to eq("Winning bid (#{name}): #{Currency.new(bid.amount)}")
+    end
+
+    it "should show the user's bid when the user has bid" do
+      auction = create(:auction, :with_bids)
+      bid = auction.bids.first
+      user = bid.bidder
+      view_model = AuctionShowViewModel.new(auction: auction, current_user: user)
+
+      expect(view_model.bid_label).to eq("Your bid: #{Currency.new(bid.amount)}")
+    end
+
+    it 'should show the current bid when the auction has any bids' do
+      auction = create(:auction, :with_bids)
+      bid = WinningBid.new(auction).find
+      user = create(:user)
+      view_model = AuctionShowViewModel.new(auction: auction, current_user: user)
+
+      expect(view_model.bid_label).to eq("Current bid: #{Currency.new(bid.amount)}")
+    end
+
+    it "should show the starting price when auction hasn't started yet" do
+      auction = create(:auction, :future, start_price: 1000)
+      user = create(:user)
+      view_model = AuctionShowViewModel.new(auction: auction, current_user: user)
+
+      expect(view_model.bid_label).to eq("Starting price: $1,000.00")
+    end
+
+    it 'should be blank if auction had no bids' do
+      auction = create(:auction, :closed)
+      user = create(:user)
+      view_model = AuctionShowViewModel.new(auction: auction, current_user: user)
+
+      expect(view_model.bid_label).to be_blank
+    end
+  end
 end


### PR DESCRIPTION
Fixes #1292 
Fixes #1293 

In addition, I decided to add the bid_label to admin/auctions/:id show since it's required for this pull request, but I also supported some other status messages.