### PR TITLE
Move states into separate tables

### DIFF
--- a/app/models/auction.rb
+++ b/app/models/auction.rb
@@ -8,6 +8,7 @@ class Auction < ActiveRecord::Base
   belongs_to :customer
   has_many :bids
   has_many :bidders, through: :bids
+  has_many :states, foreign_key: 'auction_id', class_name: 'AuctionState'
   has_and_belongs_to_many :skills
 
   has_secure_token

--- a/app/models/auction_parser.rb
+++ b/app/models/auction_parser.rb
@@ -7,7 +7,7 @@ class AuctionParser
   end
 
   def attributes
-    auction_params.merge(
+    @_attributes ||= auction_params.merge(
       delivery_due_at: delivery_due_at,
       ended_at: ended_at,
       started_at: started_at,
@@ -16,7 +16,15 @@ class AuctionParser
     ).delete_if { |_key, value| value.nil? }
   end
 
+  def publishing?
+    changing?('published', 'published')
+  end
+
   private
+
+  def changing?(key, value)
+    attributes[key] == value
+  end
 
   def auction_params
     strong_params.require(:auction).permit(

--- a/app/models/auction_state.rb
+++ b/app/models/auction_state.rb
@@ -1,0 +1,3 @@
+class AuctionState < ActiveRecord::Base
+  belongs_to :auction
+end

--- a/db/migrate/20170111193433_create_auction_states.rb
+++ b/db/migrate/20170111193433_create_auction_states.rb
@@ -1,0 +1,9 @@
+class CreateAuctionStates < ActiveRecord::Migration
+  def change
+    create_table :auction_states do |t|
+      t.integer :auction_id
+      t.string :state_value
+      t.string :name
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160921135321) do
+ActiveRecord::Schema.define(version: 20170111193433) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "auction_states", force: :cascade do |t|
+    t.integer "auction_id"
+    t.string  "state_value"
+    t.string  "name"
+  end
 
   create_table "auctions", force: :cascade do |t|
     t.string   "issue_url",       default: ""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 db:
    image: postgres:9
 web:
+    tty: true
+    stdin_open: true
     build: .
     env_file: .env
     environment:

--- a/docs/moving-states-to-tables.md
+++ b/docs/moving-states-to-tables.md
@@ -1,0 +1,74 @@
+Refactoring data pattern:
+* Build the new data abstraction
+* Find all writes
+* Write to old and new location (ongoing, evented)
+* Backfill task to populate new location (batch)
+* Read from the new location
+* Remove old writes (in code)
+* Remove old fields (in database)
+
+---------
+# try this one first:
+Published: draft => published | archived
+
+
+Auction bidding state: not yet bidding -> bidding -> closed
+Auction won state: no bids -> won
+Auction work state: not started -> in progress -> delivered | not delivered
+Work acceptance: not evaluated -> accepted | rejected
+Budget: not requested => requested => approved | rejected
+Payment: not paid -> payment sent -> payment confirmed ??
+
+
+create migration
+
+create_table :auction_states do |t|
+  t.string 'name'
+  t.string '_value' # reserved :(
+  t.int 'auction_id'
+end
+
+class SetAuctionState
+  def initialize(name, auction)
+  end
+end
+
+SetAuctionState.new('published', auction).set('published').save
+
+class PublishedAuctionStates
+  StateValues =  {
+    published: ['not published', 'published', 'archived']
+  }.freeze
+
+  def initialize(name, auction)
+  end
+
+  #def name
+  #  'published'
+  #end
+
+  def state
+    # @state = AuctionStates.where(auction_id: auciton.id, name: name)
+  end
+
+  def new_state
+    # AuctionState.new(auction_id: auction.id)
+    auction.states.build
+  end
+
+  def save
+    auction.save
+    state.save
+  end
+
+  private
+
+  def set(value)
+    # validator = "#{name.capitalize.constantize}Validator
+    # polymporphism here, for validation
+    # do we want to validate the value
+    valid_states = StateValues[name]
+    raise if !(valid_states.include?(value))
+    state._value = value;
+  end
+end

--- a/spec/models/auction_parser_spec.rb
+++ b/spec/models/auction_parser_spec.rb
@@ -1,6 +1,25 @@
 require 'rails_helper'
 
 describe AuctionParser do
+  describe '#publishing?' do
+    it 'returns true' do
+      user = create(:user)
+      params = {
+        auction: {
+          title: 'title',
+          description: 'description',
+          github_repo: 'github url',
+          issue_url: 'issue url',
+          published: 'published'
+        }
+      }
+      parser = AuctionParser.new(params, user)
+      publishing = parser.publishing?
+
+      expect(publishing).to be true
+    end
+  end
+
   describe '#attributes' do
     context 'attributes in params' do
       it 'assigns attributes correctly' do

--- a/spec/models/auction_parser_spec.rb
+++ b/spec/models/auction_parser_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe AuctionParser do
-  describe '#perform' do
+  describe '#attributes' do
     context 'attributes in params' do
       it 'assigns attributes correctly' do
         user = create(:user)

--- a/spec/services/update_auction_spec.rb
+++ b/spec/services/update_auction_spec.rb
@@ -2,6 +2,43 @@ require 'rails_helper'
 
 describe UpdateAuction do
   describe '#perform' do
+    context 'when publishing an auction' do
+      it 'creates an AuctionState record' do
+        auction = create(:auction, :unpublished)
+
+        params = {
+          auction: {"published" => "published"}
+        }
+
+        expect do
+          UpdateAuction.new(
+            auction: auction,
+            params: params,
+            current_user: auction.user
+          ).perform
+        end.to change { AuctionState.count }.by(1)
+
+        auction.reload
+
+        # do we want to low-level test for the published state object, like this?
+        published_state = auction.states.find {|state| state.name == 'published'}
+        expect(published_state.state_value).to eq('published')
+
+        # and/or this?:
+        # expect(auction.published?).to be true
+
+        # and/or this?:
+        # published = AuctionPublishedState.new(auction).perform
+        # expect(published).to be true
+
+        # and/or this?:
+        # published = FindAuctionState.new(auction, name: 'published').perform
+        # expect(published).to be true
+
+        # maybe all or some of the above assertions are needed, but in a different test venue?
+      end
+    end
+
     context 'when changing ended_at' do
       context 'job not enqueued' do
         it 'creates the Auction Ended Job' do


### PR DESCRIPTION
Working with @baccigalupi to pay down some technical debt by moving many of the groupings of fields on `Auction` into their own state objects. The disambiguation will make the code easier to reason about, and easier to modify as state needs change. 