### PR TITLE
BUG: Work in progress auctions weren't shown pending delivery

### DIFF
--- a/app/models/auction_query.rb
+++ b/app/models/auction_query.rb
@@ -55,7 +55,7 @@ class AuctionQuery
   end
 
   def delivery_needed
-    relation.published.ended.pending_delivery
+    relation.published.ended.to_be_delivered
   end
 
   def c2_payment_needed

--- a/app/models/concerns/auction_scopes.rb
+++ b/app/models/concerns/auction_scopes.rb
@@ -6,6 +6,10 @@ module AuctionScopes
     scope :accepted_pending_payment_url, lambda {
       where(delivery_status: delivery_statuses['accepted_pending_payment_url'])
     }
+    scope :to_be_delivered, lambda {
+      where(delivery_status: [delivery_statuses['pending_delivery'],
+                              delivery_statuses['work_in_progress']])
+    }
     scope :accepted_or_accepted_and_pending_payment_url, lambda {
       where(delivery_status: [delivery_statuses['accepted'],
                               delivery_statuses['accepted_pending_payment_url']])

--- a/spec/models/auction_query_spec.rb
+++ b/spec/models/auction_query_spec.rb
@@ -134,13 +134,14 @@ describe AuctionQuery do
       _regular = create(:auction)
       _unpublished = create(:auction, :unpublished)
       _pending_delivery = create(:auction, :closed)
+      _work_in_progress = create(:auction, :closed, :work_in_progress)
       _pending_acceptance = create(:auction, :evaluation_needed)
       _payment_needed = create(:auction, :payment_needed)
       _pending_url = create(:auction, :closed, :accepted_pending_payment_url)
 
       query = AuctionQuery.new
 
-      expect(query.needs_attention_count).to eq(5)
+      expect(query.needs_attention_count).to eq(6)
     end
   end
 


### PR DESCRIPTION
Fixes #1380 

Because we added a distinct new delivery status for `work_in_progress`, this meant those auctions no longer showed up on the needs_attention pane as `pending delivery`, even though they should. Added a new scope that spans both `pending_delivery` and `work_in_progress`
