### PR TITLE
No bids messaging

### DIFF
--- a/app/models/admin_auction_status_presenter_factory.rb
+++ b/app/models/admin_auction_status_presenter_factory.rb
@@ -18,6 +18,8 @@ class AdminAuctionStatusPresenterFactory
   def default_purchase_card_presenter
     if auction.archived?
       AdminAuctionStatusPresenter::Archived
+    elsif over_and_no_bids?
+      AdminAuctionStatusPresenter::NoBids
     elsif auction.c2_status == 'not_requested'
       C2StatusPresenter::NotRequested
     elsif auction.c2_status == 'sent'
@@ -83,6 +85,10 @@ class AdminAuctionStatusPresenterFactory
 
   def available?
     bidding_status.available?
+  end
+
+  def over_and_no_bids?
+    over? && !bids?
   end
 
   def won?

--- a/app/models/admin_auction_status_presenter_factory.rb
+++ b/app/models/admin_auction_status_presenter_factory.rb
@@ -6,80 +6,174 @@ class AdminAuctionStatusPresenterFactory
   end
 
   def create
-    if auction.purchase_card == 'default'
-      default_purchase_card_presenter
-    else
-      other_purchase_card_presenter
-    end.new(auction: auction)
+    presenter_class.new(auction: auction)
   end
 
   private
 
-  def default_purchase_card_presenter
-    if auction.archived?
-      AdminAuctionStatusPresenter::Archived
-    elsif over_and_no_bids?
-      AdminAuctionStatusPresenter::NoBids
-    elsif auction.c2_status == 'not_requested'
-      C2StatusPresenter::NotRequested
-    elsif auction.c2_status == 'sent'
-      C2StatusPresenter::Sent
-    elsif auction.c2_status == 'pending_approval'
-      C2StatusPresenter::PendingApproval
-    elsif future? && auction.published?
-      AdminAuctionStatusPresenter::Future
-    elsif auction.unpublished?
-      AdminAuctionStatusPresenter::ReadyToPublish
-    elsif available?
-      AdminAuctionStatusPresenter::Available
-    elsif won? && auction.pending_delivery?
-      AdminAuctionStatusPresenter::WorkNotStarted
-    elsif overdue_delivery?
-      AdminAuctionStatusPresenter::OverdueDelivery
-    elsif auction.work_in_progress?
-      AdminAuctionStatusPresenter::WorkInProgress
-    elsif auction.missed_delivery?
-      AdminAuctionStatusPresenter::MissedDelivery
-    elsif auction.pending_acceptance?
-      AdminAuctionStatusPresenter::PendingAcceptance
-    elsif auction.accepted_pending_payment_url?
-      AdminAuctionStatusPresenter::AcceptedPendingPaymentUrl
-    elsif auction.accepted? && !(auction.c2_paid? || auction.payment_confirmed?)
-      AdminAuctionStatusPresenter::DefaultPcard::Accepted
-    elsif auction.rejected?
-      AdminAuctionStatusPresenter::Rejected
-    elsif auction.c2_paid?
-      C2StatusPresenter::C2Paid
-    else # auction.payment_confirmed?
-      C2StatusPresenter::PaymentConfirmed
+  def presenter_class
+    if auction.purchase_card == 'default'
+      default_purchase_card_presenter
+    else
+      other_purchase_card_presenter
     end
+  end
+
+  def default_purchase_card_presenter
+    ordered_default_pcard_presenter_classes.detect do |presenter_class|
+      presenter_class.relevant?(BidStatusInformation.new(auction))
+    end || C2StatusPresenter::PaymentConfirmed
+  end
+
+  def ordered_default_pcard_presenter_classes
+    [
+      AdminAuctionStatusPresenter::Archived,
+      AdminAuctionStatusPresenter::NoBids,
+      C2StatusPresenter::NotRequested,
+      C2StatusPresenter::Sent,
+      C2StatusPresenter::PendingApproval,
+      AdminAuctionStatusPresenter::Future,
+      AdminAuctionStatusPresenter::ReadyToPublish,
+      AdminAuctionStatusPresenter::Available,
+      AdminAuctionStatusPresenter::WorkNotStarted,
+      AdminAuctionStatusPresenter::OverdueDelivery,
+      AdminAuctionStatusPresenter::WorkInProgress,
+      AdminAuctionStatusPresenter::MissedDelivery,
+      AdminAuctionStatusPresenter::PendingAcceptance,
+      AdminAuctionStatusPresenter::AcceptedPendingPaymentUrl,
+      AdminAuctionStatusPresenter::DefaultPcard::Accepted,
+      AdminAuctionStatusPresenter::Rejected,
+      C2StatusPresenter::C2Paid
+    ]
   end
 
   def other_purchase_card_presenter
     if auction.archived?
+      puts 1
       AdminAuctionStatusPresenter::Archived
     elsif future? && auction.published?
+      puts 2
       AdminAuctionStatusPresenter::Future
     elsif auction.unpublished?
+      puts 3
       AdminAuctionStatusPresenter::ReadyToPublish
     elsif available?
+      puts 4
       AdminAuctionStatusPresenter::Available
     elsif overdue_delivery?
+      puts 5
       AdminAuctionStatusPresenter::OverdueDelivery
     elsif auction.work_in_progress?
+      puts 6
       AdminAuctionStatusPresenter::WorkInProgress
     elsif auction.missed_delivery?
+      puts 7
       AdminAuctionStatusPresenter::MissedDelivery
     elsif auction.pending_acceptance?
+      puts 8
       AdminAuctionStatusPresenter::PendingAcceptance
     elsif auction.accepted_pending_payment_url?
+      puts 9
       AdminAuctionStatusPresenter::AcceptedPendingPaymentUrl
     elsif auction.accepted? && auction.paid_at.nil?
+      puts 10
       AdminAuctionStatusPresenter::OtherPcard::Accepted
     elsif auction.accepted? && auction.paid_at.present?
