### PR TITLE
Admin can manually approve pending C2 auctions now

### DIFF
--- a/app/presenters/c2_status_presenter/pending_approval.rb
+++ b/app/presenters/c2_status_presenter/pending_approval.rb
@@ -4,7 +4,8 @@ class C2StatusPresenter::PendingApproval < C2StatusPresenter::Base
   end
 
   def body
-    I18n.t('statuses.c2_presenter.pending_approval.body')
+    I18n.t('statuses.c2_presenter.pending_approval.body',
+           link: auction.c2_proposal_url)
   end
 
   def action_partial

--- a/app/views/admin/auctions/_pending.html.erb
+++ b/app/views/admin/auctions/_pending.html.erb
@@ -1,1 +1,5 @@
-<%= raw t('statuses.c2_presenter.pending_approval.action', link: status.auction.c2_proposal_url) %>
+<%= simple_form_for [:admin, status.auction], url: admin_auction_path, method: :patch do |f| %>
+  <%= f.hidden_field :c2_status, value: 'budget_approved', hidden: true %>
+  <%= f.submit t('statuses.c2_presenter.pending_approval.actions.approve'),
+      class: 'usa-button usa-button-outline action-button' %>
+<% end %>

--- a/config/locales/statuses/en.yml
+++ b/config/locales/statuses/en.yml
@@ -197,8 +197,10 @@ en:
       pending_approval:
         header: "Pending C2 approval"
         body: >
-          This auction has been sent to C2 for approval.
-        action: You can check on the status <a href=%{link}>here</a>.
+          This auction has been sent to C2 for approval. You can check
+          on the status <a href="%{link}">here</a>.
+        actions:
+          approve: Approve C2 Request
       budget_approved:
         body: "This auction has been approved in C2: <a href=%{link}>%{link}</a>"
         header: "Approved in C2"

--- a/features/admin_manually_adds_c2_information.feature
+++ b/features/admin_manually_adds_c2_information.feature
@@ -47,3 +47,16 @@ Feature: Admin manually adds C2 information for default P-card auctions
 
     When I mark the auction as paid
     Then I should see the C2 status for an auction pending payment confirmation
+
+  Scenario: Admin can manually approve C2 requests
+    Given I am an administrator
+    And I sign in
+    And there is an unpublished auction
+    And the auction has a c2 proposal url
+    And the c2 proposal for the auction is pending approval
+
+    When I visit the admin auction page for that auction
+    Then I should see an "Approve C2 Request" button
+
+    When I click on the "Approve C2 Request" button
+    Then I should see a "Publish" button

--- a/features/step_definitions/auction_status_steps.rb
+++ b/features/step_definitions/auction_status_steps.rb
@@ -125,8 +125,9 @@ Then(/^I should see winning bidder status for a rejected auction$/) do
 end
 
 Then(/^I should see that the C2 status for an auction pending C2 approval$/) do
-  expect(page).to have_content(
-    I18n.t('statuses.c2_presenter.pending_approval.body')
+  expect(page.html).to include(
+    I18n.t('statuses.c2_presenter.pending_approval.body',
+           link: @auction.c2_proposal_url)
   )
 end
 

--- a/features/step_definitions/auction_status_steps.rb
+++ b/features/step_definitions/auction_status_steps.rb
@@ -127,7 +127,7 @@ end
 Then(/^I should see that the C2 status for an auction pending C2 approval$/) do
   expect(page.html).to include(
     I18n.t('statuses.c2_presenter.pending_approval.body',
-           link: @auction.c2_proposal_url)
+           link: @auction.reload.c2_proposal_url)
   )
 end
 

--- a/spec/factories/auctions.rb
+++ b/spec/factories/auctions.rb
@@ -154,6 +154,7 @@ FactoryGirl.define do
 
     trait :pending_c2_approval do
       future
+      c2_proposal_url 'https://c2-dev.18f.gov/proposals/2486'
       c2_status :pending_approval
       purchase_card :default
       unpublished

--- a/spec/presenters/c2_status_presenter/pending_approval_spec.rb
+++ b/spec/presenters/c2_status_presenter/pending_approval_spec.rb
@@ -3,17 +3,18 @@ require 'rails_helper'
 describe C2StatusPresenter::PendingApproval do
   describe '#body' do
     it 'returns the body for pending_approval' do
-      auction = create(:auction)
+      auction = create(:auction, :pending_c2_approval)
       presenter = C2StatusPresenter::PendingApproval.new(auction: auction)
 
       expect(presenter.body)
-        .to eq(I18n.t('statuses.c2_presenter.pending_approval.body'))
+        .to eq(I18n.t('statuses.c2_presenter.pending_approval.body',
+                      link: auction.c2_proposal_url))
     end
   end
 
   describe '#header' do
     it 'returns the header for pending_approval' do
-      auction = create(:auction)
+      auction = create(:auction, :pending_c2_approval)
       presenter = C2StatusPresenter::PendingApproval.new(auction: auction)
 
       expect(presenter.header)


### PR DESCRIPTION
Fixes #1370 

![localhost_3000_admin_auctions_1](https://cloud.githubusercontent.com/assets/2044/19826648/253e27a0-9d5e-11e6-8c7b-84e8bbe598d0.jpg)
