### PR TITLE
Add a missed_delivery status for auctions

### DIFF
--- a/app/models/admin_auction_status_presenter_factory.rb
+++ b/app/models/admin_auction_status_presenter_factory.rb
@@ -32,8 +32,12 @@ class AdminAuctionStatusPresenterFactory
       AdminAuctionStatusPresenter::Available
     elsif won? && auction.pending_delivery?
       AdminAuctionStatusPresenter::WorkNotStarted
+    elsif overdue_delivery?
+      AdminAuctionStatusPresenter::OverdueDelivery
     elsif auction.work_in_progress?
       AdminAuctionStatusPresenter::WorkInProgress
+    elsif auction.missed_delivery?
+      AdminAuctionStatusPresenter::MissedDelivery
     elsif auction.pending_acceptance?
       AdminAuctionStatusPresenter::PendingAcceptance
     elsif auction.accepted_pending_payment_url?
@@ -58,8 +62,12 @@ class AdminAuctionStatusPresenterFactory
       AdminAuctionStatusPresenter::ReadyToPublish
     elsif available?
       AdminAuctionStatusPresenter::Available
+    elsif overdue_delivery?
+      AdminAuctionStatusPresenter::OverdueDelivery
     elsif auction.work_in_progress?
       AdminAuctionStatusPresenter::WorkInProgress
+    elsif auction.missed_delivery?
+      AdminAuctionStatusPresenter::MissedDelivery
     elsif auction.pending_acceptance?
       AdminAuctionStatusPresenter::PendingAcceptance
     elsif auction.accepted_pending_payment_url?
@@ -91,6 +99,12 @@ class AdminAuctionStatusPresenterFactory
 
   def future?
     bidding_status.future?
+  end
+
+  def overdue_delivery?
+    won? &&
+      (auction.pending_delivery? || auction.work_in_progress?) &&
+      auction.delivery_due_at < Time.now
   end
 
   def bidding_status

