### PR TITLE
Sources github refs via https

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
 ruby '2.3.3'
 


### PR DESCRIPTION
Sources github repos via https and will remove warnings such as this:
```
The git source `git://github.com/18f/c2-api-client-ruby.git` uses the `git` protocol, which transmits data without encryption. Disable this warning with `bundle config git.allow_insecure true`, or switch to the `https` protocol to keep your data secure.
```