### PR TITLE
Fetches github repos over https

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,10 @@
 source 'https://rubygems.org'
 
+git_source(:github) do |repo_name|
+  repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
+  "https://github.com/#{repo_name}.git"
+end
+
 ruby '2.3.3'
 
 gem 'rails', '4.2.7.1'


### PR DESCRIPTION
Squashes warnings about

```
The git source `git://github.com/....git` uses the `git` protocol, which transmits 
data without encryption. Disable this warning with 
`bundle config git.allow_insecure true`, or switch to the `https` 
protocol to keep your data secure.
```