### PR TITLE
Fixed a few missing i18n keys

### DIFF
--- a/app/mailers/winning_bidder_mailer.rb
+++ b/app/mailers/winning_bidder_mailer.rb
@@ -69,7 +69,7 @@ class WinningBidderMailer < ActionMailer::Base
     mail(
       to: @winning_bid.bidder.email,
       subject: I18n.t(
-        'mailers.auction_mailer.auction_paid_other_pcard.subject',
+        'mailers.winning_bidder_mailer.auction_paid_other_pcard.subject',
         auction_title: @auction.title
       ),
       from: SMTPCredentials.default_from,

--- a/app/view_models/admin/draft_list_item.rb
+++ b/app/view_models/admin/draft_list_item.rb
@@ -15,7 +15,8 @@ class Admin::DraftListItem < Admin::BaseViewModel
 
   def c2_proposal_status
     if auction.purchase_card == 'default'
-      I18n.t("drafts.c2_status.#{auction.c2_status}.status")
+      status_key = "drafts.c2_status.#{auction.c2_status}.status"
+      I18n.t(status_key)
     else
       'N/A'
     end

--- a/config/initializers/i18n_test.rb
+++ b/config/initializers/i18n_test.rb
@@ -1,0 +1,13 @@
+if Rails.env.test? || Rails.env.development?
+  class I18n::JustRaiseExceptionHandler < I18n::ExceptionHandler
+    def call(exception, locale, key, options)
+      if exception.is_a?(I18n::MissingTranslation) && key.to_s != 'i18n.plural.rule'
+        fail exception.to_exception
+      else
+        super
+      end
+    end
+  end
+
+  I18n.exception_handler = I18n::JustRaiseExceptionHandler.new
+end

--- a/config/locales/drafts/en.yml
+++ b/config/locales/drafts/en.yml
@@ -13,3 +13,5 @@ en:
         status: "Awaiting payment confirmation"
       payment_confirmed:
         status: "Payment confirmed"
+      c2_canceled:
+        status: "Canceled"

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -87,12 +87,13 @@ en:
         greeting: "Dear %{vendor_name},"
         para_1: >
           Payment in the amount of %{amount} has recently been made to
-          %{payment_url} for %{auction_title}. Please let us know if you've received it:
+          %{payment_url} for %{auction_title}. Please let us know if
+          you have received it
         para_2: "Questions? Contact micropurchase@gsa.gov."
         sign_off: "Sincerely,"
         from: "The 18F Micro-purchase team"
       auction_paid_other_pcard:
-        subject: Payment has been made for %{auction_title}
+        subject: "Payment has been made for %{auction_title}"
         greeting: "Dear %{vendor_name},"
         para_1: >-
           Payment in the amount of %{amount} has recently been made to

--- a/config/locales/statuses/en.yml
+++ b/config/locales/statuses/en.yml
@@ -160,7 +160,7 @@ en:
           The <a href=%{delivery_url}>pull request</a> from %{winner_url}
           was accepted. However, this vendor cannot
           be paid until they’ve specified a valid payment URL.
-      default_card:
+      default_pcard:
         accepted:
           header: Accepted
           body: >
@@ -175,8 +175,8 @@ en:
             %{accepted_at}. %{customer_url} has been asked to remit
             payment. You must manually mark this auction as paid when it
             is paid by the customer.
-            actions:
-              mark_paid: Mark as paid
+          actions:
+            mark_paid: Mark as paid
         paid:
           header: Paid
           body: >

--- a/features/step_definitions/admin_auction_status_steps.rb
+++ b/features/step_definitions/admin_auction_status_steps.rb
@@ -1,3 +1,3 @@
 Then(/^I should see that approval has not been requested for the auction$/) do
-    I18n.t('statuses.c2_presenter.approval_not_requested.body', link: '')
+    I18n.t('statuses.c2_presenter.not_requested.body', link: '')
 end


### PR DESCRIPTION
Fixes #1395 

I added an initializer for i18n that will cause missing keys to throw exceptions in development or test rather than display the `missing translation: ...` string. This revealed a few other cases of missing keys I have fixed as well.