### PR TITLE
Fix manifest for staging deploy on GovCloud

### DIFF
--- a/manifest-staging.yml
+++ b/manifest-staging.yml
@@ -5,6 +5,9 @@ applications:
   instances: 1
   host: micropurchase-staging
   buildpack: https://github.com/cloudfoundry/ruby-buildpack.git
+  no-hostname: true
+  domains:
+    - micropurchase-staging.18f.gov
   services:
     - data-dot-gov
     - micropurchase-c2

--- a/manifest-staging.yml
+++ b/manifest-staging.yml
@@ -4,7 +4,7 @@ applications:
   memory: 1G
   instances: 1
   host: micropurchase-staging
-  buildpack: https://github.com/cloudfoundry/ruby-buildpack.git
+  buildpack: ruby_buildpack
   no-hostname: true
   domains:
     - micropurchase-staging.18f.gov


### PR DESCRIPTION
because the omniauth is fixed but the login.gov still isn't working

In addition, use cloud.gov internal ruby buildpack