### PR TITLE
Only existing admin users can log in with Login.gov

### DIFF
--- a/app/controllers/saml_authentications_controller.rb
+++ b/app/controllers/saml_authentications_controller.rb
@@ -1,12 +1,20 @@
 class SamlAuthenticationsController < ApplicationController
   def create
     user = User.from_saml_omniauth(request.env['omniauth.auth'])
-    session[:user_id] = user.id
 
-    redirect_to(
-      admin_path,
-      notice: t('omniauth_callbacks.success')
-    )
+    if user
+      session[:user_id] = user.id
+
+      redirect_to(
+        admin_path,
+        notice: t('omniauth_callbacks.success')
+      )
+    else
+      redirect_to(
+        root_path,
+        error: t('omniauth_callbacks.failure', reason: 'no admin account found.')
+      )
+    end
   end
 
   def destroy

--- a/app/models/admins.rb
+++ b/app/models/admins.rb
@@ -1,7 +1,7 @@
 class Admins
-  def verify?(uid)
-    return false if uid.nil?
-    github_ids.include?(uid.to_s)
+  def verify?(github_id)
+    return false if github_id.nil?
+    github_ids.include?(github_id.to_s)
   end
 
   def github_ids

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,8 +4,8 @@ class User < ActiveRecord::Base
   validates :payment_url, url: { allow_blank: true, no_local: true, schemes: %w(http https) }
   validates :duns_number, duns_number: true
   validates :email, presence: true, email: true
-  validates :github_id, presence: true, if: :not_login_user?
-  validates :github_login, presence: true, if: :not_login_user?
+  validates :github_id, presence: true
+  validates :github_login, presence: true
   validates :sam_status, presence: true
 
   enum sam_status: { duns_blank: 0, sam_accepted: 1, sam_rejected: 2, sam_pending: 3 }
@@ -33,11 +33,5 @@ class User < ActiveRecord::Base
     self.uid = auth.uid
     self.email = auth.info.email
     self.name = "#{auth.info.first_name} #{auth.info.last_name}"
-  end
-
-  private
-
-  def not_login_user?
-    uid.blank?
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,28 +3,9 @@ require 'rails_helper'
 describe User do
   describe "Validations" do
     it { should validate_presence_of(:email) }
+    it { should validate_presence_of(:github_id) }
+    it { should validate_presence_of(:github_login) }
     it { should validate_presence_of(:sam_status) }
-
-    describe 'github validations' do
-      context 'user has a uid' do
-        it 'does not validate github id and name presence' do
-          user = build(:user, uid: '1234', github_id: nil, github_login: nil)
-
-          expect(user).to be_valid
-        end
-      end
-
-      context 'user does not have a uid' do
-        it 'validates github id and name' do
-          user = build(:user, uid: nil, github_id: nil, github_login: nil)
-
-          expect(user).to be_invalid
-          expect(user.errors.full_messages).to eq(
-            ["Github can't be blank", "Github login can't be blank"]
-          )
-        end
-      end
-    end
 
     describe 'duns number validations' do
       context 'duns is 13 chars long' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -44,4 +44,81 @@ describe User do
       end
     end
   end
+
+  describe '.from_saml_omniauth' do
+    context 'user with saml uid exists' do
+      context 'user is an admin' do
+        context 'provided auth uid is not empty' do
+          it 'returns the user' do
+            uid = '1234'
+            info = double(email: '', first_name: '', last_name: '')
+            auth_data = double(uid: uid, info: info)
+            admin = create(:admin_user, uid: uid)
+
+            expect(User.from_saml_omniauth(auth_data)).to eq admin
+          end
+        end
+
+        context 'provied auth uid is empty string' do
+          it 'returns nil' do
+            uid = ''
+            info = double(email: '', first_name: '', last_name: '')
+            auth_data = double(uid: uid, info: info)
+            _admin = create(:admin_user, uid: uid)
+
+            expect(User.from_saml_omniauth(auth_data)).to eq nil
+          end
+        end
+      end
+
+      context 'user is not an admin' do
+        it 'returns nil' do
+          uid = '1234'
+          info = double(email: '', first_name: '', last_name: '')
+          auth_data = double(uid: uid, info: info)
+          _user = create(:user, uid: uid)
+
+          expect(User.from_saml_omniauth(auth_data)).to eq nil
+        end
+      end
+    end
+
+    context 'user with uid does not exist' do
+      context 'user with auth email exists' do
+        context 'user with auth email is admin' do
+          it 'updates the existing user with the uid and returns the user' do
+            uid = '1234'
+            email = 'test@example.com'
+            info = double(email: email, first_name: '', last_name: '')
+            auth_data = double(uid: uid, info: info)
+            admin = create(:admin_user, uid: '', email: email)
+
+            expect(User.from_saml_omniauth(auth_data)).to eq admin
+            expect(admin.reload.uid).to eq uid
+          end
+        end
+
+        context 'user with auth email is not an admin' do
+          it 'returns nil' do
+            email = 'test@example.com'
+            info = double(email: email, first_name: '', last_name: '')
+            auth_data = double(uid: '', info: info)
+            _user = create(:user, email: email)
+
+            expect(User.from_saml_omniauth(auth_data)).to eq nil
+          end
+        end
+      end
+
+      context 'user with auth email does not exist' do
+        it 'returns nil' do
+          email = 'test@example.com'
+          info = double(email: email, first_name: '', last_name: '')
+          auth_data = double(uid: '', info: info)
+
+          expect(User.from_saml_omniauth(auth_data)).to eq nil
+        end
+      end
+    end
+  end
 end

