### PR TITLE
Ruboclean

### DIFF
--- a/app/models/statistics/total_savings.rb
+++ b/app/models/statistics/total_savings.rb
@@ -1,6 +1,6 @@
 class Statistics::TotalSavings
   def to_s
-    if completed_auctions.count > 0
+    if completed_auctions.count.positive?
       Currency.new(total_starting_price - total_winning_bid_amount).to_s
     else
       'n/a'

--- a/app/presenters/admin_auction_status_presenter/available.rb
+++ b/app/presenters/admin_auction_status_presenter/available.rb
@@ -4,7 +4,7 @@ class AdminAuctionStatusPresenter::Available < AdminAuctionStatusPresenter::Base
   end
 
   def body
-    if total_bids > 0
+    if total_bids.positive?
       I18n.t(
         'statuses.bid_status_presenter.available.admin.has_bids',
         end_date: end_date,

--- a/app/presenters/average.rb
+++ b/app/presenters/average.rb
@@ -8,7 +8,7 @@ class Average
   end
 
   def to_s
-    if count > 0
+    if count.positive?
       calculate
     else
       'n/a'

--- a/app/presenters/bid_status_presenter/over/vendor/winner/accepted_pending_payment_url.rb
+++ b/app/presenters/bid_status_presenter/over/vendor/winner/accepted_pending_payment_url.rb
@@ -6,7 +6,7 @@ class BidStatusPresenter::Over::Vendor::Winner::AcceptedPendingPaymentUrl < BidS
   def body
     I18n.t(
       'statuses.bid_status_presenter.over.winner.accepted_pending_payment_url.body',
-      delivery_url: auction.delivery_url,
+      delivery_url: auction.delivery_url
     )
   end
 end

--- a/app/presenters/dc_time_presenter.rb
+++ b/app/presenters/dc_time_presenter.rb
@@ -61,7 +61,7 @@ class DcTimePresenter
                         pluralize(abs_time_diff / 60, "minute")
                       end
 
-      if time_diff > 0
+      if time_diff.positive?
         "in #{relative_time}"
       else
         "#{relative_time} ago"

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -11,10 +11,14 @@ class UserSerializer < ActiveModel::Serializer
   )
 
   def created_at
-    object.created_at.iso8601 rescue nil
+    object.created_at.iso8601
+  rescue
+    nil
   end
 
   def updated_at
-    object.updated_at.iso8601 rescue nil
+    object.updated_at.iso8601
+  rescue
+    nil
   end
 end

--- a/app/services/check_payment.rb
+++ b/app/services/check_payment.rb
@@ -7,12 +7,11 @@ class CheckPayment < C2ApiWrapper
     auctions.each do |auction|
       paid_at = find_purchase_timestamp(proposal_json(auction))
 
-      if paid_at
-        auction.update(c2_status: :c2_paid, paid_at: DateTime.parse(paid_at))
-        WinningBidderMailer.auction_paid_default_pcard(
-          auction: auction
-        ).deliver_later
-      end
+      next unless paid_at
+      auction.update(c2_status: :c2_paid, paid_at: DateTime.parse(paid_at))
+      WinningBidderMailer.auction_paid_default_pcard(
+        auction: auction
+      ).deliver_later
     end
   end
 

--- a/app/view_models/admin/base_view_model.rb
+++ b/app/view_models/admin/base_view_model.rb
@@ -24,7 +24,7 @@ class Admin::BaseViewModel
   end
 
   def needs_attention_count_partial
-    if needs_attention_auctions_count > 0
+    if needs_attention_auctions_count.positive?
       'admin/needs_attention_auction_count'
     else
       'components/null'

--- a/app/view_models/admin/user_show_view_model.rb
+++ b/app/view_models/admin/user_show_view_model.rb
@@ -39,7 +39,7 @@ class Admin::UserShowViewModel < Admin::BaseViewModel
   private
 
   def bids?
-    user_auctions.count > 0
+    user_auctions.count.positive?
   end
 
   def sam_status

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,7 +18,7 @@ module Micropurchase
     config.time_zone = 'Etc/UTC'
     config.active_record.raise_in_transactional_callbacks = true
     config.active_job.queue_adapter = :delayed_job
-    config.assets.precompile += %w( *-bundle.js )
+    config.assets.precompile += %w(*-bundle.js)
 
     config.middleware.insert_before 0, 'Rack::Cors' do
       allow do

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,3 +1,3 @@
 Rails.application.config.assets.version = (ENV["ASSETS_VERSION"] || "1.0")
-Rails.application.config.assets.precompile += %w( jquery.js )
-Rails.application.config.assets.precompile += %w( uswds/us_flag_small.png )
+Rails.application.config.assets.precompile += %w(jquery.js)
+Rails.application.config.assets.precompile += %w(uswds/us_flag_small.png)

--- a/features/step_definitions/admin_views_drafts_steps.rb
+++ b/features/step_definitions/admin_views_drafts_steps.rb
@@ -53,11 +53,10 @@ Then(/^I should see the auction as a missed delivery auction$/) do
 end
 
 Then(/^I should not see the auction as a draft auction$/) do
-  begin
-    table_xpath = needs_attention_table_xpath('drafts')
-    expect(page).to_not have_selector(table_xpath)
-  rescue Capybara::Poltergeist::InvalidSelector
-  end
+  table_xpath = needs_attention_table_xpath('drafts')
+  expect do
+    page.find(table_xpath)
+  end.to raise_error(Capybara::Poltergeist::InvalidSelector)
 end
 
 Then(/^I should see the auction as an archived auction$/) do

--- a/features/step_definitions/auction_attributes_steps.rb
+++ b/features/step_definitions/auction_attributes_steps.rb
@@ -8,7 +8,8 @@ Then(/^I should see the auction's (.+)$/) do |field|
     expect(page).to have_text(
       DcTimePresenter
         .convert(@auction.ended_at)
-        .strftime(DcTimePresenter::FORMAT))
+        .strftime(DcTimePresenter::FORMAT)
+    )
   else
     expect(page).to have_text(@auction.send(field))
   end

