### PR TITLE
Show winning bid labels for reverse auctions

### DIFF
--- a/app/presenters/bidding_status_presenter/available.rb
+++ b/app/presenters/bidding_status_presenter/available.rb
@@ -19,6 +19,26 @@ class BiddingStatusPresenter::Available < BiddingStatusPresenter::Base
     'Open'
   end
 
+  def bid_label(user)
+    bid = highlighted_bid(user)
+    amount = Currency.new(bid.amount)
+
+    if bid.is_a?(NullBid)
+      I18n.t('bidding_status.available.bid_label.no_bids')
+    elsif auction.type == 'sealed_bid'
+      I18n.t('bidding_status.available.bid_label.sealed_bid',
+             amount: amount)
+    elsif auction.type == 'reverse' && bid.bidder == user
+      I18n.t('bidding_status.available.bid_label.reverse.vendor_winning',
+             amount: amount)
+    else
+      bidder_name = bid.bidder.name || bid.bidder.github_login
+      I18n.t('bidding_status.available.bid_label.reverse.default',
+             amount: amount,
+             bidder_name: bidder_name)
+    end
+  end
+
   def tag_data_value_status
     "#{HumanTime.new(time: auction.ended_at).distance_of_time_to_now} left"
   end
@@ -37,11 +57,15 @@ class BiddingStatusPresenter::Available < BiddingStatusPresenter::Base
 
   private
 
-  def winning_bid_amount_as_currency
-    Currency.new(lowest_bid.amount).to_s
+  def rules
+    @_rules ||= RulesFactory.new(auction).create
   end
 
-  def lowest_bid
-    auction.lowest_bid || NullBid.new
+  def highlighted_bid(user)
+    rules.highlighted_bid(user)
+  end
+
+  def winning_bid_amount_as_currency
+    Currency.new(rules.winning_bid.amount)
   end
 end

--- a/app/view_models/auction_show_view_model.rb
+++ b/app/view_models/auction_show_view_model.rb
@@ -65,7 +65,10 @@ class AuctionShowViewModel
   end
 
   def bid_label
-    if over? && auction.bids.any?
+    if available?
+      bidding_status_presenter.bid_label(current_user)
+    # will replace below in future issues
+    elsif over? && auction.bids.any?
       "Winning bid (#{lowest_bidder_name}): #{highlighted_bid_amount_as_currency}"
     elsif user_bids.any?
       "Your bid: #{Currency.new(lowest_user_bid_amount)}"

--- a/app/view_models/auction_show_view_model.rb
+++ b/app/view_models/auction_show_view_model.rb
@@ -67,7 +67,6 @@ class AuctionShowViewModel
   def bid_label
     if available?
       bidding_status_presenter.bid_label(current_user)
-    # will replace below in future issues
     elsif over? && auction.bids.any?
       "Winning bid (#{lowest_bidder_name}): #{highlighted_bid_amount_as_currency}"
     elsif user_bids.any?

--- a/config/locales/bidding_status/en.yml
+++ b/config/locales/bidding_status/en.yml
@@ -1,0 +1,12 @@
+en:
+  bidding_status:
+    available:
+      start_label: Bid start time
+      deadline_lable: Bid deadline
+      label: Open
+      bid_label:
+        no_bids: ''
+        sealed_bid: "Your bid: %{amount}"
+        reverse:
+          vendor_winning: "You have the lowest bid: %{amount}"
+          default: "Current low bid: %{amount} (%{bidder_name})"

--- a/features/guest_views_open_auction.feature
+++ b/features/guest_views_open_auction.feature
@@ -19,7 +19,7 @@ Feature: Guest views open auction
     And I should see an "Open" label
     And I should see when the auction started
     And I should see when the auction ends
-    And I should see a current bid amount
+    And I should see the current winning bid in a header subtitle
     And there should be meta tags for the open auction
     And I should not see the bid form
     And I should see the open auction message for guests

--- a/features/step_definitions/label_steps.rb
+++ b/features/step_definitions/label_steps.rb
@@ -41,3 +41,28 @@ Then(/^I should see a relative closing time for the auction$/) do
   relative_time = DcTimePresenter.new(@auction.ended_at).relative_time
   expect(page).to have_content("Closes #{relative_time}")
 end
+
+Then(/^I should see the current winning bid in a header subtitle$/) do
+  within(:css, '.auction-subtitles') do
+    expect(page).to have_content(
+      I18n.t('bidding_status.available.bid_label.reverse.default',
+             amount: winning_amount,
+             bidder_name: winner_name)
+    )
+  end
+end
+
+Then(/^I should not see the current winning bid in a header subtitle$/) do
+  within(:css, '.auction-subtitles') do
+    expect(page).to_not have_content("Current low bid:")
+  end
+end
+
+Then(/^I should see I have the current winning bid in a header subtitle$/) do
+  within(:css, '.auction-subtitles') do
+    expect(page).to have_content(
+      I18n.t('bidding_status.available.bid_label.reverse.vendor_winning',
+             amount: winning_amount)
+    )
+  end
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -47,7 +47,7 @@ module AuctionHelpers
   end
 
   def winning_bid
