### PR TITLE
Auction types on homepage should link to rules pages

### DIFF
--- a/app/models/rules/base_rules.rb
+++ b/app/models/rules/base_rules.rb
@@ -7,10 +7,6 @@ class Rules::BaseRules
     @eligibility = eligibility
   end
 
-  def path
-    "/auctions/rules/#{auction.type.dasherize}"
-  end
-
   def eligibility_label
     eligibility.label
   end

--- a/app/models/rules/reverse_auction.rb
+++ b/app/models/rules/reverse_auction.rb
@@ -22,4 +22,12 @@ class Rules::ReverseAuction < Rules::BaseRules
   def show_bids?
     true
   end
+
+  def rules_label
+    'Reverse'
+  end
+
+  def rules_route
+    'auctions_rules_reverse'
+  end
 end

--- a/app/models/rules/sealed_bid_auction.rb
+++ b/app/models/rules/sealed_bid_auction.rb
@@ -39,6 +39,14 @@ class Rules::SealedBidAuction < Rules::BaseRules
     !auction_available?
   end
 
+  def rules_label
+    'Sealed bid'
+  end
+
+  def rules_route
+    'auctions_rules_sealed_bid'
+  end
+
   private
 
   def lowest_user_bid(user)

--- a/app/view_models/auction_list_item.rb
+++ b/app/view_models/auction_list_item.rb
@@ -26,8 +26,12 @@ class AuctionListItem
     MarkdownRender.new(auction.summary).to_s
   end
 
-  def capitalized_formatted_type
-    auction.type.dasherize.capitalize
+  def rules_label
+    rules.rules_label
+  end
+
+  def rules_route
+    rules.rules_route
   end
 
   def starting_price
@@ -100,5 +104,9 @@ class AuctionListItem
 
   def bidding_status
     BiddingStatus.new(auction)
+  end
+
+  def rules
+    @_rules ||= RulesFactory.new(auction).create
   end
 end

--- a/app/view_models/auction_show_view_model.rb
+++ b/app/view_models/auction_show_view_model.rb
@@ -45,8 +45,12 @@ class AuctionShowViewModel
     auction.issue_url
   end
 
-  def rules_path
-    rules.path
+  def rules_route
+    rules.rules_route
+  end
+
+  def rules_label
+    rules.rules_label
   end
 
   def capitalized_type

--- a/app/views/auctions/_list_item.html.erb
+++ b/app/views/auctions/_list_item.html.erb
@@ -29,7 +29,7 @@
           <li class="details-list-item">
             <div class="details-label">Type</div>
             <div class="details-title">
-              <%= auction.capitalized_formatted_type %>
+              <%= link_to auction.rules_label, polymorphic_path(auction.rules_route) %>
             </div>
           </li>
 

--- a/app/views/auctions/show.html.erb
+++ b/app/views/auctions/show.html.erb
@@ -52,8 +52,8 @@
 
           <h6>Auction type:</h6>
           <p class="auction-label-info">
-          <%= @view_model.capitalized_type %>
-          (<%= link_to 'rules', @view_model.rules_path %>)
+          <%= @view_model.rules_label %>
+          (<%= link_to 'rules', polymorphic_path(@view_model.rules_route) %>)
           </p>
           <%= render partial: @view_model.paid_at_partial, locals: { auction: @view_model } %>
           <%= render partial: @view_model.accepted_at_partial, locals: { auction: @view_model } %>

--- a/features/guest_views_auctions.feature
+++ b/features/guest_views_auctions.feature
@@ -11,6 +11,20 @@ Feature: Basic Auction Views
     And I should not see the unpublished auction
     And there should be meta tags for the index page for 1 open and 0 future auctions
 
+  Scenario: Navigating to the rules
+    Given there is an open auction
+    And there is a sealed-bid auction
+    When I visit the home page
+    Then I should see a "Reverse" link
+    And I should see a "Sealed bid" link
+
+    When I click on the "Reverse" link
+    Then I should be on the rules page for reverse auctions
+
+    When I visit the home page
+    And I click on the "Sealed bid" link
+    Then I should be on the rules page for sealed-bid auctions
+
   Scenario: There are no auctions
     When I visit the home page
     Then I should see a message about no auctions

--- a/features/step_definitions/auction_rules_steps.rb
+++ b/features/step_definitions/auction_rules_steps.rb
@@ -1,7 +1,7 @@
-Then(/^I should see that the auction is (Sealed-bid|Reverse)$/) do |type|
+Then(/^I should see that the auction is (Sealed bid|Reverse)$/) do |type|
   expect(page).to have_content(type)
 end
 
-Then(/^I should see the rules for (Sealed-bid|Reverse) auctions$/) do |type|
+Then(/^I should see the rules for (Sealed bid|Reverse) auctions$/) do |type|
   expect(page).to have_content("#{type} (rules)")
 end

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -145,3 +145,11 @@ end
 Then(/^I should be on the auction receipt page$/) do
   expect(page.current_path).to eq(new_auction_receipt_path(@auction))
 end
+
+Then(/^I should be on the rules page for reverse auctions$/) do
+  expect(page.current_path).to eq('/auctions/rules/reverse')
+end
+
+Then(/^I should be on the rules page for sealed-bid auctions$/) do
+  expect(page.current_path).to eq('/auctions/rules/sealed-bid')
+end

--- a/features/vendor_bids_sealed_auction.feature
+++ b/features/vendor_bids_sealed_auction.feature
@@ -6,10 +6,10 @@ Feature: Vendor bids on a sealed-bid auction
   Scenario: viewing the rules page
     Given there is a sealed-bid auction
     When I visit the home page
-    Then I should see that the auction is Sealed-bid
+    Then I should see that the auction is Sealed bid
 
     When I click on the auction's title
-    Then I should see the rules for Sealed-bid auctions
+    Then I should see the rules for Sealed bid auctions
 
   @javascript
   Scenario: bidding on a sealed-bid auction


### PR DESCRIPTION
Fixes #1441 

Also, did you know you could use `polymorphic_path` and `polymorphic_url` to create URLs from route strings? Now you do.