### PR TITLE
Set the C2 URL manually from the C2 Sent screen

### DIFF
--- a/app/models/auction_parser.rb
+++ b/app/models/auction_parser.rb
@@ -22,6 +22,7 @@ class AuctionParser
     strong_params.require(:auction).permit(
       :billable_to,
       :c2_proposal_url,
+      :c2_status,
       :customer_id,
       :delivery_status,
       :delivery_url,

--- a/app/presenters/c2_status_presenter/sent.rb
+++ b/app/presenters/c2_status_presenter/sent.rb
@@ -6,4 +6,8 @@ class C2StatusPresenter::Sent < C2StatusPresenter::Base
   def body
     I18n.t('statuses.c2_presenter.sent.body')
   end
+
+  def action_partial
+    'admin/auctions/sent'
+  end
 end

--- a/app/services/update_auction.rb
+++ b/app/services/update_auction.rb
@@ -8,7 +8,7 @@ class UpdateAuction
   def perform
     assign_attributes
     update_auction_ended_job
-    perform_budget_approved_auction_tasks
+    perform_accepted_auction_tasks
     perform_rejected_auction_tasks
     auction.save
   end
@@ -47,7 +47,7 @@ class UpdateAuction
     parsed_attributes.key?(:ended_at)
   end
 
-  def perform_budget_approved_auction_tasks
+  def perform_accepted_auction_tasks
     if auction.accepted? && auction.accepted_at.nil? && auction.bids.any?
       AcceptAuction.new(
         auction: auction,

--- a/app/views/admin/auctions/_sent.html.erb
+++ b/app/views/admin/auctions/_sent.html.erb
@@ -1,0 +1,6 @@
+<%= simple_form_for [:admin, status.auction], url: admin_auction_path, method: :patch do |f| %>
+  <%= f.input :c2_proposal_url %>
+  <%= f.hidden_field :c2_status, value: 'pending_approval', hidden: true %>
+  <%= f.submit t('statuses.c2_presenter.sent.actions.set'),
+      class: 'usa-button usa-button-outline action-button' %>
+<% end %>

--- a/config/locales/statuses/en.yml
+++ b/config/locales/statuses/en.yml
@@ -193,7 +193,7 @@ en:
         header: "Pending C2 approval"
         body: "This auction has been sent to C2 for approval."
         actions:
-          set: Set C2
+          set: Set C2 URL
       pending_approval:
         header: "Pending C2 approval"
         body: >

--- a/config/locales/statuses/en.yml
+++ b/config/locales/statuses/en.yml
@@ -190,12 +190,15 @@ en:
               used without first being granted approval in C2."
         header: "C2 approval required"
       sent:
-         header: "Pending C2 approval"
-         body: "This auction has been sent to C2 for approval."
-      pending_approval:
         header: "Pending C2 approval"
         body: "This auction has been sent to C2 for approval."
-        action: "You can check on the status <a href=%{link}>here</a>."
+        actions:
+          set: Set C2
+      pending_approval:
+        header: "Pending C2 approval"
+        body: >
+          This auction has been sent to C2 for approval.
+        action: You can check on the status <a href=%{link}>here</a>.
       budget_approved:
         body: "This auction has been approved in C2: <a href=%{link}>%{link}</a>"
         header: "Approved in C2"

--- a/features/admin_archives_auction.feature
+++ b/features/admin_archives_auction.feature
@@ -8,7 +8,7 @@ Feature: Admin archives auction
     And I sign in
     And there is an unpublished auction
     And the auction is for the default purchase card
-    And the c2 proposal for the auction is not budget approved
+    And the c2 proposal for the auction is pending approval
     When I visit the admin form for that auction
     Then I should see the Archive button
 

--- a/features/admin_manually_adds_c2_information.feature
+++ b/features/admin_manually_adds_c2_information.feature
@@ -1,0 +1,36 @@
+Feature: Admin manually adds C2 information for default P-card auctions
+  As an administrator
+  I want to be able to move an auction through the approval flow manually if C2 integration is broken
+  so that I can publish it
+
+  @background_jobs_off
+  Scenario: Admin sees option to manually enter C2 information for pending approval
+    Given I am an administrator
+    And I sign in
+    And there is an unpublished auction
+    And the auction does not have a c2 proposal url
+    When I visit the admin auction page for that auction
+    Then I should see that approval has not been requested for the auction
+
+    When I click on the "Request approval" button
+    Then I should see "This auction has been sent to C2 for approval."
+    And I should see that the auction does not have a C2 Proposal URL
+    And I should not see a "Request approval" button
+    And I should see a text input for the C2 URL
+    And I should see a "Set C2" button
+
+  @background_jobs_off
+  Scenario: Admin manually enters C2 URL for pending approval
+    Given I am an administrator
+    And I sign in
+    And there is an unpublished auction
+    And the auction does not have a c2 proposal url
+    And the C2 proposal was sent for the auction
+
+    When I visit the admin auction page for that auction
+    Then I should see "This auction has been sent to C2 for approval."
+
+    When I enter a C2 URL in the C2 URL input
+    And I click on the "Set C2" button
+    Then I should see that the auction has a C2 Proposal URL
+    And I should see that the C2 status for an auction pending C2 approval

--- a/features/admin_manually_adds_c2_information.feature
+++ b/features/admin_manually_adds_c2_information.feature
@@ -13,11 +13,11 @@ Feature: Admin manually adds C2 information for default P-card auctions
     Then I should see that approval has not been requested for the auction
 
     When I click on the "Request approval" button
-    Then I should see "This auction has been sent to C2 for approval."
+    Then I should see the auction was sent to C2 for approval
     And I should see that the auction does not have a C2 Proposal URL
     And I should not see a "Request approval" button
     And I should see a text input for the C2 URL
-    And I should see a "Set C2" button
+    And I should see a "Set C2 URL" button
 
   @background_jobs_off
   Scenario: Admin manually enters C2 URL for pending approval
@@ -28,9 +28,9 @@ Feature: Admin manually adds C2 information for default P-card auctions
     And the C2 proposal was sent for the auction
 
     When I visit the admin auction page for that auction
-    Then I should see "This auction has been sent to C2 for approval."
+    Then I should see the auction was sent to C2 for approval
 
     When I enter a C2 URL in the C2 URL input
-    And I click on the "Set C2" button
+    And I click on the "Set C2 URL" button
     Then I should see that the auction has a C2 Proposal URL
     And I should see that the C2 status for an auction pending C2 approval

--- a/features/admin_publishes_auction.feature
+++ b/features/admin_publishes_auction.feature
@@ -17,7 +17,7 @@ Feature: Admin publishes auction in the admin panel
     And I sign in
     And there is an unpublished auction
     And the auction is for the default purchase card
-    And the c2 proposal for the auction is not budget approved
+    And the c2 proposal for the auction is pending approval
     When I visit the admin auction page for that auction
     Then I should see that the C2 status for an auction pending C2 approval
 

--- a/features/admin_requests_c2_approval.feature
+++ b/features/admin_requests_c2_approval.feature
@@ -12,7 +12,7 @@ Feature: Admin requests C2 approval for an auction
     Then I should see that approval has not been requested for the auction
 
     When I click on the "Request approval" button
-    Then I should see "This auction has been sent to C2 for approval."
+    Then I should see the auction was sent to C2 for approval
     And I should see that the auction does not have a C2 Proposal URL
     And I should not see a "Request approval" button
 

--- a/features/step_definitions/admin_auction_form_steps.rb
+++ b/features/step_definitions/admin_auction_form_steps.rb
@@ -226,3 +226,12 @@ end
 When(/^I should not see the 'Paid' checkbox$/) do
   expect(page).not_to have_field('auction_paid_at')
 end
+
+Then(/^I should see a text input for the C2 URL$/) do
+  find_field('auction_c2_proposal_url')
+end
+
+When(/^I enter a C2 URL in the C2 URL input$/) do
+  @c2_url = "https://c2-dev.18f.gov/proposals/#{rand(10_000)}"
+  fill_in('auction_c2_proposal_url', with: @c2_url)
+end

--- a/features/step_definitions/admin_auction_status_steps.rb
+++ b/features/step_definitions/admin_auction_status_steps.rb
@@ -1,3 +1,3 @@
 Then(/^I should see that approval has not been requested for the auction$/) do
-    I18n.t('statuses.c2_presenter.not_requested.body', link: '')
+  I18n.t('statuses.c2_presenter.not_requested.body', link: '')
 end

--- a/features/step_definitions/auction_create_steps.rb
+++ b/features/step_definitions/auction_create_steps.rb
@@ -193,8 +193,12 @@ Given(/^the auction needs payment$/) do
   @auction.update(FactoryGirl.attributes_for(:auction, :payment_needed))
 end
 
-Given(/^the c2 proposal for the auction is not budget approved$/) do
+Given(/^the c2 proposal for the auction is pending approval$/) do
   @auction.update(c2_status: :pending_approval)
+end
+
+Given(/^the C2 proposal was sent for the auction$/) do
+  @auction.update(c2_status: :sent)
 end
 
 Given(/^the auction does not have a c2 proposal url$/) do

--- a/features/step_definitions/auction_status_steps.rb
+++ b/features/step_definitions/auction_status_steps.rb
@@ -264,9 +264,15 @@ end
 
 Then(/^I should see the admin status message for an archived auction$/) do
   @auction.reload
-  expect(page.html).to have_content(
+  expect(page).to have_content(
     I18n.t(
       'statuses.admin_auction_status_presenter.archived.body'
     )
+  )
+end
+
+Then(/^I should see the auction was sent to C2 for approval$/) do
+  expect(page).to have_content(
+    I18n.t('statuses.c2_presenter.sent.body')
   )
 end

--- a/spec/services/update_auction_spec.rb
+++ b/spec/services/update_auction_spec.rb
@@ -58,6 +58,24 @@ describe UpdateAuction do
       end
     end
 
+    context 'when setting c2_proposal_url and c2_status manually' do
+      it 'should set the c2_proposal_url and c2_status' do
+        auction = create(:auction, c2_status: :sent)
+        c2_proposal_url = 'https://c2-dev.18f.gov/proposals/2486'
+        params = {auction: {c2_proposal_url: c2_proposal_url, c2_status: 'pending_approval'}}
+
+        UpdateAuction.new(
+          auction: auction,
+          params: params,
+          current_user: auction.user
+        ).perform
+
+        auction.reload
+        expect(auction.c2_proposal_url).to eq(c2_proposal_url)
+        expect(auction.c2_status).to eq('pending_approval')
+      end
+    end
+
     context 'when changing the title' do
       it 'updates the title' do
         auction = create(:auction, :delivery_due_at_expired)


### PR DESCRIPTION
Fixes #1368 

I need some help on the text here that is shown when the proposal has been sent for the auction

![localhost_3000_admin_auctions_13](https://cloud.githubusercontent.com/assets/2044/19769878/25301eaa-9c2b-11e6-8033-11f3e5282da2.jpg)

Also, we discussed having this action kill any existing job to create the proposal (to avoid duplicates). However, given that this requires the user to create a proposal on C2 then paste it in here, this would mean many minutes between clicking Sent and filling out this form, in which case either the job will have worked (and there is no need for the proposal) or have failed already. So I'm not going to add the extra complexity of finding and deleting a failed job here unless we decide we really need it.