### PR TITLE
Remove first / last name request from SAML oauth

### DIFF
--- a/app/controllers/saml_authentications_controller.rb
+++ b/app/controllers/saml_authentications_controller.rb
@@ -31,7 +31,7 @@ class SamlAuthenticationsController < ApplicationController
     if params.key?(:loa)
       request.env['omniauth.strategy'].options[:authn_context] = [
         "http://idmanagement.gov/ns/assurance/loa/#{params[:loa]}",
-        'http://idmanagement.gov/ns/requested_attributes?ReqAttr=email,first_name,last_name'
+        'http://idmanagement.gov/ns/requested_attributes?ReqAttr=email'
       ]
     end
     render text: 'Omniauth setup phase.', status: 404

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,6 +32,5 @@ class User < ActiveRecord::Base
   def assign_from_auth(auth)
     self.uid = auth.uid
     self.email = auth.info.email
-    self.name = "#{auth.info.first_name} #{auth.info.last_name}"
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -32,7 +32,7 @@ describe User do
         context 'provided auth uid is not empty' do
           it 'returns the user' do
             uid = '1234'
-            info = double(email: '', first_name: '', last_name: '')
+            info = double(email: '')
             auth_data = double(uid: uid, info: info)
             admin = create(:admin_user, uid: uid)
 
@@ -43,7 +43,7 @@ describe User do
         context 'provied auth uid is empty string' do
           it 'returns nil' do
             uid = ''
-            info = double(email: '', first_name: '', last_name: '')
+            info = double(email: '')
             auth_data = double(uid: uid, info: info)
             _admin = create(:admin_user, uid: uid)
 
@@ -55,7 +55,7 @@ describe User do
       context 'user is not an admin' do
         it 'returns nil' do
           uid = '1234'
-          info = double(email: '', first_name: '', last_name: '')
+          info = double(email: '')
           auth_data = double(uid: uid, info: info)
           _user = create(:user, uid: uid)
 
@@ -70,7 +70,7 @@ describe User do
           it 'updates the existing user with the uid and returns the user' do
             uid = '1234'
             email = 'test@example.com'
-            info = double(email: email, first_name: '', last_name: '')
+            info = double(email: email)
             auth_data = double(uid: uid, info: info)
             admin = create(:admin_user, uid: '', email: email)
 
@@ -82,7 +82,7 @@ describe User do
         context 'user with auth email is not an admin' do
           it 'returns nil' do
             email = 'test@example.com'
-            info = double(email: email, first_name: '', last_name: '')
+            info = double(email: email)
             auth_data = double(uid: '', info: info)
             _user = create(:user, email: email)
 
@@ -94,7 +94,7 @@ describe User do
       context 'user with auth email does not exist' do
         it 'returns nil' do
           email = 'test@example.com'
-          info = double(email: email, first_name: '', last_name: '')
+          info = double(email: email)
           auth_data = double(uid: '', info: info)
 
           expect(User.from_saml_omniauth(auth_data)).to eq nil


### PR DESCRIPTION
* We get this from GitHub already
* LOA1 users will not necessarily have a name in IDP app
* Easier to just not worry about it