--- a/features/step_definitions/auction_create_steps.rb
+++ b/features/step_definitions/auction_create_steps.rb
@@ -119,7 +119,7 @@ Given(/^there is a closed sealed-bid auction$/) do
 end
 
 Given(/^there is an auction that needs evaluation$/) do
-   @auction = FactoryGirl.create(:auction, :with_bids, :evaluation_needed, :c2_budget_approved)
+  @auction = FactoryGirl.create(:auction, :with_bids, :evaluation_needed, :c2_budget_approved)
 end
 
 Given(/^there is an auction within the simplified acquisition threshold$/) do

--- a/features/step_definitions/auction_status_steps.rb
+++ b/features/step_definitions/auction_status_steps.rb
@@ -127,8 +127,7 @@ end
 Then(/^I should see winning bidder status for a missed delivery auction$/) do
   expect(page).to have_content(
     I18n.t('statuses.bid_status_presenter.over.winner.work_not_delivered.body',
-           delivery_deadline: delivery_due_date
-    )
+           delivery_deadline: delivery_due_date)
   )
 end
 
@@ -160,8 +159,7 @@ Then(/^I should see the admin status for an auction that is pending acceptance$/
   expect(page.html).to include(
     I18n.t('statuses.admin_auction_status_presenter.pending_acceptance.body',
            winner_url: winner_url,
-           delivery_url: @auction.delivery_url
-    )
+           delivery_url: @auction.delivery_url)
   )
 end
 

--- a/features/step_definitions/bid_history_steps.rb
+++ b/features/step_definitions/bid_history_steps.rb
@@ -131,7 +131,6 @@ end
 Then(/^I should see I have placed no bids$/) do
   expect(page.html).to include(
     I18n.t('labels.vendor.account.bids_placed.no_bids_html',
-            index_url: Url.new(link_text: 'current and upcoming auctions', path_name: 'root')
-    )
+           index_url: Url.new(link_text: 'current and upcoming auctions', path_name: 'root'))
   )
 end

--- a/features/step_definitions/meta_tag_steps.rb
+++ b/features/step_definitions/meta_tag_steps.rb
@@ -22,17 +22,19 @@ end
 
 # FIXME
 Then(/^there should be meta tags for the index page for (\d+) open and (\d+) future auctions$/) do |open_count, future_count|
+  description = "The Micro-purchase Marketplace is the place to bid on open-source issues from the 18F team."
+
   expect(page).to have_css("title", visible: false, text: "18F - Micro-purchase")
   expect(page).to have_css(
     "meta[property='og:title'][content='18F - Micro-purchase']",
     visible: false
   )
   expect(page).to have_css(
-    "meta[name='description'][content='The Micro-purchase Marketplace is the place to bid on open-source issues from the 18F team.']",
+    "meta[name='description'][content='#{description}']",
     visible: false
   )
   expect(page).to have_css(
-    "meta[property='og:description'][content='The Micro-purchase Marketplace is the place to bid on open-source issues from the 18F team.']",
+    "meta[property='og:description'][content='#{description}']",
     visible: false
   )
   expect(page).to have_css(

--- a/features/step_definitions/page_content_steps.rb
+++ b/features/step_definitions/page_content_steps.rb
@@ -9,7 +9,8 @@ end
 Then(/^I should see a message about no auctions$/) do
   expect(page).to have_content(
     "There are no current open auctions on the site. " \
-    "Please check back soon to view micropurchase opportunities.")
+    "Please check back soon to view micropurchase opportunities."
+  )
 end
 
 Then(/^I should see a current bid amount( of \$([\d\.]+))?$/) do |_, amount|
@@ -18,7 +19,7 @@ Then(/^I should see a current bid amount( of \$([\d\.]+))?$/) do |_, amount|
 end
 
 Then(/^I should see the starting price$/) do
-  expect(page).to have_content("Starting price: #{Currency.new(@auction.start_price).to_s}")
+  expect(page).to have_content("Starting price: #{Currency.new(@auction.start_price)}")
 end
 
 Then(/^I should see a winning bid amount( of \$([\d\.]+))?$/) do |_, amount|

--- a/features/support/business_time.rb
+++ b/features/support/business_time.rb
@@ -1,11 +1,9 @@
 # Business_time doesn't seem to get along with poltergeist bc threading
 # See https://github.com/18F/micropurchase/issues/1318 for details
-module BusinessTime
-  class Config
-    class << self
-      def config
-        @_config ||= default_config
-      end
+class BusinessTime::Config
+  class << self
+    def config
+      @_config ||= default_config
     end
   end
 end

--- a/features/support/selectize_helper.rb
+++ b/features/support/selectize_helper.rb
@@ -6,5 +6,5 @@ end
 
 def select_selectize_option(field, text)
   find(".#{field} .selectize-input input").native.send_keys(text) # fill the input text
-  find(:xpath, ("//div[@data-selectable and contains(., '#{text}')]")).click # wait for the input and then click on it
+  find(:xpath, "//div[@data-selectable and contains(., '#{text}')]").click # wait for the input and then click on it
 end

--- a/lib/server_env.rb
+++ b/lib/server_env.rb
@@ -6,6 +6,6 @@ module ServerEnv
   end
 
   def self.first_instance?
-    instance_index == 0
+    instance_index.zero?
   end
 end

--- a/lib/swagger/schema.rb
+++ b/lib/swagger/schema.rb
@@ -8,6 +8,7 @@ require_relative 'schema/number'
 require_relative 'schema/string'
 require_relative 'schema/array'
 require_relative 'schema/object'
+require_relative 'schema/factory'
 
 class Swagger::Schema
   include Swagger::Mixins::Description
@@ -74,31 +75,6 @@ class Swagger::Schema
   end
 
   def self.factory(name, fields, specification)
