### PR TITLE
Force DefaultDateTime to be in EDT

### DIFF
--- a/spec/view_models/admin/edit_auction_view_model_spec.rb
+++ b/spec/view_models/admin/edit_auction_view_model_spec.rb
@@ -4,7 +4,7 @@ describe Admin::EditAuctionViewModel do
   describe '#hour_default' do
     context 'time present' do
       it 'returns hour in DC time' do
-        Timecop.freeze(Time.parse("10:00:00 UTC")) do
+        Timecop.freeze(Time.parse("09-09-2016 10:00:00 UTC")) do
           auction = build(:auction, delivery_due_at: Time.current)
           view_model = Admin::EditAuctionViewModel.new(auction)
 


### PR DESCRIPTION
This test fails from November to March when we are 5 hours behind UTC. 
This fixes the failing test in several current PRs