### PR TITLE
Don't show the CSV download for auctions without bidders

### DIFF
--- a/app/view_models/admin/auction_show_view_model.rb
+++ b/app/view_models/admin/auction_show_view_model.rb
@@ -7,7 +7,7 @@ class Admin::AuctionShowViewModel < Admin::BaseViewModel
   end
 
   def csv_report_partial
-    if bidding_status.over?
+    if bidding_status.over? && bids?
       'admin/auctions/csv_report'
     else
       'components/null'
@@ -120,8 +120,8 @@ class Admin::AuctionShowViewModel < Admin::BaseViewModel
     end
   end
 
-  def bidding_status
-    BiddingStatus.new(auction)
+  def bids?
+    auction.bids.any?
   end
 
   def customer

--- a/spec/view_models/admin/auction_show_view_model_spec.rb
+++ b/spec/view_models/admin/auction_show_view_model_spec.rb
@@ -30,4 +30,38 @@ describe Admin::AuctionShowViewModel do
       end
     end
   end
+
+  describe "#csv_report_partial" do
+    it 'should return a partial when the auction is over and has a winner' do
+      auction = create(:auction, :with_bids, :closed)
+      user = create(:user)
+      view_model = Admin::AuctionShowViewModel.new(auction: auction, current_user: user)
+
+      expect(view_model.csv_report_partial).to_not eq('components/null')
+    end
+
+    it 'should return a null partial when the auction had no winners' do
+      auction = create(:auction, :closed)
+      user = create(:user)
+      view_model = Admin::AuctionShowViewModel.new(auction: auction, current_user: user)
+
+      expect(view_model.csv_report_partial).to eq('components/null')
+    end
+
+    it 'should be a null partial when the auction has not started' do
+      auction = create(:auction, :future)
+      user = create(:user)
+      view_model = Admin::AuctionShowViewModel.new(auction: auction, current_user: user)
+
+      expect(view_model.csv_report_partial).to eq('components/null')
+    end
+
+    it 'should be a null partial when the auction is still running' do
+      auction = create(:auction, :with_bids)
+      user = create(:user)
+      view_model = Admin::AuctionShowViewModel.new(auction: auction, current_user: user)
+
+      expect(view_model.csv_report_partial).to eq('components/null')
+    end
+  end
 end


### PR DESCRIPTION
Fixes #1362

Only show the "Download CSV Report" on the `/admin/auctions/:id` screen for auctions that closed and had bidders (not any auction that has an end date in the past)