-    if fields.key?('$ref')
-      Swagger::Reference.new(name, fields, specification)
-    elsif fields.key?('allOf')
-      Swagger::Schema::AllOf.new(name, fields, specification)
-    else
-      case fields['type']
-      when ::Array
-        if fields['type'].size == 2 && fields['type'].last == 'null'
-          factory(name, fields.merge('nullable' => true, 'type' => fields['type'].first), specification)
-        else
-          fail "Unhandled array type: #{fields.inspect}"
-        end
-      when 'string'
-        Swagger::Schema::String.new(name, fields, specification)
-      when 'integer', 'number', 'boolean'
-        Swagger::Schema::Number.new(name, fields, specification)
-      when 'boolean'
-        Swagger::Schema::Boolean.new(name, fields, specification)
-      when 'array'
-        Swagger::Schema::Array.new(name, fields, specification)
-      when 'object', nil
-        Swagger::Schema::Object.new(name, fields, specification)
-      else
-        fail "Unhandled property type: #{fields.inspect}"
-      end
-    end
+    Swagger::Schema::Factory.new(name, fields, specification).call
   end
 end

--- a/lib/swagger/schema/factory.rb
+++ b/lib/swagger/schema/factory.rb
@@ -1,0 +1,86 @@
+class Swagger::Schema::Factory
+  attr_reader :name, :fields, :specification
+
+  def initialize(name, fields, specification)
+    @name = name
+    @fields = fields
+    @specification = specification
+  end
+
+  def call
+    if fields.key?('$ref')
+      Swagger::Reference.new(name, fields, specification)
+    elsif fields.key?('allOf')
+      Swagger::Schema::AllOf.new(name, fields, specification)
+    else
+      other_schema_by_type
+    end
+  end
+
+  private
+
+  def other_schema_by_type
+    fail "Unhandled property type: #{fields.inspect}" unless valid_type?
+    typed_schema_element
+  end
+
+  def typed_schema_element
+    array_class || string || number || boolean || array || object
+  end
+
+  def string
+    return unless type == 'string'
+    Swagger::Schema::String.new(name, fields, specification)
+  end
+
+  def number
+    return unless number_type?
+    Swagger::Schema::Number.new(name, fields, specification)
+  end
+
+  def boolean
+    return unless type == 'boolean'
+    Swagger::Schema::Boolean.new(name, fields, specification)
+  end
+
+  def array
+    return unless type == 'array'
+    Swagger::Schema::Array.new(name, fields, specification)
+  end
+
+  def object
+    return if !(type == 'object') && type.nil?
+    Swagger::Schema::Object.new(name, fields, specification)
+  end
+
+  def type
+    fields['type']
+  end
+
+  def valid_type?
+    array_class? ||
+      ['string', 'integer', 'number', 'boolean', 'boolean', 'array', 'object', nil].include?(type)
+  end
+
+  def number_type?
+    type == 'integer' || type == 'number'
+  end
+
+  def array_class?
+    type.class == ::Array
+  end
+
+  def array_class
+    return unless array_class?
+    fail "Unhandled array type: #{fields.inspect}" unless valid_array_class?
+    recurse_for_array
+  end
+
+  def valid_array_class?
+    type.size == 2 && type.last == 'null'
+  end
+
+  def recurse_for_array
+    self.class.new(name, fields.merge('nullable' => true, 'type' => type.first), specification).call
+  end
+end

--- a/lib/swagger/schema/factory.rb
+++ b/lib/swagger/schema/factory.rb
@@ -49,7 +49,7 @@ class Swagger::Schema::Factory
   end
 
   def object
-    return if !(type == 'object') && type.nil?
+    return if !(type == 'object') && !type.nil?
     Swagger::Schema::Object.new(name, fields, specification)
   end
 

--- a/lib/swagger/schema/string.rb
+++ b/lib/swagger/schema/string.rb
@@ -8,21 +8,17 @@ class Swagger::Schema::String < Swagger::Schema
   end
 
   def default_sample_value
-    case format
-    when 'date-time'
-      '"2016-01-01T13:00:00Z"'
-    when 'email'
-      '"user@example.com"'
-    when 'hostname'
-      '"example.com"'
-    when 'url'
-      '"http://example.com/"'
-    when 'markdown'
-      '"A **markdown** string"'
-    when 'duns'
-      '"123456789"'
-    else
-      '"example"'
-    end
+    value_for_format(format) || '"example"'
+  end
+
+  def value_for_format(format)
+    {
+      'date-time' => '"2016-01-01T13:00:00Z"',
+      'email'     => '"user@example.com"',
+      'hostname'  => '"example.com"',
+      'url'       => '"http://example.com/"',
+      'markdown'  => '"A **markdown** string"',
+      'duns'      => '"123456789"'
+    }[format]
   end
 end

--- a/spec/controllers/api/v0/business_days_controller_spec.rb
+++ b/spec/controllers/api/v0/business_days_controller_spec.rb
@@ -3,14 +3,14 @@ require 'rails_helper'
 RSpec.describe Api::V0::BusinessDaysController do
   describe 'show' do
     it 'should return a date N business days from the date and time in the DC time zone' do
-      get :show, { date: '2016-08-30', time: '13:00', day_count: '1' }
+      get :show, date: '2016-08-30', time: '13:00', day_count: '1'
       json = JSON.parse(response.body)
       expect(json['date']).to eq("August 31, 2016 01:00:00 PM EDT")
     end
 
     it 'should handle holidays correctly' do
       BusinessTime::Config.holidays << Date.parse('2016-09-05')
-      get :show, { date: '2016-09-01', time: '13:00', day_count: '5' }
+      get :show, date: '2016-09-01', time: '13:00', day_count: '5'
       json = JSON.parse(response.body)
       expect(json['date']).to eq("September 09, 2016 01:00:00 PM EDT")
     end