--- a/spec/requests/slo_spec.rb
+++ b/spec/requests/slo_spec.rb
@@ -9,6 +9,9 @@ describe 'SLO' do
     get '/auth/saml'
     idp_uri = URI(response.headers['Location'])
     saml_idp_resp = Net::HTTP.get(idp_uri)
+    saml_response = OneLogin::RubySaml::Response.new(saml_idp_resp)
+    uid = saml_response.attributes['uid']
+    _admin_user = create(:admin_user, uid: uid)
     post '/auth/saml/callback', SAMLResponse: saml_idp_resp
   end
 

--- a/spec/requests/sso_spec.rb
+++ b/spec/requests/sso_spec.rb
@@ -5,10 +5,8 @@ describe 'SSO' do
     OmniAuth.config.test_mode = false
   end
 
-  context 'LOA1' do
-    it 'uses external SAML IdP' do
-      expect(User.count).to eq 0
-
+  context 'user is an admin' do
+    it 'does not sign in the user' do
       get '/auth/saml'
       expect(response).to redirect_to(%r{idp\.example\.com\/saml\/auth})
 
@@ -16,13 +14,34 @@ describe 'SSO' do
       saml_idp_resp = Net::HTTP.get(idp_uri)
 
       saml_response = OneLogin::RubySaml::Response.new(saml_idp_resp)
+      uid = saml_response.attributes['uid']
+      _user = create(:user, uid: uid)
+      asserted_attributes = saml_response.attributes.attributes.keys.map(&:to_sym)
+      expect(asserted_attributes).to match_array([:uid, :email])
+
+      post '/auth/saml/callback', SAMLResponse: saml_idp_resp
+
+      expect(response).to redirect_to('http://www.example.com/')
+    end
+  end
+
+  context 'user is not an admin' do
+    it 'uses external SAML IdP to sign in the user' do
+      get '/auth/saml'
+      expect(response).to redirect_to(%r{idp\.example\.com\/saml\/auth})
+
+      idp_uri = URI(response.headers['Location'])
+      saml_idp_resp = Net::HTTP.get(idp_uri)
+
+      saml_response = OneLogin::RubySaml::Response.new(saml_idp_resp)
+      uid = saml_response.attributes['uid']
+      _admin_user = create(:admin_user, uid: uid)
       asserted_attributes = saml_response.attributes.attributes.keys.map(&:to_sym)
       expect(asserted_attributes).to match_array([:uid, :email])
 
       post '/auth/saml/callback', SAMLResponse: saml_idp_resp
 
       expect(response).to redirect_to('http://www.example.com/admin')
-      expect(User.count).to eq 1
     end
   end
 end

--- a/spec/requests/sso_spec.rb
+++ b/spec/requests/sso_spec.rb
@@ -5,7 +5,7 @@ describe 'SSO' do
     OmniAuth.config.test_mode = false
   end
 
-  context 'user is an admin' do
+  context 'user is not an admin' do
     it 'does not sign in the user' do
       get '/auth/saml'
       expect(response).to redirect_to(%r{idp\.example\.com\/saml\/auth})
@@ -25,7 +25,7 @@ describe 'SSO' do
     end
   end
 
-  context 'user is not an admin' do
+  context 'user is an admin' do
     it 'uses external SAML IdP to sign in the user' do
       get '/auth/saml'
       expect(response).to redirect_to(%r{idp\.example\.com\/saml\/auth})


### PR DESCRIPTION
* Adds specs and logic to ensure that only admins can log in with
  login.gov
* Show error flash when non-admin user tries to sign in