### PR TITLE
Make Ed Mullen an admin

### DIFF
--- a/config/admins.yml
+++ b/config/admins.yml
@@ -8,3 +8,4 @@ github_ids:
   - 6518236  # Alla Goldman
   - 5840989  # Laura Gerhardt
   - 601515   # Jessie Young
+  - 2654503  # Ed Mullen


### PR DESCRIPTION
Fixes #1390 

This will need to be deployed to production to make it happen, but we can do a Deploy PR after this is merged.