--- a/spec/controllers/auctions_controller_spec.rb
+++ b/spec/controllers/auctions_controller_spec.rb
@@ -13,17 +13,20 @@ describe AuctionsController do
         create(
           :auction,
           started_at: date_start,
-          ended_at: date_middle)
+          ended_at: date_middle
+        )
 
         create(
           :auction,
           started_at: date_start,
-          ended_at: date_latest)
+          ended_at: date_latest
+        )
 
         create(
           :auction,
           started_at: date_start,
-          ended_at: date_first)
+          ended_at: date_first
+        )
 
         get :index
         auctions = assigns(:auction_collection).auctions

--- a/spec/db/chores/update_existing_users_spec.rb
+++ b/spec/db/chores/update_existing_users_spec.rb
@@ -8,9 +8,9 @@ describe UpdateExistingUsers do
       it 'does not update user' do
         create(:user, github_login: 'abc')
 
-        expect {
+        expect do
           UpdateExistingUsers.new.perform
-        }.not_to raise_error
+        end.not_to raise_error
       end
     end
 
@@ -19,9 +19,9 @@ describe UpdateExistingUsers do
         user = build(:user, github_login: nil, github_id: FakeGitHubApi::DELETED_USER_ID)
         user.save(validate: false)
 
-        expect {
+        expect do
           UpdateExistingUsers.new.perform
-        }.not_to raise_error
+        end.not_to raise_error
       end
     end
 
@@ -30,9 +30,9 @@ describe UpdateExistingUsers do
         user = build(:user, github_login: nil, github_id: FakeGitHubApi::NO_NAME_USER_ID)
         user.save(validate: false)
 
-        expect {
+        expect do
           UpdateExistingUsers.new.perform
-        }.not_to raise_error
+        end.not_to raise_error
       end
     end
 
@@ -42,9 +42,9 @@ describe UpdateExistingUsers do
         user.save(validate: false)
         github_login_from_fixture = 'pjhyett'
 
-        expect {
+        expect do
           UpdateExistingUsers.new.perform
-        }.not_to raise_error
+        end.not_to raise_error
 
         expect(user.reload.github_login).to eq github_login_from_fixture
       end

--- a/spec/factories/client_accounts.rb
+++ b/spec/factories/client_accounts.rb
@@ -2,6 +2,6 @@ FactoryGirl.define do
   factory :client_account do
     sequence(:name) { |n| "Client Account #{n}" }
     billable true
-    sequence(:tock_id) {|n| n}
+    sequence(:tock_id) { |n| n }
   end
 end

--- a/spec/models/admin_auction_status_presenter_factory_spec.rb
+++ b/spec/models/admin_auction_status_presenter_factory_spec.rb
@@ -21,8 +21,13 @@ describe AdminAuctionStatusPresenterFactory do
 
   context "when the vendor is late on delivery" do
     it 'should return a AdminAuctionStatusPresenter::OverdueDelivery' do
-      auction = create(:auction, :closed, :published, :with_bids,
-        delivery_status: :work_in_progress, delivery_due_at: 4.minutes.ago)
+      auction = create(
+        :auction,
+        :closed,
+        :published,
+        :with_bids,
+        delivery_status: :work_in_progress, delivery_due_at: 4.minutes.ago
+      )
 
       expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
         .to be_a(AdminAuctionStatusPresenter::OverdueDelivery)
@@ -31,8 +36,13 @@ describe AdminAuctionStatusPresenterFactory do
 
   context "when the auction has been marked as a missed delivery" do
     it 'should return a AdminAuctionStatusPresenter::Future' do
-      auction = create(:auction, :closed, :published, :with_bids,
-        delivery_due_at: 4.minutes.ago, delivery_status: :missed_delivery)
+      auction = create(
+        :auction,
+        :closed,
+        :published,
+        :with_bids,
+        delivery_due_at: 4.minutes.ago, delivery_status: :missed_delivery
+      )
 
       expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
         .to be_a(AdminAuctionStatusPresenter::MissedDelivery)
@@ -41,8 +51,14 @@ describe AdminAuctionStatusPresenterFactory do
 
   context "when an auction has been accepted but doesn't have a payment URL yet" do
     it 'should return a AdminAuctionStatusPresenter::AcceptedPendingPaymentUrl' do
-      auction = create(:auction, :closed, :with_bids, :published,
-        :delivery_url, delivery_status: :accepted_pending_payment_url)
+      auction = create(
+        :auction,
+        :closed,
+        :with_bids,
+        :published,
+        :delivery_url,
+        delivery_status: :accepted_pending_payment_url
+      )
 
       expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
         .to be_a(AdminAuctionStatusPresenter::AcceptedPendingPaymentUrl)
@@ -122,8 +138,13 @@ describe AdminAuctionStatusPresenterFactory do
 
   context 'when auction is closed, pending delivery' do
     it 'should return the correct presenter' do
-      auction = create(:auction, :c2_budget_approved, :closed, :with_bids,
-        delivery_status: :pending_delivery)
+      auction = create(
+        :auction,
+        :c2_budget_approved,
+        :closed,
+        :with_bids,
+        delivery_status: :pending_delivery
+      )
 
       expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
         .to be_a(AdminAuctionStatusPresenter::WorkNotStarted)

--- a/spec/models/admin_auction_status_presenter_factory_spec.rb
+++ b/spec/models/admin_auction_status_presenter_factory_spec.rb
@@ -21,7 +21,8 @@ describe AdminAuctionStatusPresenterFactory do
 
   context "when the vendor is late on delivery" do
     it 'should return a AdminAuctionStatusPresenter::OverdueDelivery' do
-      auction = create(:auction, :closed, :published, :with_bids, delivery_status: :work_in_progress, delivery_due_at: 4.minutes.ago)
+      auction = create(:auction, :closed, :published, :with_bids,
+        delivery_status: :work_in_progress, delivery_due_at: 4.minutes.ago)
 
       expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
         .to be_a(AdminAuctionStatusPresenter::OverdueDelivery)