-    WinningBid.new(@auction).find
+    WinningBid.new(@auction.reload).find
   end
 
   def winning_amount

--- a/features/vendor_bids_reverse_auction.feature
+++ b/features/vendor_bids_reverse_auction.feature
@@ -13,20 +13,20 @@ Feature: Vendor bids on a reverse auction
     And I should see I do not have the winning bid
 
   @javascript
-  Scenario: Auction already has bids
+  Scenario: I have not bid on the auction yet
     Given there is an open auction
     And the auction has a lowest bid amount of 1000
     When I visit the home page
-    Then I should see "Current winning bid: $1,000"
-
     And I am a user with a verified SAM account
     And I sign in and verify my account information
     And I click on the auction's title
 
+    Then I should see the current winning bid in a header subtitle
+
     When I submit a bid for $999
     And I click OK on the javascript confirm dialog for a bid amount of $999.00
-    Then I should see "Your bid: $999"
     And I should not see the bid form
+    And I should see I have the current winning bid in a header subtitle
     And I should see I have the winning bid
 
  @javascript

--- a/features/vendor_bids_reverse_auction.feature
+++ b/features/vendor_bids_reverse_auction.feature
@@ -3,6 +3,15 @@ Feature: Vendor bids on a reverse auction
   I want to be able to bid on auctions
   So I can be paid for work
 
+  Scenario: Viewing an auction when someone else has outbid me
+    Given there is an open auction
+    And I am an authenticated vendor
+    And I have placed a bid that is not the lowest
+    When I visit the home page
+    And I click on the auction's title
+    And I should see the maximum bid amount in the bidding form
+    And I should see I do not have the winning bid
+
   @javascript
   Scenario: Auction already has bids
     Given there is an open auction

--- a/features/vendor_bids_sealed_auction.feature
+++ b/features/vendor_bids_sealed_auction.feature
@@ -21,7 +21,8 @@ Feature: Vendor bids on a sealed-bid auction
     When I click on the auction's title
     Then I should be on the auction page
     And I should not see "Your bid:"
-    And I should see "Current bid:"
+    And I should not see "Current bid:"
+    And I should not see the current winning bid in a header subtitle
     And I should see the bid form
     And I should see the maximum bid amount in the bidding form
 

--- a/spec/view_models/auction_show_view_model_spec.rb
+++ b/spec/view_models/auction_show_view_model_spec.rb
@@ -37,13 +37,13 @@ describe AuctionShowViewModel do
       expect(view_model.bid_label).to eq("Winning bid (#{name}): #{Currency.new(bid.amount)}")
     end
 
-    it "should show the user's bid when the user has bid" do
+    it "should show the user's bid when the user is winning" do
       auction = create(:auction, :with_bids)
-      bid = auction.bids.first
+      bid = auction.bids.last
       user = bid.bidder
       view_model = AuctionShowViewModel.new(auction: auction, current_user: user)
 
-      expect(view_model.bid_label).to eq("Your bid: #{Currency.new(bid.amount)}")
+      expect(view_model.bid_label).to eq("You have the lowest bid: #{Currency.new(bid.amount)}")
     end
 
     it 'should show the current bid when the auction has any bids' do
@@ -52,7 +52,7 @@ describe AuctionShowViewModel do
       user = create(:user)
       view_model = AuctionShowViewModel.new(auction: auction, current_user: user)
 
-      expect(view_model.bid_label).to eq("Current bid: #{Currency.new(bid.amount)}")
+      expect(view_model.bid_label).to eq("Current low bid: #{Currency.new(bid.amount)} (#{bid.bidder.name})")
     end
 
     it "should show the starting price when auction hasn't started yet" do
@@ -61,6 +61,24 @@ describe AuctionShowViewModel do
       view_model = AuctionShowViewModel.new(auction: auction, current_user: user)
 
       expect(view_model.bid_label).to eq("Starting price: $1,000.00")
+    end
+
+    it "should be blank when auction is sealed-bid and currently running" do
+      auction = create(:auction, :with_bids, :sealed_bid, start_price: 2500)
+      user = create(:user)
+      view_model = AuctionShowViewModel.new(auction: auction, current_user: user)
+
+      expect(view_model.bid_label).to eq("")
+    end
+
+    it "should show the user's bid when auction is sealed-bid and currently running and the user had bid" do
+      auction = create(:auction, :with_bids, :sealed_bid, start_price: 2500)
+      bid = auction.bids.first
+      user = bid.bidder
+
+      view_model = AuctionShowViewModel.new(auction: auction, current_user: user)
+
+      expect(view_model.bid_label).to eq("Your bid: #{Currency.new(bid.amount)}")
     end
 
     it 'should be blank if auction had no bids' do


### PR DESCRIPTION
Fixes #1291

Note that this also includes some code for available sealed-bid auctions even though there is no corresponding issue next. I just needed to ensure this solution would not leak information to sealed-bid vendors.

Also, I have moved this into the bidding_status presenters and also have tried to use the AuctionRules objects to determine winning bidder, etc. This only covers available auctions. Future work will clean up closed auctions and other bidding statuses.