--- a/app/models/auction.rb
+++ b/app/models/auction.rb
@@ -25,6 +25,7 @@ class Auction < ActiveRecord::Base
   enum delivery_status: {
     pending_delivery: 0,
     work_in_progress: 5,
+    missed_delivery: 6,
     pending_acceptance: 3,
     accepted_pending_payment_url: 4,
     accepted: 1,

--- a/app/presenters/admin_auction_status_presenter/missed_delivery.rb
+++ b/app/presenters/admin_auction_status_presenter/missed_delivery.rb
@@ -1,0 +1,11 @@
+class AdminAuctionStatusPresenter::MissedDelivery < AdminAuctionStatusPresenter::Base
+  def header
+    I18n.t('statuses.admin_auction_status_presenter.missed_delivery.header')
+  end
+
+  def body
+    I18n.t(
+      'statuses.admin_auction_status_presenter.missed_delivery.body'
+    )
+  end
+end

--- a/app/presenters/admin_auction_status_presenter/overdue_delivery.rb
+++ b/app/presenters/admin_auction_status_presenter/overdue_delivery.rb
@@ -1,0 +1,16 @@
+class AdminAuctionStatusPresenter::OverdueDelivery < AdminAuctionStatusPresenter::Base
+  def header
+    I18n.t('statuses.admin_auction_status_presenter.overdue_delivery.header')
+  end
+
+  def body
+    I18n.t(
+      'statuses.admin_auction_status_presenter.overdue_delivery.body',
+      winner_url: winner_url
+    )
+  end
+
+  def action_partial
+    'admin/auctions/overdue_delivery'
+  end
+end

--- a/app/presenters/admin_auction_status_presenter/pending_acceptance.rb
+++ b/app/presenters/admin_auction_status_presenter/pending_acceptance.rb
@@ -14,14 +14,4 @@ class AdminAuctionStatusPresenter::PendingAcceptance < AdminAuctionStatusPresent
   def action_partial
     'admin/auctions/accept_or_reject'
   end
-
-  private
-
-  def winner_url
-    Url.new(
-      link_text: winner.email,
-      path_name: 'admin_user',
-      params: { id: winner.id }
-    )
-  end
 end

--- a/app/views/admin/auctions/_overdue_delivery.html.erb
+++ b/app/views/admin/auctions/_overdue_delivery.html.erb
@@ -1,0 +1,5 @@
+<%= simple_form_for [:admin, status.auction], url: admin_auction_path, method: :patch do |f| %>
+  <%= f.hidden_field :delivery_status, value: 'missed_delivery', hidden: true %>
+  <%= f.submit t('statuses.admin_auction_status_presenter.overdue_delivery.actions.mark_not_delivered'),
+    class: 'usa-button usa-button-outline action-button' %>
+<% end %>

--- a/config/locales/statuses/en.yml
+++ b/config/locales/statuses/en.yml
@@ -144,6 +144,16 @@ en:
            %{delivery_deadline}.
         actions:
           mark_delivered: Mark as delivered
+      overdue_delivery:
+        header: Auction is past due
+        body: >
+          %{winner_url} has not submitted a delivery URL for this
+          auction.
+        actions:
+          mark_not_delivered: Mark as not delivered
+      missed_delivery:
+        header: Not delivered
+        body: This auction has been marked as not delivered
       pending_acceptance:
         body: >
           %{winner_url} made a <a href=%{delivery_url}>pull

--- a/features/admin_marks_auction_missed_delivery.feature
+++ b/features/admin_marks_auction_missed_delivery.feature
@@ -1,0 +1,16 @@
+Feature: Admin can mark a delivery missed for an auction
+  As an administrator
+  I should be able to mark an auction as not delivered
+  So that we can keep track of auctions that were not delivered
+
+ Scenario: Admin sees a way to mark an auction as not delivered
+   Given I am an administrator
+   And I sign in
+   And there is an auction with work in progress
+   And the delivery deadline for that auction has passed
+   When I visit the admin auction page for that auction
+   Then I should see the admin status for an auction with overdue delivery
+   And I should see a "Mark as not delivered" button
+
+   When I click on the "Mark as not delivered" button
+   And I should see the admin status for an auction with missed delivery

--- a/features/step_definitions/auction_create_steps.rb
+++ b/features/step_definitions/auction_create_steps.rb
@@ -213,6 +213,10 @@ Given(/^the auction has a c2 proposal url$/) do
   @auction.update!(c2_proposal_url: 'https://c2-dev.18f.gov/proposals/123')
 end
 
+Given(/^the delivery deadline for that auction has passed$/) do
+  @auction.update!(delivery_due_at: 4.minutes.ago)
+end
+
 Given(/^there is an auction with an associated customer$/) do
   @customer = FactoryGirl.create(:customer)
   @auction = FactoryGirl.create(:auction, customer: @customer)

--- a/features/step_definitions/auction_status_steps.rb
+++ b/features/step_definitions/auction_status_steps.rb
@@ -149,7 +149,20 @@ end
 
 Then(/^I should see the admin status for an auction that is pending acceptance$/) do
   expect(page).to have_content(
-    I18n.t('statuses.admin_auction_status_presenter.pending_acceptance.header')
+    I18n.t('statuses.admin_auction_status_presenter.pending_acceptance.body')
+  )
+end
+
+Then(/^I should see the admin status for an auction with overdue delivery$/) do
+  expect(page.html).to include(
+    I18n.t('statuses.admin_auction_status_presenter.overdue_delivery.body',
+           winner_url: winner_url)
+  )
+end
+
+Then(/^I should see the admin status for an auction with missed delivery$/) do
+  expect(page).to have_content(
+    I18n.t('statuses.admin_auction_status_presenter.missed_delivery.header')
   )
 end
 

--- a/features/step_definitions/auction_status_steps.rb
+++ b/features/step_definitions/auction_status_steps.rb
@@ -148,8 +148,11 @@ Then(/^I should see the admin status for an auction pending payment from the def
 end
 
 Then(/^I should see the admin status for an auction that is pending acceptance$/) do
-  expect(page).to have_content(
-    I18n.t('statuses.admin_auction_status_presenter.pending_acceptance.body')
+  expect(page.html).to include(
+    I18n.t('statuses.admin_auction_status_presenter.pending_acceptance.body',
+           winner_url: winner_url,
+           delivery_url: @auction.delivery_url
+    )
   )
 end
 

--- a/spec/models/admin_auction_status_presenter_factory_spec.rb
+++ b/spec/models/admin_auction_status_presenter_factory_spec.rb
@@ -19,6 +19,24 @@ describe AdminAuctionStatusPresenterFactory do
     end
   end
 
+  context "when the vendor is late on delivery" do
+    it 'should return a AdminAuctionStatusPresenter::OverdueDelivery' do
+      auction = create(:auction, :closed, :published, :with_bids, delivery_status: :work_in_progress, delivery_due_at: 4.minutes.ago)
+
+      expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
+        .to be_a(AdminAuctionStatusPresenter::OverdueDelivery)
+    end
+  end
+
+  context "when the auction has been marked as a missed delivery" do
+    it 'should return a AdminAuctionStatusPresenter::Future' do
+      auction = create(:auction, :closed, :published, :with_bids, delivery_due_at: 4.minutes.ago, delivery_status: :missed_delivery)
+
+      expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
+        .to be_a(AdminAuctionStatusPresenter::MissedDelivery)
+    end
+  end
+
   context "when an auction has been accepted but doesn't have a payment URL yet" do
     it 'should return a AdminAuctionStatusPresenter::AcceptedPendingPaymentUrl' do
       auction = create(:auction, :closed, :with_bids, :published, :delivery_url, delivery_status: :accepted_pending_payment_url)


### PR DESCRIPTION
Fixes #1411

This allows us to explicitly mark some auctions where delivery deadline was missed