@@ -30,7 +31,8 @@ describe AdminAuctionStatusPresenterFactory do
 
   context "when the auction has been marked as a missed delivery" do
     it 'should return a AdminAuctionStatusPresenter::Future' do
-      auction = create(:auction, :closed, :published, :with_bids, delivery_due_at: 4.minutes.ago, delivery_status: :missed_delivery)
+      auction = create(:auction, :closed, :published, :with_bids,
+        delivery_due_at: 4.minutes.ago, delivery_status: :missed_delivery)
 
       expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
         .to be_a(AdminAuctionStatusPresenter::MissedDelivery)
@@ -39,7 +41,8 @@ describe AdminAuctionStatusPresenterFactory do
 
   context "when an auction has been accepted but doesn't have a payment URL yet" do
     it 'should return a AdminAuctionStatusPresenter::AcceptedPendingPaymentUrl' do
-      auction = create(:auction, :closed, :with_bids, :published, :delivery_url, delivery_status: :accepted_pending_payment_url)
+      auction = create(:auction, :closed, :with_bids, :published,
+        :delivery_url, delivery_status: :accepted_pending_payment_url)
 
       expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
         .to be_a(AdminAuctionStatusPresenter::AcceptedPendingPaymentUrl)
@@ -119,7 +122,8 @@ describe AdminAuctionStatusPresenterFactory do
 
   context 'when auction is closed, pending delivery' do
     it 'should return the correct presenter' do
-      auction = create(:auction, :c2_budget_approved, :closed, :with_bids, delivery_status: :pending_delivery)
+      auction = create(:auction, :c2_budget_approved, :closed, :with_bids,
+        delivery_status: :pending_delivery)
 
       expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
         .to be_a(AdminAuctionStatusPresenter::WorkNotStarted)

--- a/spec/models/winning_bidder_export_spec.rb
+++ b/spec/models/winning_bidder_export_spec.rb
@@ -4,8 +4,8 @@ describe WinningBidderExport do
   describe '#export_csv' do
     context 'DUNs number valid' do
       it 'include the correct information in the CSV' do
-        end_date = DateTime.new(2016, 07, 11, 00, 00, 0)
-        delivery_date = DateTime.new(2016, 07, 17, 00, 00, 0)
+        end_date = DateTime.new(2016, 7, 11, 0, 0, 0)
+        delivery_date = DateTime.new(2016, 7, 17, 0, 0, 0)
         auction = create(
           :auction,
           :closed,

--- a/spec/presenters/default_deadline_date_time_spec.rb
+++ b/spec/presenters/default_deadline_date_time_spec.rb
@@ -4,13 +4,15 @@ describe DefaultDeadlineDateTime do
   describe '#initialize' do
     it 'should be N business days later' do
       time = DcTimePresenter.parse('2016-08-29 15:00')
-      expect(DefaultDeadlineDateTime.new(start_time: time, day_offset: 3).dc_time).to be_within(0.1).of(Time.parse('2016-09-01 15:00 -0400'))
+      default_time = DefaultDeadlineDateTime.new(start_time: time, day_offset: 3).dc_time
+      expect(default_time).to be_within(0.1).of(Time.parse('2016-09-01 15:00 -0400'))
     end
 
     it 'should handle holidays correctly' do
       BusinessTime::Config.holidays << Date.parse('2016-09-05')
       time = DefaultDateTime.new(Time.parse('2016-08-29 15:00 -0400')).convert
-      expect(DefaultDeadlineDateTime.new(start_time: time, day_offset: 5).dc_time).to be_within(0.1).of(Time.parse('2016-09-06 13:00 -0400'))
+      default_time = DefaultDeadlineDateTime.new(start_time: time, day_offset: 5).dc_time
+      expect(default_time).to be_within(0.1).of(Time.parse('2016-09-06 13:00 -0400'))
     end
   end
 end

--- a/spec/requests/api/v0/bids_spec.rb
+++ b/spec/requests/api/v0/bids_spec.rb
@@ -186,7 +186,7 @@ describe 'API bid requests' do
 
           it 'returns a json error' do
             post api_v0_auction_bids_path(auction), params, headers
-            expect(json_response['error']).to eq("Amount was not accepted. Please enter a whole number less than $#{ current_auction_price - 1}.")
+            expect(json_response['error']).to eq("Amount was not accepted. Please enter a whole number less than $#{current_auction_price - 1}.")
           end
 
           it 'returns a 403 status code' do

--- a/spec/requests/api/v0/bids_spec.rb
+++ b/spec/requests/api/v0/bids_spec.rb
@@ -186,7 +186,9 @@ describe 'API bid requests' do
 
           it 'returns a json error' do
             post api_v0_auction_bids_path(auction), params, headers
-            expect(json_response['error']).to eq("Amount was not accepted. Please enter a whole number less than $#{current_auction_price - 1}.")
+            amount_limit = current_auction_price - 1
+            message = "Amount was not accepted. Please enter a whole number less than $#{amount_limit}."
+            expect(json_response['error']).to eq(message)
           end
 
           it 'returns a 403 status code' do

--- a/spec/requests/api/v0/business_days_spec.rb
+++ b/spec/requests/api/v0/business_days_spec.rb
@@ -5,14 +5,14 @@ describe Api::V0::BusinessDaysController do
 
   describe 'GET /business_days' do
     it 'returns the date based on params passed in' do
-      friday = Time.local(2016, 07, 22, 4)
+      friday = Time.local(2016, 0o7, 22, 4)
       next_friday = "July 29, 2016 01:00:00 PM EDT"
 
       Timecop.freeze(friday) do
         get(
           api_v0_business_day_path(format: :json),
           { day_count: 5, date: '2016-07-22', time: '1:00 PM' },
-          { 'HTTP_ACCEPT' => 'text/x-json' }
+          'HTTP_ACCEPT' => 'text/x-json'
         )
 
         expect(json_response['date']).to eq next_friday

--- a/spec/services/mark_auction_as_paid_spec.rb
+++ b/spec/services/mark_auction_as_paid_spec.rb
@@ -22,13 +22,13 @@ describe MarkAuctionAsPaid do
         )
         mailer_double = double(deliver_later: true)
         allow(WinningBidderMailer).to receive(:auction_paid_default_pcard)