+      puts 11
       AdminAuctionStatusPresenter::OtherPcard::Paid
     else # auction.rejected?
+      puts 12
       AdminAuctionStatusPresenter::Rejected
+    end
+  end
+
+  def ordered_other_pcard_classes
+    [
+      AdminAuctionStatusPresenter::Archived,
+      AdminAuctionStatusPresenter::Future,
+      AdminAuctionStatusPresenter::ReadyToPublish,
+      AdminAuctionStatusPresenter::Available,
+      AdminAuctionStatusPresenter::OverdueDelivery,
+      AdminAuctionStatusPresenter::WorkInProgress,
+      AdminAuctionStatusPresenter::MissedDelivery,
+      AdminAuctionStatusPresenter::PendingAcceptance,
+      AdminAuctionStatusPresenter::AcceptedPendingPaymentUrl
+    ]
+
+    AdminAuctionStatusPresenter::OtherPcard::Accepted
+    AdminAuctionStatusPresenter::OtherPcard::Paid
+    AdminAuctionStatusPresenter::Rejected
+  end
+
+  class BidStatusInformation
+    attr_reader :auction, :bid_status
+
+    def initialize(auction)
+      @auction = auction
+      @bid_status = BiddingStatus.new(auction)
+    end
+
+    delegate :archived?, :published?, :unpublished?, :pending_delivery?, :work_in_progress?,
+      :pending_acceptance?, :accepted_pending_payment_url?, :missed_delivery?, :accepted?,
+      :c2_paid?, :payment_confirmed?, :rejected?,
+        to: :auction
+
+    def available?
+      bid_status.available?
+    end
+
+    def over_and_no_bids?
+      over? && !bids?
+    end
+
+    def c2_not_requested?
+      auction.c2_status == 'not_requested'
+    end
+
+    def c2_sent?
+      auction.c2_status == 'sent'
+    end
+
+    def c2_pending?
+      auction.c2_status == 'pending_approval'
+    end
+
+    def won?
+      over? && bids?
+    end
+
+    def over?
+      bid_status.over?
+    end
+
+    def bids?
+      auction.bids.any?
+    end
+
+    def future?
+      bid_status.future?
+    end
+
+    def pending_delivery?
+      auction.pending_delivery?
+    end
+
+    def overdue_delivery?
+      won? &&
+        (auction.pending_delivery? || auction.work_in_progress?) &&
+        auction.delivery_due_at < Time.now
+    end
+
+    def delivery_status
+      auction.delivery_status.camelize
+    end
+
+    def c2_status
+      auction.c2_status.camelize
+    end
+
+    def paid_at_info?
+      !paid_at.nil?
     end
   end
 

--- a/app/models/admin_auction_status_presenter_factory.rb
+++ b/app/models/admin_auction_status_presenter_factory.rb
@@ -13,16 +13,39 @@ class AdminAuctionStatusPresenterFactory
 
   def presenter_class
     if auction.purchase_card == 'default'
-      default_purchase_card_presenter
+      default_purchase_card_presenter_class
     else
-      other_purchase_card_presenter
+      other_purchase_card_presenter_class
     end
   end
 
-  def default_purchase_card_presenter
+  def default_purchase_card_presenter_class
     ordered_default_pcard_presenter_classes.detect do |presenter_class|
       presenter_class.relevant?(BidStatusInformation.new(auction))
     end || C2StatusPresenter::PaymentConfirmed
+  end
+
+  def other_purchase_card_presenter_class
+    ordered_other_pcard_classes.detect do |presenter_class|
+      presenter_class.relevant?(BidStatusInformation.new(auction))
+    end || AdminAuctionStatusPresenter::Rejected
+  end
+
+  def ordered_other_pcard_classes
+    [
+      AdminAuctionStatusPresenter::Archived,
+      AdminAuctionStatusPresenter::NoBids,
+      AdminAuctionStatusPresenter::Future,
+      AdminAuctionStatusPresenter::ReadyToPublish,
+      AdminAuctionStatusPresenter::Available,
+      AdminAuctionStatusPresenter::OverdueDelivery,
+      AdminAuctionStatusPresenter::WorkInProgress,
+      AdminAuctionStatusPresenter::MissedDelivery,
+      AdminAuctionStatusPresenter::PendingAcceptance,
+      AdminAuctionStatusPresenter::AcceptedPendingPaymentUrl,
+      AdminAuctionStatusPresenter::OtherPcard::Accepted,
+      AdminAuctionStatusPresenter::OtherPcard::Paid,
+    ]
   end
 
   def ordered_default_pcard_presenter_classes
@@ -45,64 +68,6 @@ class AdminAuctionStatusPresenterFactory
       AdminAuctionStatusPresenter::Rejected,
       C2StatusPresenter::C2Paid
     ]
