### PR TITLE
Email the vendor when delivery marked as missed

### DIFF
--- a/app/controllers/admin/missed_deliveries_controller.rb
+++ b/app/controllers/admin/missed_deliveries_controller.rb
@@ -1,0 +1,18 @@
+class Admin::MissedDeliveriesController < Admin::BaseController
+  def update
+    @auction = Auction.find(params[:id])
+
+    missed_delivery = MarkAuctionDeliveryMissed.new(
+      auction: @auction
+    )
+
+    if missed_delivery.perform
+      @auction.save!
+    else
+      error_messages = @auction.errors.full_messages.to_sentence
+      flash[:error] = error_messages
+    end
+
+    redirect_to admin_auction_path(@auction)
+  end
+end

--- a/app/mailers/winning_bidder_mailer.rb
+++ b/app/mailers/winning_bidder_mailer.rb
@@ -47,6 +47,20 @@ class WinningBidderMailer < ActionMailer::Base
     )
   end
 
+  def auction_not_delivered(auction:)
+    @auction = auction
+    @winning_bid = WinningBid.new(@auction).find
+    @delivery_timestamp = @auction.delivery_due_at
+
+    mail(
+      to: @winning_bid.bidder.email,
+      subject: I18n.t('mailers.winning_bidder_mailer.auction_not_delivered.subject',
+                      auction_title: @auction.title),
+      from: SMTPCredentials.default_from,
+      reply_to: 'micropurchase@gsa.gov'
+    )
+  end
+
   def auction_paid_default_pcard(auction:)
     @auction = auction
     @winning_bid = WinningBid.new(@auction).find

--- a/app/services/mark_auction_delivery_missed.rb
+++ b/app/services/mark_auction_delivery_missed.rb
@@ -1,0 +1,12 @@
+class MarkAuctionDeliveryMissed
+  attr_reader :auction
+
+  def initialize(auction:)
+    @auction = auction
+  end
+
+  def perform
+    auction.delivery_status = :missed_delivery
+    WinningBidderMailer.auction_not_delivered(auction: auction).deliver_later
+  end
+end

--- a/app/services/mark_auction_delivery_missed_spec.rb
+++ b/app/services/mark_auction_delivery_missed_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+describe MarkAuctionDeliveryMissed do
+  describe '#perform' do
+    it 'sets the auction delivery_status to missed_delivery' do
+      auction = create(:auction, :with_bids, :work_in_progress)
+
+      MarkAuctionDeliveryMissed.new(auction: auction).perform
+
+      expect(auction).to be_missed_delivery
+    end
+
+    it 'sends an email to the vendor notifying them they missed the deadline' do
+      auction = create(:auction, :with_bids, :work_in_progress)
+
+      mailer_double = double(deliver_later: true)
+      allow(WinningBidderMailer).to receive(:auction_not_delivered)
+        .with(auction: auction)
+        .and_return(mailer_double)
+
+      MarkAuctionDeliveryMissed.new(auction: auction).perform
+
+      expect(WinningBidderMailer).to have_received(:auction_not_delivered)
+      expect(mailer_double).to have_received(:deliver_later)
+    end
+  end
+end

--- a/app/views/admin/auctions/_overdue_delivery.html.erb
+++ b/app/views/admin/auctions/_overdue_delivery.html.erb
@@ -1,5 +1,4 @@
-<%= simple_form_for [:admin, status.auction], url: admin_auction_path, method: :patch do |f| %>
-  <%= f.hidden_field :delivery_status, value: 'missed_delivery', hidden: true %>
-  <%= f.submit t('statuses.admin_auction_status_presenter.overdue_delivery.actions.mark_not_delivered'),
-    class: 'usa-button usa-button-outline action-button' %>
-<% end %>
+<%= link_to I18n.t('statuses.admin_auction_status_presenter.overdue_delivery.actions.mark_not_delivered'),
+  admin_missed_delivery_path(status.auction),
+  method: :patch,
+  class: 'usa-button usa-button-outline action-button' %>

--- a/app/views/winning_bidder_mailer/auction_not_delivered.text.erb
+++ b/app/views/winning_bidder_mailer/auction_not_delivered.text.erb
@@ -1,0 +1,9 @@
+<%= I18n.t(
+  'mailers.winning_bidder_mailer.auction_not_delivered.para_1',
+  auction_title: @auction.title,
+  auction_delivery_deadline: DcTimePresenter.convert_and_format(@delivery_timestamp)
+) %>
+
+<%= I18n.t(
+  'mailers.winning_bidder_mailer.auction_not_delivered.para_2'
+) %>

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -82,6 +82,13 @@ en:
           out, we hope you will continue to participate in the future.
         sign_off: "Sincerely,"
         from: "The 18F Micro-purchase team"
+      auction_not_delivered:
+        subject: "%{auction_title} has not been delivered"
+        para_1: >
+          The delivery deadline for %{auction_title} was on %{auction_delivery_deadline} and we have not yet
+          received a delivery URL from you. Therefore you no longer qualify to receive the award.
+        para_2: >
+          If you have any questions, or if you think this is a mistake, please contact us at micropurchase@gsa.gov
       auction_paid_default_pcard:
         subject: "Please confirm payment for %{auction_title}"
         greeting: "Dear %{vendor_name},"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
     resources :auction_rejections, only: [:update]
     resources :auction_acceptances, only: [:update]
     resources :auction_mark_payments, only: [:update]
+    resources :missed_deliveries, only: [:update]
     resources :user_reports, only: [:index]
     resources :proposals, only: [:create]
     resources :users, only: [:show, :edit, :update]


### PR DESCRIPTION
Fixes #1424 

This email will not be sent when the delivery_due_at deadline is passed but when the administrator explicitly marks the auction as missed_delivery, meaning that no work will be accepted.

I'm not entirely happy with the various 1-function admin controllers for marking delivery late or accepting auctions or such. I wonder if it makes sense to relax our RESTful model and have a special auction actions controller that contains all of these. Thoughts?