### PR TITLE
Remove SAM status flashes from homepage

### DIFF
--- a/app/controllers/auctions_controller.rb
+++ b/app/controllers/auctions_controller.rb
@@ -7,7 +7,6 @@ class AuctionsController < ApplicationController
       current_user: current_user
     )
     @auctions = paginated_auctions
-    @auction_collection.sam_status_message_for(flash)
   end
 
   def show
@@ -17,6 +16,7 @@ class AuctionsController < ApplicationController
       current_user: current_user,
       bid_error: flash[:bid_error]
     )
+    @view_model.sam_status_message_for(flash)
   end
 
   def update

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,12 +3,13 @@ class UsersController < ApplicationController
 
   def edit
     @view_model = EditUserViewModel.new(current_user)
+    @view_model.sam_status_message_for(flash)
   end
 
   def update
     updater = UpdateUser.new(params, current_user)
     if updater.save
-      redirect_to root_path
+      redirect_to action: :edit
     else
       @view_model = EditUserViewModel.new(current_user)
       flash.now[:error] = updater.errors

--- a/app/view_models/auction_show_view_model.rb
+++ b/app/view_models/auction_show_view_model.rb
@@ -41,6 +41,12 @@ class AuctionShowViewModel
     }.compact
   end
 
+  def sam_status_message_for(flash)
+    if available?
+      current_user.decorate.sam_status_message_for(flash)
+    end
+  end
+
   def issue_url
     auction.issue_url
   end

--- a/app/view_models/auctions_index_view_model.rb
+++ b/app/view_models/auctions_index_view_model.rb
@@ -20,10 +20,6 @@ class AuctionsIndexViewModel
     end
   end
 
-  def sam_status_message_for(flash)
-    current_user.decorate.sam_status_message_for(flash)
-  end
-
   def welcome_message_partial
     current_user.decorate.welcome_message_partial
   end

--- a/app/view_models/edit_user_view_model.rb
+++ b/app/view_models/edit_user_view_model.rb
@@ -23,6 +23,10 @@ class EditUserViewModel
     AccountSubnavViewModel.new(current_user: @user, active_tab: :profile)
   end
 
+  def sam_status_message_for(flash)
+    @user.decorate.sam_status_message_for(flash)
+  end
+
   private
 
   attr_reader :user

--- a/features/step_definitions/flash_message_steps.rb
+++ b/features/step_definitions/flash_message_steps.rb
@@ -16,6 +16,10 @@ Then(/^I should see an error that "([^"]*)"$/) do |message|
   end
 end
 
+Then(/^I should not see an alert$/) do
+  expect(page).not_to have_css('div.usa-alert')
+end
+
 Then(/^I should see an alert that$/) do |message|
   step("I should see an alert that \"#{message}\"")
 end

--- a/features/vendor_bids_reverse_auction.feature
+++ b/features/vendor_bids_reverse_auction.feature
@@ -19,6 +19,8 @@ Feature: Vendor bids on a reverse auction
     When I visit the home page
     And I am a user with a verified SAM account
     And I sign in and verify my account information
+
+    When I visit the home page
     And I click on the auction's title
 
     Then I should see the current winning bid in a header subtitle

--- a/features/vendor_edits_profile.feature
+++ b/features/vendor_edits_profile.feature
@@ -13,7 +13,7 @@ Feature: Vendor edits profile
     When I fill the "Email address" field with "doris@example.com"
     When I fill the "Name" field with "Doris Doogooder"
     And I click on the "Update" button
-    Then I should be on the home page
+    Then I should be on my profile page
 
     When I click on the "Account" link
     Then I should see "doris@example.com" in the "Email address" field
@@ -30,14 +30,12 @@ Feature: Vendor edits profile
     Given I am a user without a DUNS number
     And I am signed in
     And I visit my profile page
-
-    When I should be on my profile page
     And I should see a profile form with my info
 
     When I fill the "Email address" field with "doris@example.com"
     When I fill the "Name" field with "Doris Doogooder"
     And I click on the "Update" button
-    Then I should be on the home page
+    Then I should be on my profile page
 
   Scenario: User tries to enter an invalid email address
     Given I am a user with a verified SAM account

--- a/features/vendor_provides_payment_url.feature
+++ b/features/vendor_provides_payment_url.feature
@@ -15,9 +15,7 @@ Feature: Vendor updates Payment URL
     When I visit my profile page
     And I fill in the Payment URL field on my profile page
     And I click on the "Update" button
-    Then I should be on the home page
-
-    When I visit my profile page
+    Then I should be on my profile page
     Then I should see my payment URL in the "Payment url" field
 
   Scenario: Vendor edits an existing Payment URL
@@ -26,9 +24,7 @@ Feature: Vendor updates Payment URL
     And I visit my profile page
     When I fill in the Payment URL field on my profile page
     And I click on the "Update" button