-  end
-
-  def other_purchase_card_presenter
-    if auction.archived?
-      puts 1
-      AdminAuctionStatusPresenter::Archived
-    elsif future? && auction.published?
-      puts 2
-      AdminAuctionStatusPresenter::Future
-    elsif auction.unpublished?
-      puts 3
-      AdminAuctionStatusPresenter::ReadyToPublish
-    elsif available?
-      puts 4
-      AdminAuctionStatusPresenter::Available
-    elsif overdue_delivery?
-      puts 5
-      AdminAuctionStatusPresenter::OverdueDelivery
-    elsif auction.work_in_progress?
-      puts 6
-      AdminAuctionStatusPresenter::WorkInProgress
-    elsif auction.missed_delivery?
-      puts 7
-      AdminAuctionStatusPresenter::MissedDelivery
-    elsif auction.pending_acceptance?
-      puts 8
-      AdminAuctionStatusPresenter::PendingAcceptance
-    elsif auction.accepted_pending_payment_url?
-      puts 9
-      AdminAuctionStatusPresenter::AcceptedPendingPaymentUrl
-    elsif auction.accepted? && auction.paid_at.nil?
-      puts 10
-      AdminAuctionStatusPresenter::OtherPcard::Accepted
-    elsif auction.accepted? && auction.paid_at.present?
-      puts 11
-      AdminAuctionStatusPresenter::OtherPcard::Paid
-    else # auction.rejected?
-      puts 12
-      AdminAuctionStatusPresenter::Rejected
-    end
-  end
-
-  def ordered_other_pcard_classes
-    [
-      AdminAuctionStatusPresenter::Archived,
-      AdminAuctionStatusPresenter::Future,
-      AdminAuctionStatusPresenter::ReadyToPublish,
-      AdminAuctionStatusPresenter::Available,
-      AdminAuctionStatusPresenter::OverdueDelivery,
-      AdminAuctionStatusPresenter::WorkInProgress,
-      AdminAuctionStatusPresenter::MissedDelivery,
-      AdminAuctionStatusPresenter::PendingAcceptance,
-      AdminAuctionStatusPresenter::AcceptedPendingPaymentUrl
-    ]
-
-    AdminAuctionStatusPresenter::OtherPcard::Accepted
-    AdminAuctionStatusPresenter::OtherPcard::Paid
-    AdminAuctionStatusPresenter::Rejected
   end
 
   class BidStatusInformation
@@ -173,49 +138,7 @@ class AdminAuctionStatusPresenterFactory
     end
 
     def paid_at_info?
-      !paid_at.nil?
+      !auction.paid_at.nil?
     end
-  end
-
-  def available?
-    bidding_status.available?
-  end
-
-  def over_and_no_bids?
-    over? && !bids?
-  end
-
-  def won?
-    over? && bids?
-  end
-
-  def over?
-    bidding_status.over?
-  end
-
-  def bids?
-    auction.bids.any?
-  end
-
-  def future?
-    bidding_status.future?
-  end
-
-  def overdue_delivery?
-    won? &&
-      (auction.pending_delivery? || auction.work_in_progress?) &&
-      auction.delivery_due_at < Time.now
-  end
-
-  def bidding_status
-    @_bidding_status ||= BiddingStatus.new(auction)
-  end
-
-  def delivery_status
-    auction.delivery_status.camelize
-  end
-
-  def c2_status
-    auction.c2_status.camelize
   end
 end

--- a/app/models/admin_auction_status_presenter_factory.rb
+++ b/app/models/admin_auction_status_presenter_factory.rb
@@ -44,7 +44,7 @@ class AdminAuctionStatusPresenterFactory
       AdminAuctionStatusPresenter::PendingAcceptance,
       AdminAuctionStatusPresenter::AcceptedPendingPaymentUrl,
       AdminAuctionStatusPresenter::OtherPcard::Accepted,
-      AdminAuctionStatusPresenter::OtherPcard::Paid,
+      AdminAuctionStatusPresenter::OtherPcard::Paid
     ]
   end
 
@@ -78,10 +78,19 @@ class AdminAuctionStatusPresenterFactory
       @bid_status = BiddingStatus.new(auction)
     end
 
-    delegate :archived?, :published?, :unpublished?, :pending_delivery?, :work_in_progress?,
-      :pending_acceptance?, :accepted_pending_payment_url?, :missed_delivery?, :accepted?,
-      :c2_paid?, :payment_confirmed?, :rejected?,
-        to: :auction
+    delegate  :archived?,
+              :published?,
+              :unpublished?,
+              :pending_delivery?,
+              :work_in_progress?,
+              :pending_acceptance?,
+              :accepted_pending_payment_url?,
+              :missed_delivery?,
+              :accepted?,
+              :c2_paid?,
+              :payment_confirmed?,
+              :rejected?,
+              to: :auction
 
     def available?
       bid_status.available?

--- a/app/presenters/admin_auction_status_presenter/accepted_pending_payment_url.rb
+++ b/app/presenters/admin_auction_status_presenter/accepted_pending_payment_url.rb
@@ -10,4 +10,8 @@ class AdminAuctionStatusPresenter::AcceptedPendingPaymentUrl < AdminAuctionStatu
       delivery_url: auction.delivery_url
     )
   end
+
+  def self.relevant?(status)
+    status.accepted_pending_payment_url?
+  end
 end

--- a/app/presenters/admin_auction_status_presenter/archived.rb
+++ b/app/presenters/admin_auction_status_presenter/archived.rb
@@ -8,4 +8,8 @@ class AdminAuctionStatusPresenter::Archived < AdminAuctionStatusPresenter::Base
       'statuses.admin_auction_status_presenter.archived.body'
     )
   end
+
+  def self.relevant?(status)
+    status.archived?
+  end
 end

--- a/app/presenters/admin_auction_status_presenter/available.rb
+++ b/app/presenters/admin_auction_status_presenter/available.rb
@@ -16,6 +16,10 @@ class AdminAuctionStatusPresenter::Available < AdminAuctionStatusPresenter::Base
     end
   end
 
+  def self.relevant?(status)
+    status.available?
+  end
+
   private
 
   def total_bids

--- a/app/presenters/admin_auction_status_presenter/default_pcard/accepted.rb
+++ b/app/presenters/admin_auction_status_presenter/default_pcard/accepted.rb
@@ -16,6 +16,10 @@ class AdminAuctionStatusPresenter::DefaultPcard::Accepted < AdminAuctionStatusPr
     'admin/auctions/mark_paid'
   end
 
+  def self.relevant?(status)
+    status.accepted? && !(status.c2_paid? || status.payment_confirmed?)
+  end
+
   private
 
   def c2_url

--- a/app/presenters/admin_auction_status_presenter/future.rb
+++ b/app/presenters/admin_auction_status_presenter/future.rb
@@ -14,6 +14,10 @@ class AdminAuctionStatusPresenter::Future < AdminAuctionStatusPresenter::Base
     'admin/auctions/unpublish'
   end
 
