### PR TITLE
Fix the holiday config bug in Cucumber

### DIFF
--- a/features/support/business_time.rb
+++ b/features/support/business_time.rb
@@ -1,0 +1,15 @@
+# Business_time doesn't seem to get along with poltergeist bc threading
+# See https://github.com/18F/micropurchase/issues/1318 for details
+module BusinessTime
+  class Config
+    class << self
+      def config
+        @_config ||= default_config
+      end
+    end
+  end
+end
+
+Holidays.between(Date.today, 2.years.from_now, :us, :observed).each do
+  |holiday| BusinessTime::Config.holidays << holiday[:date]
+end


### PR DESCRIPTION
Fixes #1318 

For some reason, business_time would occasionally fail when looking up its configuration to see what the holidays are. This seems to be an effect of it storing its configuration in Thread.main and the main thread being a Poltergeist one for Cucumber JS scenarios. I have added some code to force it to use a class variable instead and that seems to work. See issue for more details.