### PR TITLE
Change name of `saml_issuer` in dev mode

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -2,7 +2,7 @@ development:
   idp_cert_fingerprint: '8B:D5:C2:E8:9A:2B:CE:B7:4B:95:50:BA:16:79:05:27:17:D1:D3:67'
   idp_sso_url: http://localhost:3004/api/saml/auth
   idp_slo_url: http://localhost:3004/api/saml/logout
-  saml_issuer: urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost-rails
+  saml_issuer: urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost-micropurchase
   secret_key_base: 787f9378e8d9e0eac392f57c7a9927daf12c410e8a882b7bedbb4126748db4d6230893a104cb12d2bf09af76d1fb1939eeb072a97709999d062f38e965c4d1cd
 
 test:


### PR DESCRIPTION
* So we can set up the identity idp to work with us in dev mode
* Other saml_issuer is same as sp-rails so needs to change