+  def self.relevant?(status)
+    status.published? && status.future?
+  end
+
   private
 
   def start_date

--- a/app/presenters/admin_auction_status_presenter/missed_delivery.rb
+++ b/app/presenters/admin_auction_status_presenter/missed_delivery.rb
@@ -8,4 +8,8 @@ class AdminAuctionStatusPresenter::MissedDelivery < AdminAuctionStatusPresenter:
       'statuses.admin_auction_status_presenter.missed_delivery.body'
     )
   end
+
+  def self.relevant?(status)
+    status.missed_delivery?
+  end
 end

--- a/app/presenters/admin_auction_status_presenter/no_bids.rb
+++ b/app/presenters/admin_auction_status_presenter/no_bids.rb
@@ -10,6 +10,10 @@ class AdminAuctionStatusPresenter::NoBids < AdminAuctionStatusPresenter::Base
     )
   end
 
+  def self.relevant?(status)
+    status.over_and_no_bids?
+  end
+
   private
 
   def end_date

--- a/app/presenters/admin_auction_status_presenter/no_bids.rb
+++ b/app/presenters/admin_auction_status_presenter/no_bids.rb
@@ -1,0 +1,19 @@
+class AdminAuctionStatusPresenter::NoBids < AdminAuctionStatusPresenter::Base
+  def header
+    I18n.t('statuses.admin_auction_status_presenter.no_bids.header')
+  end
+
+  def body
+    I18n.t(
+      'statuses.admin_auction_status_presenter.no_bids.body',
+      end_date: end_date
+    )
+  end
+
+  private
+
+  def end_date
+    DcTimePresenter.convert_and_format(auction.ended_at)
+  end
+end
+

--- a/app/presenters/admin_auction_status_presenter/no_bids.rb
+++ b/app/presenters/admin_auction_status_presenter/no_bids.rb
@@ -16,4 +16,3 @@ class AdminAuctionStatusPresenter::NoBids < AdminAuctionStatusPresenter::Base
     DcTimePresenter.convert_and_format(auction.ended_at)
   end
 end
-

--- a/app/presenters/admin_auction_status_presenter/other_pcard/accepted.rb
+++ b/app/presenters/admin_auction_status_presenter/other_pcard/accepted.rb
@@ -16,6 +16,10 @@ class AdminAuctionStatusPresenter::OtherPcard::Accepted < AdminAuctionStatusPres
     'admin/auctions/mark_paid'
   end
 
+  def self.relevant?(status)
+    status.accepted? && !status.paid_at_info?
+  end
+
   private
 
   def accepted_at

--- a/app/presenters/admin_auction_status_presenter/other_pcard/paid.rb
+++ b/app/presenters/admin_auction_status_presenter/other_pcard/paid.rb
@@ -12,6 +12,10 @@ class AdminAuctionStatusPresenter::OtherPcard::Paid < AdminAuctionStatusPresente
     )
   end
 
+  def self.relevant?(status)
+    status.accepted? && status.paid_at_info?
+  end
+
   private
 
   def paid_at

--- a/app/presenters/admin_auction_status_presenter/overdue_delivery.rb
+++ b/app/presenters/admin_auction_status_presenter/overdue_delivery.rb
@@ -13,4 +13,8 @@ class AdminAuctionStatusPresenter::OverdueDelivery < AdminAuctionStatusPresenter
   def action_partial
     'admin/auctions/overdue_delivery'
   end
+
+  def self.relevant?(status)
+    status.overdue_delivery?
+  end
 end

--- a/app/presenters/admin_auction_status_presenter/pending_acceptance.rb
+++ b/app/presenters/admin_auction_status_presenter/pending_acceptance.rb
@@ -14,4 +14,8 @@ class AdminAuctionStatusPresenter::PendingAcceptance < AdminAuctionStatusPresent
   def action_partial
     'admin/auctions/accept_or_reject'
   end
+
+  def self.relevant?(status)
+    status.pending_acceptance?
+  end
 end

--- a/app/presenters/admin_auction_status_presenter/ready_to_publish.rb
+++ b/app/presenters/admin_auction_status_presenter/ready_to_publish.rb
@@ -35,6 +35,10 @@ class AdminAuctionStatusPresenter::ReadyToPublish < AdminAuctionStatusPresenter:
     DcTimePresenter.convert_and_format(auction.delivery_due_at)
   end
 
+  def self.relevant?(status)
+    status.unpublished?
+  end
+
   private
 
   def dc_time(field)

--- a/app/presenters/admin_auction_status_presenter/rejected.rb
+++ b/app/presenters/admin_auction_status_presenter/rejected.rb
@@ -12,6 +12,10 @@ class AdminAuctionStatusPresenter::Rejected < AdminAuctionStatusPresenter::Base
     )
   end
 
+  def self.relevant?(status)
+    status.rejected?
+  end
+
   private
 
   def rejected_at

--- a/app/presenters/admin_auction_status_presenter/work_in_progress.rb
+++ b/app/presenters/admin_auction_status_presenter/work_in_progress.rb
@@ -16,6 +16,10 @@ class AdminAuctionStatusPresenter::WorkInProgress < AdminAuctionStatusPresenter:
     'admin/auctions/work_in_progress'
   end
 
+  def self.relevant?(status)
+    status.work_in_progress?
+  end
+
   private
 
   def delivery_deadline

--- a/app/presenters/admin_auction_status_presenter/work_not_started.rb
+++ b/app/presenters/admin_auction_status_presenter/work_not_started.rb
@@ -13,6 +13,10 @@ class AdminAuctionStatusPresenter::WorkNotStarted < AdminAuctionStatusPresenter:
     )
   end
 
+  def self.relevant?(status)
+    status.won? && status.pending_delivery?
+  end
+
   private
 
   def ended_at