-                                       .with(auction: auction)
-                                       .and_return(mailer_double)
+          .with(auction: auction)
+          .and_return(mailer_double)
 
         MarkAuctionAsPaid.new(auction: auction).perform
 
         expect(WinningBidderMailer).to have_received(:auction_paid_default_pcard)
-                                        .with(auction: auction)
+          .with(auction: auction)
         expect(mailer_double).to have_received(:deliver_later)
       end
     end

--- a/spec/services/mark_auction_as_paid_spec.rb
+++ b/spec/services/mark_auction_as_paid_spec.rb
@@ -14,7 +14,7 @@ describe MarkAuctionAsPaid do
       end
 
       it 'sends the right email to the vendor for default pcard auctions' do
-        customer = create(:customer)
+        create(:customer)
 
         auction = create(
           :auction,

--- a/spec/services/update_auction_spec.rb
+++ b/spec/services/update_auction_spec.rb
@@ -62,7 +62,7 @@ describe UpdateAuction do
       it 'should set the c2_proposal_url and c2_status' do
         auction = create(:auction, c2_status: :sent)
         c2_proposal_url = 'https://c2-dev.18f.gov/proposals/2486'
-        params = {auction: {c2_proposal_url: c2_proposal_url, c2_status: 'pending_approval'}}
+        params = { auction: { c2_proposal_url: c2_proposal_url, c2_status: 'pending_approval' } }
 
         UpdateAuction.new(
           auction: auction,

--- a/spec/support/fake_github.rb
+++ b/spec/support/fake_github.rb
@@ -3,8 +3,8 @@ require 'sinatra/base'
 class FakeGitHubApi < Sinatra::Base
   INVALID_API_KEY = "invalidKey5678ijklmnop".freeze
   VALID_API_KEY = "validKeyAbcdfgh123".freeze
-  DELETED_USER_ID = '1'
-  NO_NAME_USER_ID = '2'
+  DELETED_USER_ID = '1'.freeze
+  NO_NAME_USER_ID = '2'.freeze
 
   get '/user/:id' do
     if params[:id] == DELETED_USER_ID

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -30,7 +30,11 @@ module RequestHelpers
   def handle_request(request, response_body: nil)
     response_headers = { 'Content-Type' => 'application/json' }
     bad_credentials  = "{\"message\":\"Bad Credentials\"}"
-    token = request.headers['Authorization'].split[1] rescue nil
+    token = begin
+              request.headers['Authorization'].split[1]
+            rescue
+              nil
+            end
 
     if token != FakeGitHubApi::VALID_API_KEY
       response_body = bad_credentials
@@ -40,11 +44,11 @@ module RequestHelpers
     { status: response_status, body: response_body, headers: response_headers }
   end
 
-  def stub_github(path, &block)
+  def stub_github(path)
     url = "https://api.github.com#{path}"
     request_headers_without_auth = github_request_headers
     request_headers_with_auth = github_request_headers.merge('Authorization' => /token ()/)
-    default_response_body = JSON.generate(block.call)
+    default_response_body = JSON.generate(yield)
 
     # stub requests where no Authorization header is set
     WebMock

--- a/spec/swagger/operation_spec.rb
+++ b/spec/swagger/operation_spec.rb
@@ -5,14 +5,14 @@ describe Swagger::Operation do
   describe 'unique_key' do
     context 'when the operation has an operationId' do
       it 'should just be the operationId' do
-        op = Swagger::Operation.new("/auctions/{id}", 'get', {'operationId' => 'foo'}, nil)
+        op = Swagger::Operation.new("/auctions/{id}", 'get', { 'operationId' => 'foo' }, nil)
         expect(op.unique_key).to eq('foo')
       end
     end
 
     context 'when the operation does not have an operationId' do
       it 'should be a combination of the verb and path' do
-        op = Swagger::Operation.new("/auctions/{id}", 'get', {}, nil)
+        op = Swagger::Operation.new("/auctions/{id}", 'get', { }, nil)
         expect(op.unique_key).to eq('get-auctions-id')
       end
     end

--- a/spec/swagger/reference_spec.rb
+++ b/spec/swagger/reference_spec.rb
@@ -44,5 +44,4 @@ describe Swagger::Reference do
       expect(ref).to be_dereferenced
     end
   end
-
 end

--- a/spec/swagger/schema/all_of_spec.rb
+++ b/spec/swagger/schema/all_of_spec.rb
@@ -9,7 +9,7 @@ describe Swagger::Schema::AllOf do
   describe 'properties' do
     it 'should concatenate properties from its members' do
       properties = all_of.properties
-      expect(properties.map(&:name)).to eq(['name', 'numbers', 'added_field'])
+      expect(properties.map(&:name)).to eq(%w(name numbers added_field))
     end
   end
 end

--- a/spec/swagger/schema/array_spec.rb
+++ b/spec/swagger/schema/array_spec.rb
@@ -6,16 +6,15 @@ require 'spec_helper'
 describe Swagger::Schema::Array do
   describe '#displayed_type' do
     context 'for an array of simple types' do
-      let(:array) { Swagger::Schema::Array.new('Name', {'type' => 'array', 'items' => {'type' => 'string'}}, nil) }
+      let(:array) { Swagger::Schema::Array.new('Name', { 'type' => 'array', 'items' => { 'type' => 'string' } }, nil) }
 
       it 'should return a simple string' do
         expect(array.displayed_type).to eq('array of string')
       end
-
     end
 
     context 'for an array of objects' do
-      let(:array) { Swagger::Schema::Array.new('Name', {'type' => 'array', 'items' => {'$ref' => "#\/definitions\/Thing"}}, nil) }
+      let(:array) { Swagger::Schema::Array.new('Name', { 'type' => 'array', 'items' => { '$ref' => "#\/definitions\/Thing" } }, nil) }
 
       it 'should not dereference pointers' do
         expect(array.displayed_type).to eq('array of <a href="#definition-Thing">Thing</a>')

--- a/spec/swagger/schema/array_spec.rb
+++ b/spec/swagger/schema/array_spec.rb
@@ -5,20 +5,16 @@ require 'spec_helper'
 
 describe Swagger::Schema::Array do
   describe '#displayed_type' do
-    context 'for an array of simple types' do
-      let(:array) { Swagger::Schema::Array.new('Name', { 'type' => 'array', 'items' => { 'type' => 'string' } }, nil) }
-
-      it 'should return a simple string' do
-        expect(array.displayed_type).to eq('array of string')
-      end
+    it 'for an array of simple types should return a simple string' do
+      options = { 'type' => 'array', 'items' => { 'type' => 'string' } }
+      array = Swagger::Schema::Array.new('Name', options, nil)
+      expect(array.displayed_type).to eq('array of string')
     end
 
-    context 'for an array of objects' do
-      let(:array) { Swagger::Schema::Array.new('Name', { 'type' => 'array', 'items' => { '$ref' => "#\/definitions\/Thing" } }, nil) }
-
-      it 'should not dereference pointers' do
-        expect(array.displayed_type).to eq('array of <a href="#definition-Thing">Thing</a>')
-      end
+    it 'for an array of objects should not dereference pointers' do
+      options = { 'type' => 'array', 'items' => { '$ref' => "#\/definitions\/Thing" } }
+      array = Swagger::Schema::Array.new('Name', options, nil)
+      expect(array.displayed_type).to eq('array of <a href="#definition-Thing">Thing</a>')
     end
   end
 end

--- a/spec/swagger/schema/number_spec.rb
+++ b/spec/swagger/schema/number_spec.rb
@@ -14,7 +14,12 @@ describe Swagger::Schema::Number do
     end
 
     it 'should include an exclusiveMaximum if specified' do
-      s = Swagger::Schema::Number.new('foo', { 'type' => 'integer', 'exclusiveMaximum' => true, 'maximum' => 3500 }, nil)
+      options = {
+        'type' => 'integer',
+        'exclusiveMaximum' => true,
+        'maximum' => 3500
+      }
+      s = Swagger::Schema::Number.new('foo', options, nil)
       expect(s.displayed_type).to eq('integer (n < 3500)')
     end
 
@@ -29,7 +34,13 @@ describe Swagger::Schema::Number do
     end
 
     it 'should combine maximum and minimums' do
-      s = Swagger::Schema::Number.new('foo', { 'type' => 'integer', 'maximum' => 3500, 'exclusiveMinimum' => true, 'minimum' => 0 }, nil)
+      options = {
+        'type' => 'integer',
+        'maximum' => 3500,
+        'exclusiveMinimum' => true,
+        'minimum' => 0
+      }
+      s = Swagger::Schema::Number.new('foo', options, nil)
       expect(s.displayed_type).to eq('integer (0 < n <= 3500)')
     end
   end

--- a/spec/swagger/schema/number_spec.rb
+++ b/spec/swagger/schema/number_spec.rb
@@ -4,46 +4,45 @@ require 'swagger'
 describe Swagger::Schema::Number do
   describe 'displayed_type' do
     it 'should just be the display type' do
-      s = Swagger::Schema::Number.new('foo', {'type' => 'integer'}, nil)
+      s = Swagger::Schema::Number.new('foo', { 'type' => 'integer' }, nil)
       expect(s.displayed_type).to eq('integer')
     end
 
     it 'should include an exclusiveMinimum if specified' do
-      s = Swagger::Schema::Number.new('foo', {'type' => 'integer', 'exclusiveMinimum' => true, 'minimum' => 0}, nil)
+      s = Swagger::Schema::Number.new('foo', { 'type' => 'integer', 'exclusiveMinimum' => true, 'minimum' => 0 }, nil)
       expect(s.displayed_type).to eq('integer (n > 0)')
     end
 
     it 'should include an exclusiveMaximum if specified' do
-      s = Swagger::Schema::Number.new('foo', {'type' => 'integer', 'exclusiveMaximum' => true, 'maximum' => 3500}, nil)
+      s = Swagger::Schema::Number.new('foo', { 'type' => 'integer', 'exclusiveMaximum' => true, 'maximum' => 3500 }, nil)
       expect(s.displayed_type).to eq('integer (n < 3500)')
     end
 
     it 'should include a minimum if specified' do
-      s = Swagger::Schema::Number.new('foo', {'type' => 'integer', 'minimum' => 0}, nil)
+      s = Swagger::Schema::Number.new('foo', { 'type' => 'integer', 'minimum' => 0 }, nil)
       expect(s.displayed_type).to eq('integer (n >= 0)')
     end
 
     it 'should include a maximum if specified' do
-      s = Swagger::Schema::Number.new('foo', {'type' => 'integer', 'maximum' => 3500}, nil)
+      s = Swagger::Schema::Number.new('foo', { 'type' => 'integer', 'maximum' => 3500 }, nil)
       expect(s.displayed_type).to eq('integer (n <= 3500)')
     end
 
     it 'should combine maximum and minimums' do
-      s = Swagger::Schema::Number.new('foo', {'type' => 'integer', 'maximum' => 3500, 'exclusiveMinimum' => true, 'minimum' => 0}, nil)
+      s = Swagger::Schema::Number.new('foo', { 'type' => 'integer', 'maximum' => 3500, 'exclusiveMinimum' => true, 'minimum' => 0 }, nil)
       expect(s.displayed_type).to eq('integer (0 < n <= 3500)')
     end
   end
 
   describe 'sample_value' do
     it 'should be an integer for integer' do
-      s = Swagger::Schema::Number.new('foo', {'type' => 'integer'}, nil)
+      s = Swagger::Schema::Number.new('foo', { 'type' => 'integer' }, nil)
       expect(s.sample_value).to eq(39)
     end
 
     it 'should be a float for float' do
-      s = Swagger::Schema::Number.new('foo', {'type' => 'number'}, nil)
+      s = Swagger::Schema::Number.new('foo', { 'type' => 'number' }, nil)
       expect(s.sample_value).to eq(39.4)
     end
   end
-
 end

--- a/spec/swagger/schema/object_spec.rb
+++ b/spec/swagger/schema/object_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require 'swagger'
 
 describe Swagger::Schema::Object do
-  let(:object) { Swagger::Schema::Object.new('Name', {"description" => 'description', "title" => 'title'}, nil) }
+  let(:object) { Swagger::Schema::Object.new('Name', { "description" => 'description', "title" => 'title' }, nil) }
 
   describe '#title' do
     it 'should return the title of the object' do

--- a/spec/swagger/schema/string_spec.rb
+++ b/spec/swagger/schema/string_spec.rb
@@ -4,36 +4,35 @@ require 'swagger'
 describe Swagger::Schema::String do
   describe 'displayed_type' do
     it 'should return string' do
-      s = Swagger::Schema::String.new('foo', {'type' => 'string'}, nil)
+      s = Swagger::Schema::String.new('foo', { 'type' => 'string' }, nil)
       expect(s.displayed_type).to eq('string')
     end
 
     it 'should append the format if specified' do
-      s = Swagger::Schema::String.new('foo', {'type' => 'string', 'format' => 'email'}, nil)
+      s = Swagger::Schema::String.new('foo', { 'type' => 'string', 'format' => 'email' }, nil)
       expect(s.displayed_type).to eq('string (email)')
     end
   end
 
   describe 'sample_value' do
     it 'should return a basic string if there is no format' do
-      s = Swagger::Schema::String.new('foo', {'type' => 'string'}, nil)
+      s = Swagger::Schema::String.new('foo', { 'type' => 'string' }, nil)
       expect(s.sample_value).to eq('"example"')
     end
 
     it 'should return a sample date-time' do
-      s = Swagger::Schema::String.new('foo', {'type' => 'string', 'format' => 'date-time'}, nil)
+      s = Swagger::Schema::String.new('foo', { 'type' => 'string', 'format' => 'date-time' }, nil)
       expect(s.sample_value).to eq('"2016-01-01T13:00:00Z"')
     end
 
     it 'should return a sample email' do
-      s = Swagger::Schema::String.new('foo', {'type' => 'string', 'format' => 'email'}, nil)
+      s = Swagger::Schema::String.new('foo', { 'type' => 'string', 'format' => 'email' }, nil)
       expect(s.sample_value).to eq('"user@example.com"')
     end
 
     it 'should return a markdown example' do
-      s = Swagger::Schema::String.new('foo', {'type' => 'string', 'format' => 'markdown'}, nil)
+      s = Swagger::Schema::String.new('foo', { 'type' => 'string', 'format' => 'markdown' }, nil)
       expect(s.sample_value).to eq('"A **markdown** string"')
     end
   end
-
 end

--- a/spec/view_models/admin/new_auction_view_model_spec.rb
+++ b/spec/view_models/admin/new_auction_view_model_spec.rb
@@ -4,7 +4,7 @@ describe Admin::NewAuctionViewModel do
   describe '#date_default' do
     context 'for start' do
       it 'defaults to 5 business days after today' do
-        friday = Time.local(2016, 07, 22, 4)
+        friday = Time.local(2016, 7, 22, 4)
         next_friday = Date.new(2016, 7, 29)
 
         Timecop.freeze(friday) do
@@ -17,8 +17,8 @@ describe Admin::NewAuctionViewModel do
 
     context 'for end' do
       it 'defaults to 7 business days after today' do
-        friday = Time.local(2016, 07, 22)
-        tuesday_after_next = Date.new(2016, 8, 02)
+        friday = Time.local(2016, 7, 22)
+        tuesday_after_next = Date.new(2016, 8, 2)
 
         Timecop.freeze(friday) do
           date = Admin::NewAuctionViewModel.new.date_default('ended')
@@ -30,7 +30,7 @@ describe Admin::NewAuctionViewModel do
 
     context 'for delivery' do
       it 'defaults to 12 days after today' do
-        friday = Time.local(2016, 07, 22)
+        friday = Time.local(2016, 7, 22)
         two_weeks_from_tuesday = Date.new(2016, 8, 9)
 
         Timecop.freeze(friday) do

--- a/spec/view_models/admin/open_list_item_spec.rb
+++ b/spec/view_models/admin/open_list_item_spec.rb
@@ -55,7 +55,6 @@ describe Admin::OpenListItem do
 
     it 'should return N/A if there are no bids' do
       auction = create(:auction, :sealed_bid)
-      bid = auction.bids.last
 
       view_model = Admin::OpenListItem.new(auction)
       expect(view_model.current_winner).to eq('N/A')


### PR DESCRIPTION
This tries to take as much of rubocop's advice as possible just to reduce noise:

* Uses rubocop's autocorrect capabilities for simplest stuff 
* Then does a pass at correcting a bunch more easy fixes manually
* Finally does one extraction from complex method to class

This does not tackle the simplification of status in the admin bid status presenter factory object. At a quick glance this feels like real complexity both in the product and the code. Although the individual presenter classes are ideal and the polymorphic process around getting to those classes is also great.

I am wondering if:
1. It might be time for an event log for bids to have more visibility over the history of a bid. Sometimes it is easier to convey the status of a thing if you can see its history (with a good ux). This is of course a product @mtorres253 and design question. On a code level separating a single state field into a series of logs means more information to work with to make the right decision. When you overwrite status repeatedly, you are losing information.
2. In the code there are many different statuses that are conflated. Those two complex methods might be better understood if they took apart the idea of status, and grouped the presenter choices by type.