-    Then I should be on the home page
-
-    When I visit my profile page
+    Then I should be on my profile page
     Then the new value should be stored as my Payment URL
 
   Scenario: Vendor cannot save payment URL with invalid format

--- a/features/vendor_verifies_sam_status.feature
+++ b/features/vendor_verifies_sam_status.feature
@@ -8,7 +8,11 @@ Feature: Automatically checking a user's SAM status
     And a SAM check for my DUNS will return true
     When I sign in and verify my account information
     Then I should become a valid SAM user
-    And I should see a success message that "Your DUNS number has been verified in Sam.gov"
+
+    When there is an open auction
+    And I visit the auction page
+    Then I should see a success message that "Your DUNS number has been verified in Sam.gov"
+
     When I visit my profile page
     Then I should see that my DUNS number was verified
 
@@ -57,8 +61,13 @@ Feature: Automatically checking a user's SAM status
   Scenario: No DUNS number present
     Given I am a user without a DUNS number
     And I am signed in
+    And there is an open auction
     When I visit the home page
+    Then I should not see an alert
+
+    When I click on the auction's title
     Then I should see a warning that "In order to bid, you must supply a valid DUNS number. Please update your profile"
+
 
   Scenario: Admin user
     Given I am an administrator

--- a/features/vendor_verifies_sam_status.feature
+++ b/features/vendor_verifies_sam_status.feature
@@ -20,13 +20,20 @@ Feature: Automatically checking a user's SAM status
     Given I am a user without a verified SAM account
     And I am signed in
     And a SAM check for my DUNS will return true
+    And there is an open auction
+
     When I visit my profile page
     And I enter a valid DUNS in my profile
     And I click on the "Update" button
     Then I should become a valid SAM user
+
     When I visit my profile page
     Then I should see that my DUNS number was verified
+
     When I visit the home page
+    Then I should not see an alert
+
+    When I visit the auction page
     Then I should see a success message that "Your DUNS number has been verified in Sam.gov"
 
   @background_jobs_off
@@ -37,15 +44,13 @@ Feature: Automatically checking a user's SAM status
     And I enter a new DUNS in my profile
     And I click on the "Update" button
     Then I should see a warning that "Your profile is pending while your DUNS number is being validated. This typically takes less than one hour"
-    When I visit my profile page
-    Then I should see that my DUNS number is being verified
+    And I should see that my DUNS number is being verified
 
   Scenario: Negative SAM check on login
     Given I am a user without a verified SAM account
     When I sign in and verify my account information
     Then I should see an alert that my DUNS number was not found in Sam.gov
-    When I visit my profile page
-    Then I should see that my DUNS number was not verified
+    And I should see that my DUNS number was not verified
 
   Scenario: Negative SAM check on DUNS change
     Given I am a user without a verified SAM account
@@ -55,8 +60,7 @@ Feature: Automatically checking a user's SAM status
     And I click on the "Update" button
     Then I should not become a valid SAM user
     And I should see an alert that my DUNS number was not found in Sam.gov
-    When I visit my profile page
-    Then I should see that my DUNS number was not verified
+    And I should see that my DUNS number was not verified
 
   Scenario: No DUNS number present
     Given I am a user without a DUNS number
@@ -68,9 +72,11 @@ Feature: Automatically checking a user's SAM status
     When I click on the auction's title
     Then I should see a warning that "In order to bid, you must supply a valid DUNS number. Please update your profile"
 
+    When I visit my profile page
+    Then I should see a warning that "In order to bid, you must supply a valid DUNS number. Please update your profile"
 
   Scenario: Admin user
     Given I am an administrator
     And I am signed in
     When I visit the home page
-    Then I should not see a flash message
+    Then I should not see an alert

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -23,7 +23,7 @@ describe UsersController do
       expect_any_instance_of(UpdateUser).to receive(:save).and_return(true)
       put :update, { id: user.id, user: { duns_number: '222' } }, user_id: user.id
       expect(response).to be_redirect
-      expect(response.location).to eq('http://test.host/')
+      expect(response.location).to eq('http://test.host/account/profile')
     end
   end
 


### PR DESCRIPTION
Fixes #1241 

These are now on the auction show page if the auction is available and on the user profile edit page. In addition, I changed the `user_controllers#update` to return to the edit form on update so that I can show an updated flash there. For instance

![18f_-_micro-purchase](https://cloud.githubusercontent.com/assets/2044/20368792/9026230a-ac23-11e6-8097-cc1c7a7f0730.jpg)

now leads to 

![18f_-_micro-purchase](https://cloud.githubusercontent.com/assets/2044/20368814/af4dd138-ac23-11e6-9c75-67742357ad87.jpg)

I also see it when the auction is open for bidding

![18f_micro-purchase_-_proactive_solution-oriented_framework](https://cloud.githubusercontent.com/assets/2044/20368844/ccf6235c-ac23-11e6-97d9-ea5f597fc502.jpg)

I could probably use some styling advice here