--- a/app/presenters/bidding_status_presenter/over.rb
+++ b/app/presenters/bidding_status_presenter/over.rb
@@ -26,7 +26,7 @@ class BiddingStatusPresenter::Over < BiddingStatusPresenter::Base
              winner_name: winner_name,
              amount: winning_bid_amount_as_currency)
     else
-      ''
+      I18n.t('bidding_status.over.no_bids')
     end
   end
 

--- a/app/presenters/c2_status_presenter/c2_paid.rb
+++ b/app/presenters/c2_status_presenter/c2_paid.rb
@@ -10,4 +10,8 @@ class C2StatusPresenter::C2Paid < C2StatusPresenter::Base
   def header
     I18n.t('statuses.c2_presenter.c2_paid.header')
   end
+
+  def self.relevant?(status)
+    status.c2_paid?
+  end
 end

--- a/app/presenters/c2_status_presenter/not_requested.rb
+++ b/app/presenters/c2_status_presenter/not_requested.rb
@@ -10,4 +10,8 @@ class C2StatusPresenter::NotRequested < C2StatusPresenter::Base
   def action_partial
     'admin/auctions/request_approval'
   end
+
+  def self.relevant?(status)
+    status.c2_not_requested?
+  end
 end

--- a/app/presenters/c2_status_presenter/payment_confirmed.rb
+++ b/app/presenters/c2_status_presenter/payment_confirmed.rb
@@ -13,6 +13,10 @@ class C2StatusPresenter::PaymentConfirmed < C2StatusPresenter::Base
     I18n.t('statuses.c2_presenter.payment_confirmed.header')
   end
 
+  def self.relevant?(status)
+    status.c2_payment_confirmed?
+  end
+
   private
 
   def paid_at

--- a/app/presenters/c2_status_presenter/pending_approval.rb
+++ b/app/presenters/c2_status_presenter/pending_approval.rb
@@ -11,4 +11,8 @@ class C2StatusPresenter::PendingApproval < C2StatusPresenter::Base
   def action_partial
     'admin/auctions/pending'
   end
+
+  def self.relevant?(status)
+    status.c2_pending?
+  end
 end

--- a/app/presenters/c2_status_presenter/sent.rb
+++ b/app/presenters/c2_status_presenter/sent.rb
@@ -10,4 +10,8 @@ class C2StatusPresenter::Sent < C2StatusPresenter::Base
   def action_partial
     'admin/auctions/sent'
   end
+
+  def self.relevant?(status)
+    status.c2_sent?
+  end
 end

--- a/app/view_models/auction_list_item.rb
+++ b/app/view_models/auction_list_item.rb
@@ -80,7 +80,8 @@ class AuctionListItem
     if auction.lowest_bid
       Currency.new(auction.lowest_bid.amount).to_s
     else
-      'No bids'
+      # TODO: move to i18n
+      'There are no bids'
     end
   end
 

--- a/app/view_models/auction_list_item.rb
+++ b/app/view_models/auction_list_item.rb
@@ -80,8 +80,7 @@ class AuctionListItem
     if auction.lowest_bid
       Currency.new(auction.lowest_bid.amount).to_s
     else
-      # TODO: move to i18n
-      'There are no bids'
+      I18n.t('bidding_status.over.no_bids')
     end
   end
 

--- a/config/locales/bidding_status/en.yml
+++ b/config/locales/bidding_status/en.yml
@@ -27,3 +27,4 @@ en:
       label: Closed
       start_label: Auction started at
       relative_time: "Ended on %{time}"
+      no_bids: There are no bids

--- a/config/locales/statuses/en.yml
+++ b/config/locales/statuses/en.yml
@@ -136,6 +136,9 @@ en:
             This auction is ready to publish! Please select a start date, end
             date, and delivery period for this auction.
           header: "Ready to publish"
+      no_bids:
+        header: There are no bids
+        body: "This auction ended on %{end_date} and there were no bids."
       work_not_started:
         header: Ready for work
         body: >

--- a/features/admin_views_closed_auctions.feature
+++ b/features/admin_views_closed_auctions.feature
@@ -10,6 +10,14 @@ Feature: Admin views closed auctions in the admin panel
     And I should see "No auctions have been successfully delivered yet"
     And I should see "There are no auctions that have not been delivered"
 
+  Scenario: Viewing closed auction with no bids
+    Given I am an administrator
+    And there is a closed auction with no bids
+    And I sign in
+    When I visit the admin auction page for that auction
+    Then I should see the name of the auction
+    And I should see the message that the auction is closed without bids
+
   Scenario: Viewing closed successful auctions
     Given I am an administrator
     And there is a complete and successful auction

--- a/features/guest_views_closed_auction.feature
+++ b/features/guest_views_closed_auction.feature
@@ -13,6 +13,11 @@ Feature: Guest views closed auction
     Then I should see a "Closed" label
     And I should see the closed auction message for non-bidders
 
+  Scenario: There is an auction that ended without any bids
+    Given there is a closed auction with no bids
+    When I visit the home page
+    Then I should see a messages that the auction has no bids
+
   Scenario: Winning vendor was paid
     Given there is a paid auction
     When I visit the auction page

--- a/features/guest_views_closed_auction.feature
+++ b/features/guest_views_closed_auction.feature
@@ -16,7 +16,10 @@ Feature: Guest views closed auction
   Scenario: There is an auction that ended without any bids
     Given there is a closed auction with no bids
     When I visit the home page
-    Then I should see a messages that the auction has no bids
+    Then I should see a message that the auction has no bids
+
+    When I visit the auction page
+    Then I should see a message that the auction has no bids
 
   Scenario: Winning vendor was paid
     Given there is a paid auction

--- a/features/step_definitions/admin_auction_status_steps.rb
+++ b/features/step_definitions/admin_auction_status_steps.rb
@@ -1,3 +1,11 @@
 Then(/^I should see that approval has not been requested for the auction$/) do
   I18n.t('statuses.c2_presenter.not_requested.body', link: '')
 end
+
+Then(/^I should see the message that the auction is closed without bids$/) do
+  expect(page).to have_content(I18n.t('bidding_status.over.no_bids'))
+
+  expect(page).to have_content(
+    I18n.t('statuses.admin_auction_status_presenter.no_bids.body', end_date: end_date)
+  )
+end

--- a/features/step_definitions/auction_create_steps.rb
+++ b/features/step_definitions/auction_create_steps.rb
@@ -14,6 +14,10 @@ Given(/^there is a closed auction$/) do
   @auction = FactoryGirl.create(:auction, :closed, :with_bids)
 end
 
+Given(/^there is a closed auction with no bids$/) do
+  @auction = FactoryGirl.create(:auction, :closed)
+end
+
 Given(/^I am going to win an auction$/) do
   @auction = FactoryGirl.build(:auction, :available, :with_bids)
   Timecop.freeze(@auction.ended_at - 15.minutes) do

--- a/features/step_definitions/auction_status_steps.rb
+++ b/features/step_definitions/auction_status_steps.rb
@@ -310,9 +310,8 @@ Then(/^I should see the auction was sent to C2 for approval$/) do
   )
 end
 
-# TODO: Switch to internationalization
-Then(/^I should see a messages that the auction has no bids$/) do
+Then(/^I should see a message that the auction has no bids$/) do
   expect(page).to have_content(
-    "There are no bids"
+    I18n.t('bidding_status.over.no_bids')
   )
 end

--- a/features/step_definitions/auction_status_steps.rb
+++ b/features/step_definitions/auction_status_steps.rb
@@ -309,3 +309,10 @@ Then(/^I should see the auction was sent to C2 for approval$/) do
     I18n.t('statuses.c2_presenter.sent.body')
   )
 end
+
+# TODO: Switch to internationalization
+Then(/^I should see a messages that the auction has no bids$/) do
+  expect(page).to have_content(
+    "There are no bids"
+  )
+end

--- a/features/step_definitions/debugging_steps.rb
+++ b/features/step_definitions/debugging_steps.rb
@@ -1,3 +1,3 @@
-When(/^Let me see that$/) do
+When(/^let me see that$/) do
   save_and_open_page
 end

--- a/spec/models/admin_auction_status_presenter_factory_spec.rb
+++ b/spec/models/admin_auction_status_presenter_factory_spec.rb
@@ -3,15 +3,15 @@ require 'rails_helper'
 describe AdminAuctionStatusPresenterFactory do
   context 'when the auction is archived' do
     it 'should return a Archived presenter' do
-      auction = create(:auction, :archived)
+      auction = create(:auction, :archived, :with_bids)
       expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
         .to be_a(AdminAuctionStatusPresenter::Archived)
     end
   end
 
-  context 'when the auction is archived' do
-    it 'should return a Archived presenter' do
-      auction = create(:auction, :unpublished, :accepted, :with_bids)
+  context 'when the auction is unpublished' do
+    it 'should return a ReadyToPublish presenter' do
+      auction = create(:auction, :unpublished, :accepted, ended_at: Time.now + 1.year)
       expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
         .to be_a(AdminAuctionStatusPresenter::ReadyToPublish)
     end
@@ -36,7 +36,7 @@ describe AdminAuctionStatusPresenterFactory do
   end
 
   context "when the vendor is working on the job" do
-    it 'should return a AdminAuctionStatusPresenter::OverdueDelivery' do
+    it 'should return a AdminAuctionStatusPresenter::WorkInProgress' do
       auction = create(:auction, :closed, :published, :with_bids, delivery_status: :work_in_progress)
 
       expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
@@ -60,14 +60,13 @@ describe AdminAuctionStatusPresenterFactory do
   end
 
   context "when the auction has been marked as a missed delivery" do
-    it 'should return a AdminAuctionStatusPresenter::Future' do
-      auction = create(
-        :auction,
-        :closed,
-        :published,
-        :with_bids,
-        delivery_due_at: 4.minutes.ago, delivery_status: :missed_delivery
-      )
+    it 'should return a AdminAuctionStatusPresenter::MissedDelivery' do
+      auction = create(:auction,
+                       :closed,
+                       :published,
+                       :with_bids,
+                       delivery_due_at: 4.minutes.ago,
+                       delivery_status: :missed_delivery)
 
       expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
         .to be_a(AdminAuctionStatusPresenter::MissedDelivery)
@@ -126,15 +125,6 @@ describe AdminAuctionStatusPresenterFactory do
     end
   end
 
-  context 'when an auction has been accepted but is for an other pcard' do
-    it 'should return a AdminAuctionStatusPresenter::OtherPcard::Accepted' do
-      auction = create(:auction, :payment_needed, purchase_card: :other)
-
-      expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
-        .to be_a(AdminAuctionStatusPresenter::OtherPcard::Accepted)
-    end
-  end
-
   context 'when the auction has been rejected' do
     it 'should return a AdminAuctionStatusPresenter::Rejected' do
       auction = create(:auction, :rejected, :with_bids)
@@ -149,13 +139,8 @@ describe AdminAuctionStatusPresenterFactory do
       auction = create(:auction, :closed)
 
       expect(
-        AdminAuctionStatusPresenterFactory.new(auction: auction).create.body
-      ).to eq(
-        I18n.t(
-          'statuses.admin_auction_status_presenter.no_bids.body',
-          end_date: DcTimePresenter.convert_and_format(auction.ended_at)
-        )
-      )
+        AdminAuctionStatusPresenterFactory.new(auction: auction).create
+      ).to be_a(AdminAuctionStatusPresenter::NoBids)
     end
   end
 
@@ -198,6 +183,121 @@ describe AdminAuctionStatusPresenterFactory do
 
       expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
         .to be_a(AdminAuctionStatusPresenter::WorkNotStarted)
+    end
+  end
+
+  context 'when using the non-default pcard' do
+    context 'when an auction is archived' do
+      it 'uses the Archived presenter' do
+        auction = create(:auction, :archived, purchase_card: :other)
+          expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
+            .to be_a(AdminAuctionStatusPresenter::Archived)
+      end
+    end
+
+    context 'when an auction is published and in the future' do
+      it 'uses the Future presenter' do
+        auction = create(:auction, :future, :published, purchase_card: :other)
+          expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
+            .to be_a(AdminAuctionStatusPresenter::Future)
+      end
+    end
+
+    context 'when an auction is unpublished' do
+      it 'uses the ReadyToPublish presenter' do
+        auction = create(:auction, :unpublished, purchase_card: :other)
+          expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
+            .to be_a(AdminAuctionStatusPresenter::ReadyToPublish)
+      end
+    end
+
+    context 'when an auction is unpublished' do
+      it 'uses the ReadyToPublish presenter' do
+        auction = create(:auction, :unpublished, purchase_card: :other)
+          expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
+            .to be_a(AdminAuctionStatusPresenter::ReadyToPublish)
+      end
+    end
+
+    context 'when auction is available' do
+      it 'should return the correct presenter' do
+        auction = create(:auction, :available, purchase_card: :other)
+
+        expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
+          .to be_a(AdminAuctionStatusPresenter::Available)
+      end
+    end
+
+    context "when the vendor is late on delivery" do
+      it 'should return a AdminAuctionStatusPresenter::OverdueDelivery' do
+        auction = create(:auction, :closed, :published, :with_bids, purchase_card: :other, delivery_status: :work_in_progress, delivery_due_at: 4.minutes.ago)
+
+        expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
+          .to be_a(AdminAuctionStatusPresenter::OverdueDelivery)
+      end
+    end
+
+    context "when the vendor is working on the job" do
+      it 'should return a AdminAuctionStatusPresenter::WorkInProgress' do
+        auction = create(:auction, :closed, :published, :with_bids, purchase_card: :other, delivery_status: :work_in_progress)
+
+        expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
+          .to be_a(AdminAuctionStatusPresenter::WorkInProgress)
+      end
+    end
+
+    context "when the auction has been marked as a missed delivery" do
+      it 'should return a AdminAuctionStatusPresenter::MissedDelivery' do
+        auction = create(:auction, :closed, :published, :with_bids, purchase_card: :other, delivery_due_at: 4.minutes.ago, delivery_status: :missed_delivery)
+
+        expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
+          .to be_a(AdminAuctionStatusPresenter::MissedDelivery)
+      end
+    end
+
+    context "when the vendor has delivered the job, but it has not been accepted" do
+      it 'should return a AdminAuctionStatusPresenter::PendingAcceptance' do
+        auction = create(:auction, :closed, :published, :with_bids, :pending_acceptance, purchase_card: :other)
+
+        expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
+          .to be_a(AdminAuctionStatusPresenter::PendingAcceptance)
+      end
+    end
+
+    context "when an auction has been accepted but doesn't have a payment URL yet" do
+      it 'should return a AdminAuctionStatusPresenter::AcceptedPendingPaymentUrl' do
+        auction = create(:auction, :closed, :with_bids, :published, :delivery_url, delivery_status: :accepted_pending_payment_url, purchase_card: :other)
+
+        expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
+          .to be_a(AdminAuctionStatusPresenter::AcceptedPendingPaymentUrl)
+      end
+    end
+
+    context 'when an auction has been accepted' do
+      it 'should return a AdminAuctionStatusPresenter::OtherPcard::Accepted' do
+        auction = create(:auction, :payment_needed, purchase_card: :other)
+
+        expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
+          .to be_a(AdminAuctionStatusPresenter::OtherPcard::Accepted)
+      end
+    end
+
+    context 'when an auction has been accepted' do
+      it 'should return a AdminAuctionStatusPresenter::OtherPcard::Paid' do
+        auction = create(:auction, :payment_needed, purchase_card: :other, paid_at: Time.now - 3.days)
+
+        expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
+          .to be_a(AdminAuctionStatusPresenter::OtherPcard::Paid)
+      end
+    end
+
+    context 'when an auction has been accepted' do
+      it 'should return a AdminAuctionStatusPresenter::OtherPcard::Paid' do
+        auction = create(:auction, :with_bids, :rejected, purchase_card: :other)
+
+        expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
+          .to be_a(AdminAuctionStatusPresenter::Rejected)
+      end
     end
   end
 end

--- a/spec/models/admin_auction_status_presenter_factory_spec.rb
+++ b/spec/models/admin_auction_status_presenter_factory_spec.rb
@@ -1,6 +1,22 @@
 require 'rails_helper'
 
 describe AdminAuctionStatusPresenterFactory do
+  context 'when the auction is archived' do
+    it 'should return a Archived presenter' do
+      auction = create(:auction, :archived)
+      expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
+        .to be_a(AdminAuctionStatusPresenter::Archived)
+    end
+  end
+
+  context 'when the auction is archived' do
+    it 'should return a Archived presenter' do
+      auction = create(:auction, :unpublished, :accepted, :with_bids)
+      expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
+        .to be_a(AdminAuctionStatusPresenter::ReadyToPublish)
+    end
+  end
+
   context 'when the auction approval is not requested' do
     it 'should return a C2StatusPresenter::NotRequested' do
       auction = create(:auction, c2_status: :not_requested)
@@ -16,6 +32,15 @@ describe AdminAuctionStatusPresenterFactory do
 
       expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
         .to be_a(AdminAuctionStatusPresenter::Future)
+    end
+  end
+
+  context "when the vendor is working on the job" do
+    it 'should return a AdminAuctionStatusPresenter::OverdueDelivery' do
+      auction = create(:auction, :closed, :published, :with_bids, delivery_status: :work_in_progress)
+
+      expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
+        .to be_a(AdminAuctionStatusPresenter::WorkInProgress)
     end
   end
 
@@ -46,6 +71,33 @@ describe AdminAuctionStatusPresenterFactory do
 
       expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
         .to be_a(AdminAuctionStatusPresenter::MissedDelivery)
+    end
+  end
+
+  context "when the vendor has delivered the job, but it has not been accepted" do
+    it 'should return a AdminAuctionStatusPresenter::PendingAcceptance' do
+      auction = create(:auction, :closed, :published, :with_bids, :pending_acceptance)
+
+      expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
+        .to be_a(AdminAuctionStatusPresenter::PendingAcceptance)
+    end
+  end
+
+  context "when the vendor is paid" do
+    it 'should return a C2StatusPresenter::C2Paid' do
+      auction = create(:auction, :closed, :published, :accepted, :with_bids, :paid, c2_status: :c2_paid)
+
+      expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
+        .to be_a(C2StatusPresenter::C2Paid)
+    end
+  end
+
+  context "when the vendor is paid and payment confirmed" do
+    it 'should return a C2StatusPresenter::PaymentConfirmed' do
+      auction = create(:auction, :closed, :published, :accepted, :with_bids, :paid, c2_status: :payment_confirmed)
+
+      expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
+        .to be_a(C2StatusPresenter::PaymentConfirmed)
     end
   end
 

--- a/spec/models/admin_auction_status_presenter_factory_spec.rb
+++ b/spec/models/admin_auction_status_presenter_factory_spec.rb
@@ -67,7 +67,7 @@ describe AdminAuctionStatusPresenterFactory do
 
   context 'when the auction has been accepted' do
     it 'should return a AdminAuctionStatusPresenter::DefaultPcard::Accepted' do
-      auction = create(:auction, :accepted)
+      auction = create(:auction, :accepted, :with_bids)
 
       expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
         .to be_a(AdminAuctionStatusPresenter::DefaultPcard::Accepted)
@@ -85,27 +85,25 @@ describe AdminAuctionStatusPresenterFactory do
 
   context 'when the auction has been rejected' do
     it 'should return a AdminAuctionStatusPresenter::Rejected' do
-      auction = create(:auction, :rejected)
+      auction = create(:auction, :rejected, :with_bids)
 
       expect(AdminAuctionStatusPresenterFactory.new(auction: auction).create)
         .to be_a(AdminAuctionStatusPresenter::Rejected)
     end
+  end
 
-    context 'rejected auction has no winner' do
-      it 'should return a AdminAuctionStatusPresenter::Rejected' do
-        auction = create(:auction, :rejected)
+  context 'when there are no bids' do
+    it 'should return a AdminAuctionStatusPresenter::NoBids' do
+      auction = create(:auction, :closed)
 
-        expect(
-          AdminAuctionStatusPresenterFactory.new(auction: auction).create.body
-        ).to eq(
-          I18n.t(
-            'statuses.admin_auction_status_presenter.rejected.body',
-            delivery_url: auction.delivery_url,
-            rejected_at: DcTimePresenter.convert_and_format(auction.rejected_at),
-            winner_name: 'N/A'
-          )
+      expect(
+        AdminAuctionStatusPresenterFactory.new(auction: auction).create.body
+      ).to eq(
+        I18n.t(
+          'statuses.admin_auction_status_presenter.no_bids.body',
+          end_date: DcTimePresenter.convert_and_format(auction.ended_at)
         )
-      end
+      )
     end
   end
 

--- a/spec/presenters/bidding_status_presenter/over_spec.rb
+++ b/spec/presenters/bidding_status_presenter/over_spec.rb
@@ -35,7 +35,7 @@ describe BiddingStatusPresenter::Over do
       auction = create(:auction, :closed)
       presenter = BiddingStatusPresenter::Over.new(auction)
       user = create(:user)
-      expect(presenter.bid_label(user)).to eq('')
+      expect(presenter.bid_label(user)).to eq("There are no bids")
     end
   end
 


### PR DESCRIPTION
This is for story #1443 in Waffle, and was useful to understand the state of the code and its complexities.

One note. I don't have seed data locally, so I was pretty dependent on the acceptance test to make sure this was correct. This is good in terms of assuring testing, and not good in terms of QA. Also, not sure about the flow. Do we push things we are curious about to staging manually, or is that part of the github flow automatically. Also, what is our ability to setup an auction in the right state?

----------------

### Now I am going to meander about code, information architecture and the state of states!

* I don't think that internationalization is slowing this project down, but the organization of presenters and view models is really hard. It took a long time to track down where the right message was being decided, and not very long to change it even with i18n.
* i18n should be organized around outward facing values and not their location in the presenter/view model world. The really deep nesting around who won, who is viewing and what the state of the auction is needs to be flattened some. And seeing the presenters while working on the rubocop story gave me some ideas around the types of states that are mixed together. More on that below:

#### STATES, oh the confusion of the states!

@harrisj @adelevie @mtorres253 

So, now that I have had two different pull requests where I have been able to check out the presenters and all their state representations here is what I think might be true. There are the following states all mixed together:

* Auction bidding state: not yet bidding -> bidding -> closed
* Auction won state: no bids -> won
* Auction work state: not started -> in progress -> delivered | not delivered
* Work acceptance: not evaluated -> accepted | rejected
* C2 status: no idea ... but you all probably get this
* Payment: not paid -> payment sent -> payment confirmed ??

I am sorry, because I am pretty sure I didn't get these state names and concepts right. What I am trying to peel apart are the different state machines hanging out in a very complicated presentation system. I think making the different types of states more explicit (even in the UI) will make the code and product easier to understand. This is particularly true when you layer permissions of that data. For example winner, admins, bidders and guests have different permissions on top of this state related stuff. I know this is complex, but not sure it has to be as complicated as it is.

Let me know if I am totally off the mark. As usual, I am doing drive by architecture and code review, so I acknowledge it might not resonate with developers.